### PR TITLE
Change graphic logo size

### DIFF
--- a/assets/stylesheets/kitten/organisms/headers/_header.scss
+++ b/assets/stylesheets/kitten/organisms/headers/_header.scss
@@ -32,7 +32,7 @@
   $item-spacing-xxs: k-px-to-rem(15px);
   $z-index: 10;
 
-  $graphic-logo-size: 38px;
+  $graphic-logo-size: 37px;
 
   .k-Header {
     background-color: $background-color;


### PR DESCRIPTION
Corrige un problème de 1px quand on vire les graphiques dans les logos :

<img width="207" alt="capture d ecran 2016-11-09 a 16 59 43" src="https://cloud.githubusercontent.com/assets/736319/20144769/0041a4d8-a69e-11e6-8fba-5e58ac7b65c8.png">
