### PR TITLE
Change commission label size in loan simulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   * Use `components` directory instead to match javascripts files architecture.
 - Feature: Add new `Stepper` component.
 - Feature: Add new `ArrowIcon` and `CheckedIcon` components.
+- Fix: Change font size in `k-LoanSimulator__commission`.
 
 ## [v.4.4.0] - 2016-12-27
 

--- a/assets/stylesheets/kitten/components/simulators/_loan-simulator.scss
+++ b/assets/stylesheets/kitten/components/simulators/_loan-simulator.scss
@@ -76,7 +76,7 @@
 
     .k-LoanSimulator__commission {
       margin-top: k-px-to-rem(30px);
-      @include k-typographyFontSize(0);
+      @include k-typographyFontSize(-1);
     }
   }
 }


### PR DESCRIPTION
The label size must be 14px (instead of 16px).

Screenshots:

Before: 
![capture d ecran 2017-01-09 a 12 06 00](https://cloud.githubusercontent.com/assets/16986338/21764559/0c21bba8-d664-11e6-8658-740538a9b9ec.png)

After:
![capture d ecran 2017-01-09 a 12 01 52](https://cloud.githubusercontent.com/assets/16986338/21764455/759346ca-d663-11e6-952a-3636bdf99fa5.png)


TODO:
- [x] Changelog
