### PR TITLE
Update k-UserMenu position when receiving new props

### DIFF
--- a/assets/javascripts/kitten/components/dropdowns/user-menu.js
+++ b/assets/javascripts/kitten/components/dropdowns/user-menu.js
@@ -25,6 +25,10 @@ class UserMenu extends React.Component {
     this.handlePositionUpdate()
   }
 
+  componentWillReceiveProps() {
+    this.handlePositionUpdate()
+  }
+
   // Component methods.
 
   getButtonId() {
@@ -32,7 +36,10 @@ class UserMenu extends React.Component {
   }
 
   canComputeSize() {
-    return typeof this.refs.dropdown != 'undefined'
+    return (
+      domElementHelper.canUseDom() &&
+      typeof this.refs.dropdown != 'undefined'
+    )
   }
 
   getDropdownContainer() {


### PR DESCRIPTION
Comme pour le `k-Tour`, "ça marche chez moi". Il faudrait le tester en local et vérifier que ça corrige bien le bug de latence entre la mise à jour des props.