### PR TITLE
Add onSelectChange and errorOnSelect props to TextInputAndSelect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fix: Install new grid on 10 columns.
 - Breaking change: Update button `min-width` class on `button-tiny`.
 - Feature: Add `margin` prop to `Title` component.
-- Feature: Add `onSelectChange` prop to `TextInputAndSelect` component.
+- Feature: Add `onSelectChange` and `errorOnSelect` props to `TextInputAndSelect`
+component.
 
 ## [9.5.0] - 2017-03-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fix: Install new grid on 10 columns.
 - Breaking change: Update button `min-width` class on `button-tiny`.
 - Feature: Add `margin` prop to `Title` component.
+- Feature: Add `onSelectChange` prop to `TextInputAndSelect` component.
 
 ## [9.5.0] - 2017-03-30
 

--- a/assets/javascripts/kitten/components/form/text-input-and-select.js
+++ b/assets/javascripts/kitten/components/form/text-input-and-select.js
@@ -10,9 +10,12 @@ export const TextInputAndSelect = props => {
           selectOptions,
           selectName,
           selectValue,
+          onSelectChange,
           appendSelect,
           ...textInputProps } = props
 
+  // TODO: use another prop that digits to handle
+  // `k-FormComposer__element--main` class.
   const inputWrapperClassName = classNames(
     'k-FormComposer__element',
     {
@@ -20,6 +23,7 @@ export const TextInputAndSelect = props => {
     }
   )
 
+  // TODO: handle key without currencyName prop
   const renderTextInputWrapper = () => {
     return (
       <div className={ inputWrapperClassName } key={ `${props.currencyName}1` }>
@@ -37,6 +41,7 @@ export const TextInputAndSelect = props => {
                          options={ selectOptions }
                          value={ selectValue }
                          tiny={ tiny }
+                         onInputChange={ onSelectChange }
                          disabled={ disabled } />
       </div>
     )
@@ -63,6 +68,7 @@ TextInputAndSelect.defaultProps = {
   selectOptions: [{ value: 'myValue', label: 'My label' }],
   selectName: null,
   selectValue: null,
+  onSelectChange: function() {},
   digits: null,
   appendSelect: false,
 }

--- a/assets/javascripts/kitten/components/form/text-input-and-select.js
+++ b/assets/javascripts/kitten/components/form/text-input-and-select.js
@@ -20,7 +20,8 @@ export const TextInputAndSelect = props => {
     'k-FormComposer__element',
     {
       'k-FormComposer__element--main': !props.digits
-    }
+    },
+    className,
   )
 
   // TODO: handle key without currencyName prop

--- a/assets/javascripts/kitten/components/form/text-input-and-select.js
+++ b/assets/javascripts/kitten/components/form/text-input-and-select.js
@@ -11,6 +11,7 @@ export const TextInputAndSelect = props => {
           selectName,
           selectValue,
           onSelectChange,
+          errorOnSelect,
           appendSelect,
           ...textInputProps } = props
 
@@ -43,6 +44,7 @@ export const TextInputAndSelect = props => {
                          value={ selectValue }
                          tiny={ tiny }
                          onInputChange={ onSelectChange }
+                         error={ errorOnSelect }
                          disabled={ disabled } />
       </div>
     )
@@ -70,6 +72,7 @@ TextInputAndSelect.defaultProps = {
   selectName: null,
   selectValue: null,
   onSelectChange: function() {},
+  errorOnSelect: false,
   digits: null,
   appendSelect: false,
 }

--- a/assets/javascripts/kitten/components/form/text-input-and-select.test.js
+++ b/assets/javascripts/kitten/components/form/text-input-and-select.test.js
@@ -1,0 +1,120 @@
+import React from 'react'
+import { expect } from 'chai'
+import { shallow } from 'enzyme'
+import { TextInputAndSelect } from
+  'kitten/components/form/text-input-and-select'
+import SelectWithState from 'kitten/components/form/select-with-state'
+import { TextInput } from 'kitten/components/form/text-input'
+
+describe('<TextInputWithSelect />', () => {
+  describe('by default', () => {
+    it('renders 2 <div class="k-FormComposer__element">', () => {
+      const component = shallow(<TextInputAndSelect />)
+      const wrapper = component.find('.k-FormComposer__element')
+
+      expect(wrapper).to.have.length(2)
+    })
+
+    it('renders a <div class="k-FormComposer__element--main">', () => {
+      const component = shallow(<TextInputAndSelect />)
+      const wrapper = component.find('.k-FormComposer__element--main')
+
+      expect(wrapper).to.have.length(1)
+    })
+
+
+    it('renders a <TextInput /> component', () => {
+      const component = shallow(<TextInputAndSelect />)
+      const textInput = component.find(TextInput)
+
+      expect(textInput).to.have.length(1)
+    })
+
+
+    it('renders a <Select /> component', () => {
+      const component = shallow(<TextInputAndSelect />)
+      const selectWithState = component.find(SelectWithState)
+
+      expect(selectWithState).to.have.length(1)
+    })
+  })
+
+  describe('with tiny prop', () => {
+    it('pass the tiny prop to <TextInput />', () => {
+      const component = shallow(<TextInputAndSelect tiny />)
+      const textInput = component.find(TextInput)
+      const expectedProps = {
+        tiny: true
+      }
+
+      expect(textInput.props()).to.contain.all.keys(expectedProps)
+    })
+  })
+
+  describe('with disabled prop', () => {
+    it('pass the disabled prop to <TextInput />', () => {
+      const component = shallow(<TextInputAndSelect disabled />)
+      const textInput = component.find(TextInput)
+      const expectedProps = { disabled: true }
+
+      expect(textInput.props()).to.contain.any.keys(expectedProps)
+    })
+  })
+
+  describe('with selectName prop', () => {
+    it('pass the selectName prop to <SelectWithState />', () => {
+      const selectName = 'custom-select-name'
+      const component = shallow(<TextInputAndSelect selectName={ selectName } />)
+      const selectWithState = component.find(SelectWithState)
+      const expectedProps = { name: selectName }
+
+      expect(selectWithState.props()).to.contain.any.keys(expectedProps)
+    })
+  })
+
+  describe('with selectValue prop', () => {
+    it('pass the selectName prop to <SelectWithState />', () => {
+      const selectValue = 'custom-select-value'
+      const component = shallow(<TextInputAndSelect selectValue={ selectValue } />)
+      const selectWithState = component.find(SelectWithState)
+      const expectedProps = { value: selectValue }
+
+      expect(selectWithState.props()).to.contain.any.keys(expectedProps)
+    })
+  })
+
+  describe('with digits prop', () => {
+    it('removes k-FormComposer__element--main class from the input wrapper', () => {
+      const component = shallow(<TextInputAndSelect digits="2" />)
+      const input = component.find('.k-FormComposer__element--main')
+
+      expect(input).to.have.length(0)
+    })
+  })
+
+  describe('with onSelectChange prop', () => {
+    it('pass the selectName prop to <SelectWithState />', () => {
+      const handleSelectChange = () => {}
+      const component = shallow(<TextInputAndSelect
+        onSelectChange={ handleSelectChange }
+      />)
+      const selectWithState = component.find(SelectWithState)
+      const expectedProps = { onInputChange: handleSelectChange }
+
+      expect(selectWithState.props()).to.contain.any.keys(expectedProps)
+    })
+  })
+
+  describe('with custom prop', () => {
+    it('pass the prop to <TextInput />', () => {
+      const component = shallow(<TextInputAndSelect data-custom="Alice" />)
+      const textInput = component.find(TextInput)
+      const expectedProps = { ['data-custom']: 'Alice' }
+
+      expect(textInput.props()).to.contain.any.keys(expectedProps)
+    })
+  })
+
+  // TODO
+  describe('with appendSelect prop', () => {})
+})

--- a/assets/javascripts/kitten/components/form/text-input-and-select.test.js
+++ b/assets/javascripts/kitten/components/form/text-input-and-select.test.js
@@ -121,10 +121,8 @@ describe('<TextInputWithSelect />', () => {
         <TextInputAndSelect className="k-TextInput--custom" />
       )
       const inputWrapper = component.find('.k-TextInput--custom')
-      const wrapperContainsInput = inputWrapper.find(TextInput)
 
-      expect(wrapperContainsInput).to.have.length(1)
-      expect(expectation).to.have.length(1)
+      expect(inputWrapper).to.have.length(1)
     })
   })
 

--- a/assets/javascripts/kitten/components/form/text-input-and-select.test.js
+++ b/assets/javascripts/kitten/components/form/text-input-and-select.test.js
@@ -107,7 +107,6 @@ describe('<TextInputWithSelect />', () => {
 
   describe('with errorOnSelect prop', () => {
     it('pass the errorOnSelect prop to <SelectWithState />', () => {
-      const handleSelectChange = () => {}
       const component = shallow(<TextInputAndSelect errorOnSelect />)
       const selectWithState = component.find(SelectWithState)
       const expectedProps = { error: true }

--- a/assets/javascripts/kitten/components/form/text-input-and-select.test.js
+++ b/assets/javascripts/kitten/components/form/text-input-and-select.test.js
@@ -120,9 +120,11 @@ describe('<TextInputWithSelect />', () => {
       const component = shallow(
         <TextInputAndSelect className="k-TextInput--custom" />
       )
-      const inputWrapper = component.find('.k-FormComposer__element--main')
+      const inputWrapper = component.find('.k-TextInput--custom')
+      const wrapperContainsInput = inputWrapper.find(TextInput)
 
-      expect(inputWrapper).to.have.className('k-TextInput--custom')
+      expect(wrapperContainsInput).to.have.length(1)
+      expect(expectation).to.have.length(1)
     })
   })
 

--- a/assets/javascripts/kitten/components/form/text-input-and-select.test.js
+++ b/assets/javascripts/kitten/components/form/text-input-and-select.test.js
@@ -105,6 +105,17 @@ describe('<TextInputWithSelect />', () => {
     })
   })
 
+  describe('with errorOnSelect prop', () => {
+    it('pass the errorOnSelect prop to <SelectWithState />', () => {
+      const handleSelectChange = () => {}
+      const component = shallow(<TextInputAndSelect errorOnSelect />)
+      const selectWithState = component.find(SelectWithState)
+      const expectedProps = { error: true }
+
+      expect(selectWithState.props()).to.contain.any.keys(expectedProps)
+    })
+  })
+
   describe('with custom prop', () => {
     it('pass the prop to <TextInput />', () => {
       const component = shallow(<TextInputAndSelect data-custom="Alice" />)

--- a/assets/javascripts/kitten/components/form/text-input-and-select.test.js
+++ b/assets/javascripts/kitten/components/form/text-input-and-select.test.js
@@ -115,6 +115,17 @@ describe('<TextInputWithSelect />', () => {
     })
   })
 
+  describe ('with a custom class', () => {
+    it('pass the class name to the input wrapper', () => {
+      const component = shallow(
+        <TextInputAndSelect className="k-TextInput--custom" />
+      )
+      const inputWrapper = component.find('.k-FormComposer__element--main')
+
+      expect(inputWrapper).to.have.className('k-TextInput--custom')
+    })
+  })
+
   describe('with custom prop', () => {
     it('pass the prop to <TextInput />', () => {
       const component = shallow(<TextInputAndSelect data-custom="Alice" />)


### PR DESCRIPTION
Pour gérer les cas d'erreur et la soumission des valeurs du composant `FormAmountAndCurrency`, j'ai ajouté dans cette PR : 
- une prop `errorOnSelect` pour gérer l'état d'erreur sur `SelectWithState`,
- un handler pour la prop `onInputChange` de `SelectWithState`.

J'ai laissé un test en stand-by (n'ayant pas trouvé d'idée de comment le tester) et j'ai également ajouté des TODO dans le composant lui-même pour retirer tout couplage entre ce composant et des possibles composants parents.

TODO:

- [x] Tests
- [x] Changelog
