### PR TITLE
Add inputClassName on RadioButton and Checkbox components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
-- Feature: Add `inputClassName` on `RadioButton` and `Checkbox` components.
+- Feature: Add `className` prop on `Checkbox` component.
+- Feature: Add `inputClassName` prop on `RadioButton` and `Checkbox` components.
 - Feature: Add new `TagButton` React component.
 
 ## [5.5.0] - 2017-01-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Feature: Add `inputClassName` on `RadioButton` and `Checkbox` components.
 - Feature: Add new `TagButton` React component.
 
 ## [5.5.0] - 2017-01-25

--- a/assets/javascripts/kitten/components/form/checkbox.js
+++ b/assets/javascripts/kitten/components/form/checkbox.js
@@ -4,14 +4,19 @@ import deprecated from 'react-prop-types/lib/deprecated'
 
 export class Checkbox extends React.Component {
   render() {
-    const { id, children, text, ...others } = this.props
+    const { className,
+            id,
+            children,
+            text,
+            inputClassName,
+            ...inputProps } = this.props
 
     return (
-      <div className="k-Checkbox">
+      <div className={ classNames('k-Checkbox', className) }>
         <input id={ id }
                type="checkbox"
-               className="k-Checkbox__input"
-               { ...others } />
+               className={ classNames('k-Checkbox__input', inputClassName) }
+               { ...inputProps } />
 
         <label htmlFor={ id } className="k-Checkbox__label">
           { children || text }

--- a/assets/javascripts/kitten/components/form/checkbox.test.js
+++ b/assets/javascripts/kitten/components/form/checkbox.test.js
@@ -22,18 +22,20 @@ describe('Checkbox with default props', () => {
       <Checkbox id="input-1"
                 htmlFor="input-1"
                 children="Filter 1"
-                inputClassName="custom-class" />
+                className="custom-class"
+                inputClassName="custom-input-class" />
     )
 
     it('renders a <div class="k-Checkbox" />', () => {
       expect(component).to.have.className('k-Checkbox')
+      expect(component).to.have.className('custom-class')
     })
 
     it('renders input with passed props', () => {
       const input = component.find('input')
 
       expect(input).to.have.attr('id', 'input-1')
-      expect(input).to.have.className('custom-class')
+      expect(input).to.have.className('custom-input-class')
     })
   })
 

--- a/assets/javascripts/kitten/components/form/checkbox.test.js
+++ b/assets/javascripts/kitten/components/form/checkbox.test.js
@@ -21,7 +21,8 @@ describe('Checkbox with default props', () => {
     const component = shallow(
       <Checkbox id="input-1"
                 htmlFor="input-1"
-                children="Filter 1" />
+                children="Filter 1"
+                inputClassName="custom-class" />
     )
 
     it('renders a <div class="k-Checkbox" />', () => {
@@ -32,6 +33,7 @@ describe('Checkbox with default props', () => {
       const input = component.find('input')
 
       expect(input).to.have.attr('id', 'input-1')
+      expect(input).to.have.className('custom-class')
     })
   })
 

--- a/assets/javascripts/kitten/components/form/radio-button.js
+++ b/assets/javascripts/kitten/components/form/radio-button.js
@@ -25,6 +25,7 @@ export class RadioButton extends React.Component {
             largeContent,
             children,
             content,
+            inputClassName,
             ...inputProps } = this.props
 
     let radioButtonClassNames = classNames (
@@ -36,7 +37,7 @@ export class RadioButton extends React.Component {
       <div className={ classNames('k-RadioButton', className) }>
         <input id={ id }
                type="radio"
-               className="k-RadioButton__input"
+               className={ classNames('k-RadioButton__input', inputClassName) }
                { ...inputProps } />
 
         <label htmlFor={ id }

--- a/assets/javascripts/kitten/components/form/radio-button.test.js
+++ b/assets/javascripts/kitten/components/form/radio-button.test.js
@@ -27,7 +27,8 @@ describe('RadioButton with default props', () => {
     const component = shallow(
       <RadioButton id="karl-radio-button-1"
                    large="false"
-                   largeContent="false" />
+                   largeContent="false"
+                   inputClassName="custom-class" />
     )
 
     it('renders a <div class="k-RadioButton" />', () => {
@@ -41,6 +42,7 @@ describe('RadioButton with default props', () => {
       expect(input).to.have.attr('id', 'karl-radio-button-1')
       expect(input).to.have.attr('type', 'radio')
       expect(input).to.have.className('k-RadioButton__input')
+      expect(input).to.have.className('custom-class')
     })
 
     it('renders label', () => {


### PR DESCRIPTION
PR qui permet d'ajouter des classes sur les `input` des composants `RadioButton` et `Checkbox`.

TODO:

- [x] Tests
- [x] Changelog
