### PR TITLE
Fix box-sizing on header nav

### DIFF
--- a/assets/stylesheets/kitten/organisms/headers/_header.scss
+++ b/assets/stylesheets/kitten/organisms/headers/_header.scss
@@ -100,6 +100,7 @@
   }
 
   .k-Header__nav__item {
+    box-sizing: content-box;
     height: k-px-to-rem($height - $border-width);
   }
 


### PR DESCRIPTION
Cette PR permets de fixer un problème de hauteur visible sur LENDO et hellomerci qui ont des `* { box-sizing: border-box; }`.

<img width="201" alt="capture d ecran 2016-11-09 a 16 38 35" src="https://cloud.githubusercontent.com/assets/736319/20143895/15720c6a-a69b-11e6-80c7-f65419bb529a.png">
