### PR TITLE
Propagate className prop to Grid and GridCol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Propagate `className` prop to `Grid` and `GridCol` components.
 - Feature: Add `Separator` component.
 - Fix: Install new grid on each components.
 - Fix: Delete example descriptions.

--- a/assets/javascripts/kitten/components/grid/grid.js
+++ b/assets/javascripts/kitten/components/grid/grid.js
@@ -5,10 +5,11 @@ const mediaQueries = ['xxs', 'xs', 's', 'm', 'l', 'xl']
 
 export class Grid extends React.Component {
   render() {
+    const { className, ...others } = this.props
+    const gridClassName = classNames('k-Grid', className)
+
     return (
-      <div className="k-Grid">
-        { this.props.children }
-      </div>
+      <div className={ gridClassName } { ...others } />
     )
   }
 }
@@ -40,6 +41,7 @@ export class GridCol extends React.Component {
         [`k-Grid__col--offset-${this.props.offset}`]: this.props.offset,
       },
       this.classByMediaQuery(),
+      this.props.className,
     )
 
     return (
@@ -50,7 +52,12 @@ export class GridCol extends React.Component {
   }
 }
 
+Grid.defaultProps = {
+  className: null,
+}
+
 GridCol.defaultProps = {
   col: '12',
   offset: null,
+  className: null,
 }

--- a/assets/javascripts/kitten/components/grid/grid.test.js
+++ b/assets/javascripts/kitten/components/grid/grid.test.js
@@ -17,6 +17,22 @@ describe('<Grid />', () => {
   it('renders children', () => {
     expect(grid).to.have.text('Test')
   })
+
+  describe('with className prop', () => {
+    const grid = shallow(<Grid className="custom__class" />)
+
+    it('has good class', () => {
+      expect(grid).to.have.className('custom__class')
+    })
+  })
+
+  describe('with other prop', () => {
+    const grid = shallow(<Grid aria-hidden="true" />)
+
+    it('has an aria-hidden attribute', () => {
+      expect(grid).to.have.attr('aria-hidden', 'true')
+    })
+  })
 })
 
 describe('<GridCol />', () => {
@@ -59,6 +75,14 @@ describe('<GridCol />', () => {
       expect(gridCol).to.have.className('k-Grid__col--offset-2@s')
       expect(gridCol).to.have.className('k-Grid__col--offset-3@m')
       expect(gridCol).to.have.className('k-Grid__col--offset-4@l')
+    })
+  })
+
+  describe('with className prop', () => {
+    const gridCol = shallow(<GridCol className="custom__class" />)
+
+    it('has good class', () => {
+      expect(gridCol).to.have.className('custom__class')
     })
   })
 })


### PR DESCRIPTION
PR qui permet de propager la prop `className` sur les composants `Grid` et `GridCol`.

TODO:

- [x] Tests
- [x] Changelog
