### PR TITLE
Add Container component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Feature: Add `Container` component.
+
 ## [10.2.0] - 2017-04-11
 
 Feature:

--- a/assets/javascripts/kitten/components/grid/container.js
+++ b/assets/javascripts/kitten/components/grid/container.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import classNames from 'classnames'
+
+export const Container = ({ className, ...props }) => {
+  const containerClassName = classNames('k-Container', className)
+
+  return (
+    <div className={ containerClassName } { ...props } />
+  )
+}
+
+Container.defaultProps = {
+  className: null,
+}

--- a/assets/javascripts/kitten/components/grid/container.test.js
+++ b/assets/javascripts/kitten/components/grid/container.test.js
@@ -1,0 +1,26 @@
+import React from 'react'
+import { expect } from 'chai'
+import { shallow } from 'enzyme'
+import { Container } from 'kitten/components/grid/container'
+
+describe('<Container />', () => {
+  describe('by default', () => {
+    const container = shallow(<Container />)
+
+    it('is a <div />', () => {
+      expect(container).to.have.tagName('div')
+    })
+
+    it('has a default class', () => {
+      expect(container).to.have.className('k-Container')
+    })
+  })
+
+  describe('with a custom class', () => {
+    const container = shallow(<Container className="custom__class" />)
+
+    it('has a custom class', () => {
+      expect(container).to.have.className('custom__class')
+    })
+  })
+})

--- a/assets/javascripts/kitten/components/grid/container.test.js
+++ b/assets/javascripts/kitten/components/grid/container.test.js
@@ -23,4 +23,20 @@ describe('<Container />', () => {
       expect(container).to.have.className('custom__class')
     })
   })
+
+  describe('with other props', () => {
+    const container = shallow(<Container aria-hidden />)
+
+    it('has aria-hidden attribute', () => {
+      expect(container).to.have.attr('aria-hidden', 'true')
+    })
+  })
+
+  describe('with children', () => {
+    const container = shallow(<Container>Lorem ipsum…</Container>)
+
+    it('has text', () => {
+      expect(container).to.have.text('Lorem ipsum…')
+    })
+  })
 })

--- a/assets/stylesheets/kitten/_components.scss
+++ b/assets/stylesheets/kitten/_components.scss
@@ -46,6 +46,7 @@
 @import 'kitten/components/form/text-input-with-unit';
 
 // Grid
+@import 'kitten/components/grid/container';
 @import 'kitten/components/grid/grid';
 @import 'kitten/components/grid/lego-grid';
 @import "kitten/components/grid/row";

--- a/assets/stylesheets/kitten/components/grid/_container.scss
+++ b/assets/stylesheets/kitten/components/grid/_container.scss
@@ -1,0 +1,17 @@
+/// Container.
+///
+/// @group grid
+///
+/// @example scss - usage
+///
+///   @include k-Container;
+///
+/// @example html
+///
+///   <div className="k-Container">…</div>
+
+@mixin k-Container {
+  .k-Container {
+    @include container;
+  }
+}

--- a/spec/dummy/client/entries/app-kitten.js
+++ b/spec/dummy/client/entries/app-kitten.js
@@ -39,6 +39,7 @@ import { TextInputWithLimit } from 'kitten/components/form/text-input-with-limit
 import { TextInputWithUnit } from 'kitten/components/form/text-input-with-unit'
 
 // Grid
+import { Container } from 'kitten/components/grid/container'
 import { Grid, GridCol } from 'kitten/components/grid/grid'
 import { KarlSideLayout } from 'kitten/karl/layout/side-layout'
 
@@ -191,8 +192,6 @@ ReactOnRails.register({
   // Form
   FormAmountAndCurrency,
   FormPhoneNumber,
-  Grid,
-  GridCol,
   GrabberIcon,
   HeaderTour,
   Label,
@@ -208,6 +207,11 @@ ReactOnRails.register({
   TextInput,
   TextInputWithLimit,
   TextInputWithUnit,
+
+  // Grid
+  Container,
+  Grid,
+  GridCol,
 
   // Icons
   GrabberIcon,

--- a/spec/dummy/client/stylesheets/kitten/_components.scss
+++ b/spec/dummy/client/stylesheets/kitten/_components.scss
@@ -118,6 +118,7 @@
 
 // Grid
 
+@include k-Container;
 @include k-Grid;
 @include k-LegoGrid;
 @include k-Row;


### PR DESCRIPTION
PR qui permet d'avoir un composant pour créer un container. Souvent nos composants de `grid` embarque un container mais en terme de composition nous sommes assez limités. Avec ce nouveau composant on peut gérer entièrement une grille en mode composition : 

```js
<Container>
  <Grid>
    <Grid col="12"/>
      …
    </Grid>
  </Grid>
</Container>
```

TODO:

- [x] Tests
- [x] Changelog
