### PR TITLE
LinkBox and DocLinkBox testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Breaking changes:
 
 Features:
 - Add test setup.
+- Add `LinkBox` and `DocLinkBox` testing.
 - Add small radio buttons label.
 - Add small paragraph for radio buttons containers.
 - Add large bullet list.

--- a/assets/javascripts/kitten/components/box/doc-link-box.test.js
+++ b/assets/javascripts/kitten/components/box/doc-link-box.test.js
@@ -11,7 +11,7 @@ describe('<DocLinkBox />', () => {
     expect(component).to.have.type(LinkBox)
   })
 
-  it('renders a svg icon', () => {
+  it('renders an svg icon', () => {
     expect(component).to.have.prop('displayIcon', true)
     expect(component.find('.k-LinkBox__icon--svg')).to.have.length(1)
   })

--- a/assets/javascripts/kitten/components/box/doc-link-box.test.js
+++ b/assets/javascripts/kitten/components/box/doc-link-box.test.js
@@ -1,0 +1,18 @@
+import React from 'react'
+import { expect } from 'chai'
+import { shallow } from 'enzyme'
+import DocLinkBox from '../../components/box/doc-link-box'
+import LinkBox from '../../components/box/link-box'
+
+describe('<DocLinkBox />', () => {
+  const component = shallow(<DocLinkBox />)
+
+  it('renders a <LinkBox />', () => {
+    expect(component).to.have.type(LinkBox)
+  })
+
+  it('renders a svg icon', () => {
+    expect(component).to.have.prop('displayIcon', true)
+    expect(component.find('.k-LinkBox__icon--svg')).to.have.length(1)
+  })
+})

--- a/assets/javascripts/kitten/components/box/link-box.test.js
+++ b/assets/javascripts/kitten/components/box/link-box.test.js
@@ -37,11 +37,11 @@ describe('<LinkBox />', () => {
       </LinkBox>
     )
 
-    it('has a icon class', () => {
+    it('has an icon class', () => {
       expect(component_with_icon).to.have.className('k-LinkBox--withIcon')
     })
 
-    it('renders a icon', () => {
+    it('renders an icon', () => {
       const icon = component_with_icon.find('.k-LinkBox__icon')
 
       expect(icon).to.have.length(1)
@@ -52,11 +52,11 @@ describe('<LinkBox />', () => {
   describe('with default props', () => {
     const default_component = shallow(<LinkBox />)
 
-    it('has default href', () => {
+    it('has a default href', () => {
       expect(default_component).attr('href', '#')
     })
 
-    it('has not icon', () => {
+    it('has no icon', () => {
       expect(default_component.find('.k-LinkBox__icon')).to.have.length(0)
     })
   })

--- a/assets/javascripts/kitten/components/box/link-box.test.js
+++ b/assets/javascripts/kitten/components/box/link-box.test.js
@@ -1,0 +1,63 @@
+import React from 'react'
+import { expect } from 'chai'
+import { shallow } from 'enzyme'
+import LinkBox from '../../components/box/link-box'
+
+describe('<LinkBox />', () => {
+  const component = shallow(
+    <LinkBox href="http://…/history.pdf"
+             title="Your history"
+             text="Download your history (pdf - 8Mo)" />
+  )
+
+  it('renders a <a class="k-LinkBox" />', () => {
+    expect(component).to.have.tagName('a')
+    expect(component).to.have.className('k-LinkBox')
+    expect(component).to.have.attr('href', 'http://…/history.pdf')
+  })
+
+  it('renders a title', () => {
+    const title = component.find('.k-LinkBox__title')
+
+    expect(title).to.have.length(1)
+    expect(title).to.have.text('Your history')
+  })
+
+  it('renders a text', () => {
+    const text = component.find('.k-LinkBox__text')
+
+    expect(text).to.have.length(1)
+    expect(text).to.have.text('Download your history (pdf - 8Mo)')
+  })
+
+  describe('with icon', () => {
+    const component_with_icon = shallow(
+      <LinkBox displayIcon="true">
+        <span>My icon</span>
+      </LinkBox>
+    )
+
+    it('has a icon class', () => {
+      expect(component_with_icon).to.have.className('k-LinkBox--withIcon')
+    })
+
+    it('renders a icon', () => {
+      const icon = component_with_icon.find('.k-LinkBox__icon')
+
+      expect(icon).to.have.length(1)
+      expect(icon).to.have.text('My icon')
+    })
+  })
+
+  describe('with default props', () => {
+    const default_component = shallow(<LinkBox />)
+
+    it('has default href', () => {
+      expect(default_component).attr('href', '#')
+    })
+
+    it('has not icon', () => {
+      expect(default_component.find('.k-LinkBox__icon')).to.have.length(0)
+    })
+  })
+})

--- a/assets/javascripts/kitten/components/box/link-box.test.js
+++ b/assets/javascripts/kitten/components/box/link-box.test.js
@@ -23,7 +23,7 @@ describe('<LinkBox />', () => {
     expect(title).to.have.text('Your history')
   })
 
-  it('renders a text', () => {
+  it('renders text', () => {
     const text = component.find('.k-LinkBox__text')
 
     expect(text).to.have.length(1)

--- a/assets/javascripts/kitten/components/box/link-box.test.js
+++ b/assets/javascripts/kitten/components/box/link-box.test.js
@@ -31,18 +31,18 @@ describe('<LinkBox />', () => {
   })
 
   describe('with icon', () => {
-    const component_with_icon = shallow(
+    const componentWithIcon = shallow(
       <LinkBox displayIcon="true">
         <span>My icon</span>
       </LinkBox>
     )
 
     it('has an icon class', () => {
-      expect(component_with_icon).to.have.className('k-LinkBox--withIcon')
+      expect(componentWithIcon).to.have.className('k-LinkBox--withIcon')
     })
 
     it('renders an icon', () => {
-      const icon = component_with_icon.find('.k-LinkBox__icon')
+      const icon = componentWithIcon.find('.k-LinkBox__icon')
 
       expect(icon).to.have.length(1)
       expect(icon).to.have.text('My icon')
@@ -50,14 +50,14 @@ describe('<LinkBox />', () => {
   })
 
   describe('with default props', () => {
-    const default_component = shallow(<LinkBox />)
+    const defaultComponent = shallow(<LinkBox />)
 
     it('has a default href', () => {
-      expect(default_component).attr('href', '#')
+      expect(defaultComponent).attr('href', '#')
     })
 
     it('has no icon', () => {
-      expect(default_component.find('.k-LinkBox__icon')).to.have.length(0)
+      expect(defaultComponent.find('.k-LinkBox__icon')).to.have.length(0)
     })
   })
 })


### PR DESCRIPTION
Ajoute des tests pour les 2 composants `LinkBox` et `DocLinkBox`.

<img width="741" alt="capture d ecran 2016-12-20 a 12 24 41" src="https://cloud.githubusercontent.com/assets/736319/21348878/6cd61b34-c6af-11e6-8637-52ace40beee2.png">
