### PR TITLE
Fix k-Popover on IE

### DIFF
--- a/assets/stylesheets/kitten/organisms/popovers/_popover.scss
+++ b/assets/stylesheets/kitten/organisms/popovers/_popover.scss
@@ -35,8 +35,6 @@
   $margin-container: k-px-to-rem(11px);
 
   .k-Popover {
-    display: flex;
-
     width: k-px-to-rem(465px);
     min-height: k-px-to-rem(218px);
     box-sizing: border-box;


### PR DESCRIPTION
Le `display: flex;` provoquait une erreur sur IE11-. Il n'est pas nécessaire car le container en dessous  dispose déjà du `display: flex;`.