### PR TITLE
Add title modifier on LinkBox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+Feature: Add `k-LinkBox__title--withEllipsis` modifier.
+Feature: Add `titleClassNames` prop to `LinkBox`.
+
 ## [v.4.4.0] - 2016-12-27
 
 Features:

--- a/app/views/kitten/components/organisms/box/link-box.html.erb
+++ b/app/views/kitten/components/organisms/box/link-box.html.erb
@@ -1,6 +1,7 @@
 <%= example 'Link box' do %>
   <%= react_component('LinkBox', props: {
     title: 'Lorem Ipsum ',
+    titleClassNames: 'k-LinkBox__title--withEllipsis',
     text: 'Aenean leo ligula, porttitor eu, vitae eleifend
         ac, enimiquam ante.',
     }

--- a/assets/javascripts/kitten/components/box/link-box.js
+++ b/assets/javascripts/kitten/components/box/link-box.js
@@ -17,6 +17,10 @@ export default class LinkBox extends React.Component {
       'k-LinkBox',
       { 'k-LinkBox--withIcon': this.props.displayIcon },
     )
+    const titleClassNames = classNames(
+      'k-LinkBox__title',
+      this.props.titleClassNames
+    )
 
     const target = this.props.isExternal ? { target: '_blank' } : {}
 
@@ -27,7 +31,7 @@ export default class LinkBox extends React.Component {
         <div className="k-LinkBox__container">
           { this.renderIcon() }
           <div className="k-LinkBox__paragraph">
-            <p className="k-LinkBox__title">{ this.props.title }</p>
+            <p className={ titleClassNames }>{ this.props.title }</p>
             <p className="k-LinkBox__text">{ this.props.text }</p>
           </div>
 
@@ -55,5 +59,6 @@ export default class LinkBox extends React.Component {
 LinkBox.defaultProps = {
   displayIcon: false,
   href: '#',
+  titleClassNames: '',
   isExternal: false,
 }

--- a/assets/javascripts/kitten/components/box/link-box.test.js
+++ b/assets/javascripts/kitten/components/box/link-box.test.js
@@ -7,6 +7,7 @@ describe('<LinkBox />', () => {
   const component = shallow(
     <LinkBox href="http://…/history.pdf"
              title="Your history"
+             titleClassNames="k-LinkBox__title--withEllipsis"
              text="Download your history (pdf - 8Mo)"
              isExternal="true" />
   )
@@ -23,6 +24,7 @@ describe('<LinkBox />', () => {
 
     expect(title).to.have.length(1)
     expect(title).to.have.text('Your history')
+    expect(title).to.have.className('k-LinkBox__title--withEllipsis')
   })
 
   it('renders text', () => {

--- a/assets/stylesheets/kitten/organisms/box/_link-box.scss
+++ b/assets/stylesheets/kitten/organisms/box/_link-box.scss
@@ -17,7 +17,7 @@
 ///     <div class="k-LinkBox__container">
 ///       <div class="k-LinkBox__icon"> … </div>
 ///       <div class="k-LinkBox__paragraph">
-///         <p class="k-LinkBox__title"> … </p>
+///         <p class="k-LinkBox__title k-LinkBox__title--withEllipsis"> … </p>
 ///         <p class="k-LinkBox__text"> … </p>
 ///       </div>
 ///       <div class="k-LinkBox__navigation k-LinkBox__navigation--withAnimation">
@@ -124,6 +124,13 @@
     @include k-typographyFontSize(0);
 
     margin: 0;
+  }
+
+  .k-LinkBox__title--withEllipsis {
+    text-overflow: ellipsis;
+    max-width: k-px-to-rem(215px);
+    white-space: nowrap;
+    overflow: hidden;
   }
 
   .k-LinkBox__text {


### PR DESCRIPTION
Ajoute la gestion de l'`ellipsis` sur le titre du composant `LinkBox`.

Screenshot:

<img width="312" alt="capture d ecran 2017-01-02 a 12 35 15" src="https://cloud.githubusercontent.com/assets/736319/21588526/ea960fce-d0e7-11e6-89e8-867b77efcb73.png">

TODO:

- [x] Tests
- [x] Changelog
