### PR TITLE
Redirect to components instead of branding by default

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Kitten::Engine.routes.draw do
   get '/sassdoc', to: redirect('/sassdoc/index.html')
 
-  get '/', to: redirect('branding')
+  get '/', to: redirect('components')
   get 'branding' => 'branding#index'
   get 'components' => 'components#index'
   get 'components/:group/:name' => 'components#show'


### PR DESCRIPTION
Je propose ce petit changement vu que par défaut on se sert plutôt de la page components plutôt que de la page branding. Qu'en pensez-vous ? #débat