### PR TITLE
Add default margins to homepage titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Add default margins to `.k-PressQuotes__title` and
+  `.k-titleWithActions__title`.
+
 ## [5.1.0] - 2017-01-11
 
 Features:

--- a/assets/stylesheets/kitten/components/press/_press-quotes.scss
+++ b/assets/stylesheets/kitten/components/press/_press-quotes.scss
@@ -24,6 +24,7 @@
   .k-PressQuotes__title {
     @include k-grid-col(12);
     margin-top: 0;
+    margin-bottom: k-px-to-rem(30px);
 
     @include k-typographyFont('source-sans-light');
     @include k-typographyFontSize(4, 1.5);

--- a/assets/stylesheets/kitten/components/titles/title-with-actions.scss
+++ b/assets/stylesheets/kitten/components/titles/title-with-actions.scss
@@ -23,6 +23,7 @@
     @include k-grid-col(12);
     @include k-typographyFont('source-sans-light');
     @include k-typographyFontSize(2);
+    margin-bottom: k-px-to-rem(30px);
 
     @include k-media-min('m') {
       @include k-grid-col(8);


### PR DESCRIPTION
Ajoute des marges par défaut pour ne pas dépendre du fait qu'on utilise des `h2` dans notre exemple de home.

Si on utilise `div` à la place de `h2` ça fait ça :

Avant :

<img width="900" alt="avant" src="https://cloud.githubusercontent.com/assets/132/21860666/ec3bab8a-d831-11e6-8d7a-a251884d673d.png">

Après : 

<img width="886" alt="apres" src="https://cloud.githubusercontent.com/assets/132/21860672/f33e9dca-d831-11e6-81b6-41681c15e77e.png">
