### PR TITLE
Add margin prop to Title component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Feature: Add `margin` prop to `Title` component.
+
 ## [9.5.0] - 2017-03-30
 
 Features:

--- a/assets/javascripts/kitten/components/typography/title.js
+++ b/assets/javascripts/kitten/components/typography/title.js
@@ -3,12 +3,15 @@ import classNames from 'classnames'
 
 export class Title extends React.Component {
   render() {
-    const { className, modifier, tag, ...other } = this.props
+    const { className, modifier, tag, margin, ...other } = this.props
 
     const titleClassNames = classNames(
       'k-Title',
       className,
-      `k-Title--${modifier}`
+      `k-Title--${modifier}`,
+      {
+        'k-Title--withoutMargin': !margin,
+      }
     )
 
     const Tag = tag
@@ -23,4 +26,5 @@ Title.defaultProps = {
   tag: 'h1',
   modifier: 'primary',
   children: 'Felis…',
+  margin: true,
 }

--- a/assets/javascripts/kitten/components/typography/title.test.js
+++ b/assets/javascripts/kitten/components/typography/title.test.js
@@ -48,5 +48,13 @@ describe('Title with default props', () => {
         expect(component).to.have.tagName('h2')
       })
     })
+
+    describe('with margin prop', () => {
+      const component = shallow(<Title margin={ false } />)
+
+      it('has a good class', () => {
+        expect(component).to.have.className('k-Title--withoutMargin')
+      })
+    })
   })
 })

--- a/assets/stylesheets/kitten/components/typography/_title.scss
+++ b/assets/stylesheets/kitten/components/typography/_title.scss
@@ -50,4 +50,9 @@
                                    $font-step-on-media: 4,
                                    $line-height: normal);
   }
+
+  .k-Title--withoutMargin {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
 }


### PR DESCRIPTION
PR qui permet d'annuler les marges verticales par défaut sur le composant `Title`.

TODO:

- [x] Tests
- [x] Changelog
