### PR TITLE
Prevent newline in mobile view for `SearchInput` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Prevent newline in mobile view for `SearchInput` component.
+
 ## [8.6.0] - 2017-03-15
 
 Features:

--- a/assets/stylesheets/kitten/components/form/_search-input.scss
+++ b/assets/stylesheets/kitten/components/form/_search-input.scss
@@ -78,6 +78,8 @@
     border-collapse: separate;
     box-sizing: border-box;
     width: $search-width;
+
+    white-space: nowrap; // Prevent newline in mobile view
   }
 
   .k-SearchInput__input {


### PR DESCRIPTION
Closes https://github.com/KissKissBankBank/kisskissbankbank/issues/1030.

Screenshot:
![image uploaded from ios](https://cloud.githubusercontent.com/assets/523306/24111865/1f770daa-0d98-11e7-9570-08fa9f629563.jpg)


TODO:

- [x] Changelog
