### PR TITLE
Increase line-height on tiny `Label`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+Fix: Increase line-height on tiny `Label`.
 
 ## [7.0.0] - 2017-02-22
 

--- a/assets/stylesheets/kitten/components/form/_label.scss
+++ b/assets/stylesheets/kitten/components/form/_label.scss
@@ -24,7 +24,7 @@
 @mixin k-Label {
   $font: 'source-sans-semi-bold';
   $font-step-tiny: -1;
-  $line-height-tiny: 1;
+  $line-height-tiny: 1.3;
 
   .k-Label {
     display: block;


### PR DESCRIPTION
PR qui augmente le `line-height` du `Label` sur la version `tiny`.

Avant : 
<img width="399" alt="capture d ecran 2017-02-22 a 15 01 29" src="https://cloud.githubusercontent.com/assets/736319/23214825/70ef4d74-f910-11e6-8a5f-4388d709f911.png">

Après : 
<img width="399" alt="capture d ecran 2017-02-22 a 15 00 52" src="https://cloud.githubusercontent.com/assets/736319/23214830/760e74a6-f910-11e6-9ebf-55be48f6cf03.png">

TODO:

- [x] Changelog
