### PR TITLE
Disable React on Rails development trace for style guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
-- Fix: disable React on Rails console traces in dev style guide
+- Fix: disable React on Rails console traces in dev style guide.
 
 ## [v.4.4.0] - 2016-12-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: disable React on Rails console traces in dev style guide
+
 ## [v.4.4.0] - 2016-12-27
 
 Features:

--- a/spec/dummy/config/initializers/react_on_rails.rb
+++ b/spec/dummy/config/initializers/react_on_rails.rb
@@ -33,7 +33,8 @@ ReactOnRails.configure do |config|
   config.prerender = true
 
   # default is true for development, off otherwise
-  config.trace = Rails.env.development?
+  # config.trace = Rails.env.development?
+  config.trace = false
 
   ################################################################################
   # SERVER RENDERING OPTIONS


### PR DESCRIPTION
Closes #182

Avant:

<img width="1189" alt="screen shot 2016-12-29 at 12 29 57" src="https://cloud.githubusercontent.com/assets/132/21543001/8dc4f116-cdc2-11e6-8e11-0005509c5c04.png">

Après:

<img width="1187" alt="screen shot 2016-12-29 at 12 28 43" src="https://cloud.githubusercontent.com/assets/132/21542991/7616aa46-cdc2-11e6-8de3-f84887b4a231.png">