### PR TITLE
Fix alignment of dropdown content

### DIFF
--- a/assets/stylesheets/kitten/organisms/headers/_header.scss
+++ b/assets/stylesheets/kitten/organisms/headers/_header.scss
@@ -48,10 +48,10 @@
 
   .k-Header__container {
     @include k-container;
+    position: relative;
   }
 
   .k-Header__row {
-    position: relative;
     display: flex;
     align-items: center;
     align-self: flex-start;


### PR DESCRIPTION
Cette PR corrige un problème d'alignement  des `dropdown_content` avec le header.

![capture d ecran 2016-10-10 a 14 18 20](https://cloud.githubusercontent.com/assets/736319/19236022/61d5645c-8ef5-11e6-843e-ccfb7d6a4512.png)
