### PR TITLE
Fix image width in footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Features:
 
 Fixes:
 - Move `babel-preset-airbnb` module from `devDependencies` to `dependencies`.
+- Fix image width on `.k-Footer__logo__img > img`.
 
 ## [v4.0.0] - 2016-12-20
 

--- a/assets/stylesheets/kitten/molecules/footer/_footer.scss
+++ b/assets/stylesheets/kitten/molecules/footer/_footer.scss
@@ -156,6 +156,8 @@
     @include k-media-min('l') {
       > img,
       > svg {
+        display: block;
+        width: 100%;
         vertical-align: top;
       }
 


### PR DESCRIPTION
Avant :
<img width="262" alt="capture d ecran 2016-12-21 a 18 30 17" src="https://cloud.githubusercontent.com/assets/736319/21399377/a640ddf8-c7ab-11e6-9d1e-7dd0dcd85685.png">

Après :
<img width="270" alt="capture d ecran 2016-12-21 a 18 25 00" src="https://cloud.githubusercontent.com/assets/736319/21399306/57b26f3a-c7ab-11e6-917a-cc7f1aa139a6.png">

TODO:

- [ ] Tests
- [x] Changelog
