### PR TITLE
Add commissionRules prop to LoanSimulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+Features:
+- Add `commissionRules` prop to `LoanSimulator`.
+
 ## [v4.3.0] - 2016-12-26
 
 Features:

--- a/assets/javascripts/kitten/components/simulators/loan-simulator.js
+++ b/assets/javascripts/kitten/components/simulators/loan-simulator.js
@@ -87,14 +87,14 @@ class LoanSimulator extends React.Component {
   }
 
   // The `commissionRules` prop has to be an array containing a `durationMax`
-  // rule. This will return the first `ratio` which matches the rule for the
+  // rule. This will return the first `rate` which matches the rule for the
   // current `duration`.
   //
   // Example `commissionRules` prop:
   //     [
-  //       { durationMax: 20, ratio: 0.3 },
-  //       { durationMax: 12, ratio: 0.2 },
-  //       { ratio: 0.1 }
+  //       { durationMax: 12, rate: 0.3 },
+  //       { durationMax: 20, rate: 0.2 },
+  //       { rate: 0.1 }
   //     ]
   commissionRateFromRules() {
     const duration = this.duration()

--- a/assets/javascripts/kitten/components/simulators/loan-simulator.js
+++ b/assets/javascripts/kitten/components/simulators/loan-simulator.js
@@ -79,7 +79,30 @@ class LoanSimulator extends React.Component {
   }
 
   commissionRate() {
+    if (this.props.commissionRules.length > 0)
+      return this.commissionRateFromRules()
+
+    // DEPRECATED in favor of commissionRules
     return this.props.commissionRate(this.duration())
+  }
+
+  // The `commissionRules` prop has to be an array containing a `durationMax`
+  // rule. This will return the first `ratio` which matches the rule for the
+  // current `duration`.
+  //
+  // Example `commissionRules` prop:
+  //     [
+  //       { durationMax: 20, ratio: 0.3 },
+  //       { durationMax: 12, ratio: 0.2 },
+  //       { ratio: 0.1 }
+  //     ]
+  commissionRateFromRules() {
+    const duration = this.duration()
+    for (let i = 0, len = this.props.commissionRules.length; i < len; i++) {
+      let rule = this.props.commissionRules[i]
+      if (!rule.durationMax || duration <= rule.durationMax)
+        return rule.rate
+    }
   }
 
   commissionAmount() {
@@ -308,6 +331,9 @@ LoanSimulator.propTypes = {
   // Display commission if requested
   displayCommission: React.PropTypes.bool,
   commissionLabel: React.PropTypes.string,
+  commissionRules: React.PropTypes.array,
+
+  // DEPRECATED in favor of commissionRules
   commissionRate: React.PropTypes.func,
 
   // Label before the slider
@@ -350,6 +376,9 @@ LoanSimulator.defaultProps = {
 
   displayCommission: false,
   commissionLabel: 'Commission:',
+  commissionRules: {},
+
+  // DEPRECATED in favor of commissionRules
   commissionRate: function() { return 0 },
 
   installmentLabel: 'Reimbursing',

--- a/assets/javascripts/kitten/karl/organisms/loan-simulator.js
+++ b/assets/javascripts/kitten/karl/organisms/loan-simulator.js
@@ -38,16 +38,13 @@ const KarlLoanSimulator = defaultProps(LoanSimulator, {
 const KarlLoanSimulatorWithCommission = defaultProps(KarlLoanSimulator, {
   displayCommission: true,
   commissionLabel: `Commission${nbsp}:`,
-  commissionRate: function(duration) {
-    if (duration <= 9)
-      return 0.03
-    else if (duration <= 18)
-      return 0.04
-    else if (duration <= 24)
-      return 0.05
-    else
-      return 0.06
-  },
+
+  commissionRules: [
+    { durationMax: 9, rate: 0.03 },
+    { durationMax: 18, rate: 0.04 },
+    { durationMax: 24, rate: 0.05 },
+    { rate: 0.06 },
+  ],
 
   initialAmount: 2500,
 


### PR DESCRIPTION
Permets d'exprimer les règles d'attribution de commission sous forme d'un hash plutôt que d'une fonction.

Avant :

```js
  commissionRate: function(duration) {
    if (duration <= 9)
      return 0.03
    else if (duration <= 18)
      return 0.04
    else if (duration <= 24)
      return 0.05
    else
      return 0.06
  },
```

Après :

```js
  commissionRules: [
    { durationMax: 9, rate: 0.03 },
    { durationMax: 18, rate: 0.04 },
    { durationMax: 24, rate: 0.05 },
    { rate: 0.06 },
  ],
```

Ça permets de passer ces valeurs plus facilement via des props que renverrait une application Rails.