### PR TITLE
Fix `TextInputWithLimit` onChange prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [unreleased]
 
 - Feature: Add color utilities.
+- Fix: Pass the `onChange` prop correctly in `TextInputWithLimit`.
 
 ## [9.3.0] - 2017-03-27
 

--- a/assets/javascripts/kitten/components/form/text-input-with-limit.js
+++ b/assets/javascripts/kitten/components/form/text-input-with-limit.js
@@ -51,4 +51,5 @@ TextInputWithLimit.defaultProps = {
   tag: 'input',
   limit: 80,
   defaultValue: "",
+  onChange: function() {},
 }

--- a/assets/javascripts/kitten/components/form/text-input-with-limit.js
+++ b/assets/javascripts/kitten/components/form/text-input-with-limit.js
@@ -15,11 +15,13 @@ export class TextInputWithLimit extends React.Component {
 
   handleChange(e) {
     this.setState({ value: e.target.value })
+    this.props.onChange(e)
   }
 
   render() {
     const { limit,
             defaultValue,
+            onChange,
             ...others } = this.props
 
     const length = this.state.value ? this.state.value.length : 0

--- a/assets/javascripts/kitten/components/form/text-input-with-limit.test.js
+++ b/assets/javascripts/kitten/components/form/text-input-with-limit.test.js
@@ -1,10 +1,17 @@
 import React from 'react'
+import sinon from 'sinon'
 import { expect } from 'chai'
 import { shallow, mount } from 'enzyme'
 import { TextInput } from 'kitten/components/form/text-input'
 import { TextInputWithLimit } from 'kitten/components/form/text-input-with-limit'
 
 describe('<TextInputWithLimit />', () => {
+  const sandbox = sinon.sandbox.create()
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
   describe('by default', () => {
     const defaultComponent = shallow(<TextInputWithLimit />)
 
@@ -44,7 +51,7 @@ describe('<TextInputWithLimit />', () => {
     })
   })
 
-  describe('on input', () => {
+  describe('on onChange event', () => {
     it('updates the TextInput value', () => {
       const component = mount(
         <TextInputWithLimit limit={ 15 } />
@@ -56,6 +63,23 @@ describe('<TextInputWithLimit />', () => {
 
       const counter = component.find('.k-TextInputLimit__counter')
       expect(counter).to.have.text('11')
+    })
+  })
+
+  describe('with onChange prop', () => {
+    const handleChange = () => {}
+    const onChangeSpy = sandbox.spy(handleChange)
+    const component = mount(
+      <TextInputWithLimit onChange={ onChangeSpy } />
+    )
+
+    before(() => {
+      const input = component.find('input')
+      input.simulate('change')
+    })
+
+    it('calls the onChange prop callback', () => {
+      expect(onChangeSpy.calledOnce).to.equal(true)
     })
   })
 })

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "mocha": "^3.2.0",
     "react-addons-test-utils": "^15.4.1",
     "sassdoc": "^2.1.20",
+    "sinon": "^2.1.0",
     "stylelint": "^6.7.1",
     "stylelint-scss": "^1.2.0"
   },


### PR DESCRIPTION
Le composant `TextInputWithLimit` gère lui-même un comportement sur l'événement `onChange`. Actuellement, lorsqu'on passe au composant une prop `onChange`, celle-ci écrase le comportement par défaut.

Cette PR ajoute le fait de prendre la prop `onChange` en compte, en plus du comportement de base pour cet événement.