### PR TITLE
Add LinkCard component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Feature: Add `LinkCard` component.
 - Feature: Add `normalLineHeight` prop to `Paragraph` component.
 - Fix: Propagate `className` prop to `Grid` and `GridCol` components.
 - Fix: Remove `error` label on Checkbox and RadioButton guideline example.

--- a/assets/javascripts/kitten/components/cards/link-card.js
+++ b/assets/javascripts/kitten/components/cards/link-card.js
@@ -1,0 +1,31 @@
+import React from 'react'
+import classNames from 'classnames'
+
+export const LinkCard = ({
+  tag,
+  className,
+  shadow,
+  translateOnHover,
+  ...props,
+}) => {
+  const Tag = tag
+  const linkClassName = classNames(
+    'k-LinkCard',
+    {
+      'k-LinkCard--shadow': shadow,
+      'k-LinkCard--translateOnHover': translateOnHover,
+    },
+    className
+  )
+
+  return (
+    <Tag className={ linkClassName } { ...props } />
+  )
+}
+
+LinkCard.defaultProps = {
+  tag: 'a',
+  className: null,
+  shadow: false,
+  translateOnHover: false,
+}

--- a/assets/javascripts/kitten/components/cards/link-card.test.js
+++ b/assets/javascripts/kitten/components/cards/link-card.test.js
@@ -1,0 +1,66 @@
+import React from 'react'
+import { expect } from 'chai'
+import { shallow } from 'enzyme'
+import { LinkCard } from 'kitten/components/cards/link-card'
+
+describe('<LinkCard />', () => {
+  describe('by default', () => {
+    const linkCard = shallow(<LinkCard />)
+
+    it('is a <a />', () => {
+      expect(linkCard).to.have.tagName('a')
+    })
+
+    it('has default classes', () => {
+      expect(linkCard).to.have.className('k-LinkCard')
+    })
+  })
+
+  describe('with custom class', () => {
+    const linkCard = shallow(<LinkCard className="custom__class" />)
+
+    it('has a custom class', () => {
+      expect(linkCard).to.have.className('custom__class')
+    })
+  })
+
+  describe('with tag prop', () => {
+    const linkCard = shallow(<LinkCard tag="span" />)
+
+    it('has a custom tag', () => {
+      expect(linkCard).to.have.tagName('span')
+    })
+  })
+
+  describe('with shadow prop', () => {
+    const linkCard = shallow(<LinkCard shadow />)
+
+    it('has a good class', () => {
+      expect(linkCard).to.have.className('k-LinkCard--shadow')
+    })
+  })
+
+  describe('with translateOnHover prop', () => {
+    const linkCard = shallow(<LinkCard translateOnHover />)
+
+    it('has a good class', () => {
+      expect(linkCard).to.have.className('k-LinkCard--translateOnHover')
+    })
+  })
+
+  describe('with other prop', () => {
+    const linkCard = shallow(<LinkCard href="#" />)
+
+    it('has an aria-hidden attribute', () => {
+      expect(linkCard).to.have.attr('href', '#')
+    })
+  })
+
+  describe('with children', () => {
+    const linkCard = shallow(<LinkCard>Lorem ipsum…</LinkCard>)
+
+    it('has text', () => {
+      expect(linkCard).to.have.text('Lorem ipsum…')
+    })
+  })
+})

--- a/assets/stylesheets/kitten/_components.scss
+++ b/assets/stylesheets/kitten/_components.scss
@@ -12,6 +12,7 @@
 
 // Cards
 @import 'kitten/components/cards/card';
+@import 'kitten/components/cards/link-card';
 
 // Dev
 @import 'kitten/components/dev/dev-breakpoint';

--- a/assets/stylesheets/kitten/components/cards/_link-card.scss
+++ b/assets/stylesheets/kitten/components/cards/_link-card.scss
@@ -1,0 +1,43 @@
+/// Link card
+///
+/// @group cards
+///
+/// @example scss - usage
+///
+///   @include k-LinkCard;
+///
+/// @example html
+///
+///   <a href="#" class="k-LinkCard">…</a>
+
+@mixin k-LinkCard {
+  $box-shadow-values: 0 5px 15px;
+  $box-shadow-color: map-get($k-colors, 'line-1');
+  $box-shadow-color-hover: map-get($k-colors, 'line-2');
+  $transition-duration: .4s;
+
+  .k-LinkCard {
+    display: block;
+    box-shadow: none;
+    transition: transform $transition-duration, box-shadow $transition-duration;
+    cursor: pointer;
+
+    &:hover {
+      box-shadow: $box-shadow-values $box-shadow-color;
+    }
+  }
+
+  .k-LinkCard--shadow {
+    box-shadow: $box-shadow-values $box-shadow-color;
+
+    &:hover {
+      box-shadow: $box-shadow-values $box-shadow-color-hover;
+    }
+  }
+
+  .k-LinkCard--translateOnHover {
+    &:hover {
+      transform: translateY(-10px);
+    }
+  }
+}

--- a/spec/dummy/client/stylesheets/kitten/_components.scss
+++ b/spec/dummy/client/stylesheets/kitten/_components.scss
@@ -15,6 +15,7 @@
 // Cards
 
 @include k-Card;
+@include k-LinkCard;
 
 // Dev
 


### PR DESCRIPTION
PR qui ajoute un shadow sur une card/container avec diverses options par rapport aux 2 cas connus à ce jour (`ProjectCard`, http://zpl.io/Z1k0hv0).

Une fois cette PR mergée, j'ajouterais ce composant dans la composition de `ProjectCard` pour avoir un cas concret d'utilisation.

TODO:

- [x] Tests
- [x] Changelog
