### PR TITLE
Testimony row is larger on xxs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
-- Fix: Testimony row is larger on xxs
+- Fix: Testimony row is larger on xxs.
 
 ## [5.1.0] - 2017-01-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Testimony row is larger on xxs
+
 ## [5.1.0] - 2017-01-11
 
 Features:

--- a/assets/stylesheets/kitten/components/testimonies/_testimony-list.scss
+++ b/assets/stylesheets/kitten/components/testimonies/_testimony-list.scss
@@ -29,8 +29,10 @@
       flex-wrap: wrap;
       justify-content: space-around;
 
-      @include k-grid-col(8);
-      @include k-grid-offset(2);
+      @include k-media-min('xs') {
+        @include k-grid-col(8);
+        @include k-grid-offset(2);
+      }
 
       @include k-media-min('m') {
         @include k-grid-col(12);


### PR DESCRIPTION
Avant :

<img width="360" alt="avant" src="https://cloud.githubusercontent.com/assets/132/21861062/9365a680-d833-11e6-9292-052b245903b7.png">

Après : 

<img width="362" alt="apres" src="https://cloud.githubusercontent.com/assets/132/21861063/93676aec-d833-11e6-96da-3eb2bcb514d7.png">
