### PR TITLE
Fix: Remove unneeded padding on `SearchInput`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Remove unneeded padding on `SearchInput` component.
+
 ## [9.1.0] - 2017-03-22
 
 Feature:

--- a/assets/stylesheets/kitten/components/form/_search-input.scss
+++ b/assets/stylesheets/kitten/components/form/_search-input.scss
@@ -35,9 +35,6 @@
   // Size
   $icon-size: k-px-to-rem(14px);
   $submit-horizontal-padding: k-px-to-rem(13px);
-  $input-right-padding: $submit-horizontal-padding * 2 +
-                        $icon-size +
-                        k-px-to-rem(15px);
 
   // Colors
 
@@ -91,7 +88,6 @@
     border-right: 0 !important;
     box-sizing: border-box;
     width: $search-input-width !important;
-    padding-right: $input-right-padding;
 
     &:focus ~ .k-SearchInput__submit {
       border-color: $border-focus;


### PR DESCRIPTION
Screenshot:
![image](https://cloud.githubusercontent.com/assets/523306/24253421/991e9ab6-0fe0-11e7-9af7-6285be90ad62.png)

TODO:

- [ ] Changelog
