### PR TITLE
Update line-height on RadioButton/Checkbox/Switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Set `line-height: normal` to `RadioButton/Checkbox/Switch` components.
 - Feature: Add `normalLineHeight` prop to `Paragraph` component.
 - Fix: Propagate `className` prop to `Grid` and `GridCol` components.
 - Fix: Remove `error` label on Checkbox and RadioButton guideline example.

--- a/assets/stylesheets/kitten/components/form/_checkbox.scss
+++ b/assets/stylesheets/kitten/components/form/_checkbox.scss
@@ -17,7 +17,7 @@
   // Font
   $font: 'source-sans-light';
   $font-step: 0;
-  $line-height: 1;
+  $line-height: normal;
 
   // Error
   $error-color: map-get($k-colors, 'error');

--- a/assets/stylesheets/kitten/components/form/_radio-button.scss
+++ b/assets/stylesheets/kitten/components/form/_radio-button.scss
@@ -29,7 +29,7 @@
   $font-step-on-media: 3;
   $font-step-content: -1;
   $font-step-content-large: 0;
-  $line-height: 1;
+  $line-height: normal;
 
   // Error
   $color-error: map-get($k-colors, 'error');

--- a/assets/stylesheets/kitten/components/form/_switch.scss
+++ b/assets/stylesheets/kitten/components/form/_switch.scss
@@ -17,7 +17,7 @@
   // Font
   $font: 'source-sans-light';
   $font-step: 0;
-  $line-height: 1;
+  $line-height: normal;
   $font-step-big: 3;
 
   // Colors


### PR DESCRIPTION
Change le `line-height` des composants `RadioButton/Checkbox/Switch`.

Avant / Après : 
![radioboxes](https://cloud.githubusercontent.com/assets/736319/24661416/9df44754-1952-11e7-98b5-0b73dd4ef638.png)

TODO:

- [x] Changelog
