### PR TITLE
Fix border-color on k-Tabbar

### DIFF
--- a/assets/stylesheets/kitten/molecules/navigation/_tab-bar.scss
+++ b/assets/stylesheets/kitten/molecules/navigation/_tab-bar.scss
@@ -50,7 +50,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    box-shadow: inset 0 $border-width 0 $border-color;
+    box-shadow: inset 0 $border-width 0 rgba($current-color, .1);
 
     list-style-type: none;
     width: 100%;


### PR DESCRIPTION
La couleur de la bordure n'était pas la bonne. Elle ne dépend pas d'une variable mais est sur les 3 versions du blanc avec une opacité de 10%.