### PR TITLE
Remove pointer-events on `k-Header__item--centered`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   on `HeaderTitles`.
 - Fix: Vertically align buttons to the middle of the line.
 - Feature: Add `quintuple` utilities in `k-utilities-margin`.
+- Fix: Remove pointer-events on `k-Header__item--centered`.
 
 ## [5.7.0] - 2017-02-02
 

--- a/assets/stylesheets/kitten/components/headers/_header.scss
+++ b/assets/stylesheets/kitten/components/headers/_header.scss
@@ -91,6 +91,8 @@
     position: absolute;
     left: 0;
     right: 0;
+
+    pointer-events: none;
   }
 
   .k-Header__nav {


### PR DESCRIPTION
PR qui annule le click sur toute la partie `k-Header__item--centered` qui passait au dessus du logo et du bouton, empêchant le click sur ceux-ci.

TODO:

- [x] Changelog
