### PR TITLE
Change default dev port for styleguide from 3000 to 3003

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Change default port in development from 3000 to 3003. You should now
+  see the style guide on http://localhost:3003 instead.
+
 ## [5.4.0] - 2017-01-17
 
 Features:

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ $ cd spec/dummy
 $ foreman start
 ```
 
-Then visit http://localhost:3000
+Then visit http://localhost:3003
 
 To share the dummy app with production settings (to share via ngrok for
 example), you can compile the assets and serve a production server:

--- a/app/helpers/kitten/webpack_helper.rb
+++ b/app/helpers/kitten/webpack_helper.rb
@@ -1,7 +1,7 @@
 module Kitten
   module WebpackHelper
     def kitten_hot_output_bundles
-      port = ENV['HOT_RAILS_PORT'] || 3500
+      port = ENV['HOT_RAILS_PORT'] || 3503
 
       Kitten.configuration.webpack_output_bundles.map do |bundle|
         "http://localhost:#{port}/#{bundle}"

--- a/spec/dummy/Procfile
+++ b/spec/dummy/Procfile
@@ -1,7 +1,7 @@
 # Procfile for development with hot reloading of JavaScript and CSS
 
 # Server
-rails: REACT_ON_RAILS_ENV=HOT rails s -p 3000 -b 0.0.0.0
+rails: REACT_ON_RAILS_ENV=HOT rails s -p 3003 -b 0.0.0.0
 
 # Run the hot reload server for client development
 hot-assets: npm run hot-assets

--- a/spec/dummy/client/bin/webpack-dev-server.js
+++ b/spec/dummy/client/bin/webpack-dev-server.js
@@ -17,7 +17,7 @@ import WebpackDevServer from 'webpack-dev-server';
 // Import development webpack config.
 import webpackConfig from './../webpack.client.dev.babel.js';
 
-const devServerPort = process.env.HOT_RAILS_PORT || 3500;
+const devServerPort = process.env.HOT_RAILS_PORT || 3503;
 const compiler = webpack(webpackConfig);
 const devServer = new WebpackDevServer(compiler, {
   publicPath: webpackConfig.output.publicPath,

--- a/spec/dummy/client/webpack.client.dev.babel.js
+++ b/spec/dummy/client/webpack.client.dev.babel.js
@@ -22,7 +22,7 @@ import merge from 'webpack-merge'
 // Import common webpack config.
 import baseConfig from './config/webpack/base.config'
 
-const devServerPort = process.env.HOT_RAILS_PORT || 3500
+const devServerPort = process.env.HOT_RAILS_PORT || 3503
 const developmentConfig = {
   entry: {
     dummy: [


### PR DESCRIPTION
Pour qu'on puisse bosser sur les différentes applications en même temps, le port par défaut passe de 3000 à 3003.

Après cette PR il faudra utiliser http://localhost:3003 pour tester nos composants.