### PR TITLE
Fix box-sizing on .k-Button__icon

### DIFF
--- a/assets/stylesheets/kitten/atoms/buttons/_button.scss
+++ b/assets/stylesheets/kitten/atoms/buttons/_button.scss
@@ -342,6 +342,7 @@
     .k-Button__icon {
       @include k-buttonRounded($button-size, $icon-width, $icon-height);
 
+      box-sizing: content-box;
       display: block;
       width: $icon-width;
       height: $icon-height;
@@ -359,6 +360,7 @@
         $icon-height-tiny
       );
 
+      box-sizing: content-box;
       display: block;
       width: $icon-width-tiny;
       height: $icon-height-tiny;


### PR DESCRIPTION
Cette PR règle encore et encore le problème de box-sizing sur LENDO et hellomerci. Les flèches n'apparaissaient pas sur les plateformes.

<img width="199" alt="capture d ecran 2016-11-15 a 12 13 25" src="https://cloud.githubusercontent.com/assets/736319/20303696/efc21d48-ab2c-11e6-9366-592bf28133fd.png">
