### PR TITLE
Add normalLineHeight prop to Paragraph component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Feature: Add `normalLineHeight` prop to `Paragraph` component.
 - Fix: Propagate `className` prop to `Grid` and `GridCol` components.
 - Fix: Remove `error` label on Checkbox and RadioButton guideline example.
 - Feature: Add `Separator` component.

--- a/assets/javascripts/kitten/components/typography/paragraph.js
+++ b/assets/javascripts/kitten/components/typography/paragraph.js
@@ -3,13 +3,23 @@ import classNames from 'classnames'
 
 export class Paragraph extends React.Component {
   render() {
-    const { className, tag, modifier, margin, ...other } = this.props
+    const {
+      className,
+      tag,
+      modifier,
+      margin,
+      normalLineHeight,
+      ...other,
+    } = this.props
 
     const paragraphClassNames = classNames(
       'k-Paragraph',
       className,
       `k-Paragraph--${modifier}`,
-      { 'k-Paragraph--withoutMargin': !margin }
+      {
+        'k-Paragraph--withoutMargin': !margin,
+        'k-Paragraph--normalLineHeight': normalLineHeight,
+      }
     )
 
     const Tag = tag
@@ -24,4 +34,5 @@ Paragraph.defaultProps = {
   tag: 'p',
   modifier: 'primary',
   margin: true,
+  normalLineHeight: false,
 }

--- a/assets/javascripts/kitten/components/typography/paragraph.test.js
+++ b/assets/javascripts/kitten/components/typography/paragraph.test.js
@@ -49,4 +49,12 @@ describe('Paragraph with default props', () => {
       expect(component).to.have.className('k-Paragraph--withoutMargin')
     })
   })
+
+  describe('with normalLineHeight prop', () => {
+    const component = shallow(<Paragraph normalLineHeight />)
+
+    it('has a good class', () => {
+      expect(component).to.have.className('k-Paragraph--normalLineHeight')
+    })
+  })
 })

--- a/assets/stylesheets/kitten/components/typography/_paragraph.scss
+++ b/assets/stylesheets/kitten/components/typography/_paragraph.scss
@@ -69,4 +69,8 @@
     margin-top: 0;
     margin-bottom: 0;
   }
+
+  .k-Paragraph--normalLineHeight {
+    line-height: normal;
+  }
 }


### PR DESCRIPTION
PR qui permet d'avoir une option/classe pour mettre le `line-height` par défaut dans le composant `Paragraph`.

TODO:

- [x] Tests
- [x] Changelog
