### PR TITLE
Add grid in `LegoGrid.Item` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
-- Feature: Add `LegoGrid.ItemContent` component.
+- Feature: Update grid in `LegoGrid.Item` component.
 - Feature: Add `Container` component.
 
 ## [10.2.0] - 2017-04-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Feature: Add `LegoGrid.ItemContent` component.
 - Feature: Add `Container` component.
 
 ## [10.2.0] - 2017-04-11

--- a/app/assets/stylesheets/kitten/karl/_card.scss
+++ b/app/assets/stylesheets/kitten/karl/_card.scss
@@ -42,5 +42,4 @@ $karl-card-layout: (
   height: k-px-to-rem(100px);
   background-color: map-get($k-colors, 'background-1');
   box-shadow: 0 5px 10px map-get($k-colors, 'line-2');
-  margin: 0 k-px-to-rem(10px) k-px-to-rem(20px);
 }

--- a/assets/javascripts/kitten/components/grid/lego-grid.js
+++ b/assets/javascripts/kitten/components/grid/lego-grid.js
@@ -15,19 +15,15 @@ export const LegoGrid = props => {
   )
 }
 
-LegoGrid.Item = props => {
+LegoGrid.Item = ({ children, ...props }) => {
   const itemClassName = classNames('k-LegoGrid__item', props.className)
 
   return (
-    <div { ...props } className={ itemClassName } />
-  )
-}
-
-LegoGrid.ItemContent = props => {
-  const itemClassName = classNames('k-LegoGrid__item__content', props.className)
-
-  return (
-    <div { ...props } className={ itemClassName } />
+    <div { ...props } className={ itemClassName }>
+      <div className="k-LegoGrid__item__content">
+        { children }
+      </div>
+    </div>
   )
 }
 
@@ -37,9 +33,5 @@ LegoGrid.defaultProps = {
 }
 
 LegoGrid.Item.defaultProps = {
-  className: null,
-}
-
-LegoGrid.ItemContent.defaultProps = {
   className: null,
 }

--- a/assets/javascripts/kitten/components/grid/lego-grid.js
+++ b/assets/javascripts/kitten/components/grid/lego-grid.js
@@ -23,11 +23,23 @@ LegoGrid.Item = props => {
   )
 }
 
+LegoGrid.ItemContent = props => {
+  const itemClassName = classNames('k-LegoGrid__item__content', props.className)
+
+  return (
+    <div { ...props } className={ itemClassName } />
+  )
+}
+
 LegoGrid.defaultProps = {
   className: null,
   masonryProps: {},
 }
 
 LegoGrid.Item.defaultProps = {
+  className: null,
+}
+
+LegoGrid.ItemContent.defaultProps = {
   className: null,
 }

--- a/assets/javascripts/kitten/components/grid/lego-grid.test.js
+++ b/assets/javascripts/kitten/components/grid/lego-grid.test.js
@@ -54,7 +54,7 @@ describe('<LegoGrid.Item />', () => {
       expect(legoGridItem).to.have.tagName('div')
     })
 
-    it('has a default classes', () => {
+    it('has default classes', () => {
       expect(legoGridItem).to.have.className('k-LegoGrid__item')
       expect(legoGridItem).to.have.descendants('.k-LegoGrid__item__content')
     })

--- a/assets/javascripts/kitten/components/grid/lego-grid.test.js
+++ b/assets/javascripts/kitten/components/grid/lego-grid.test.js
@@ -75,3 +75,37 @@ describe('<LegoGrid.Item />', () => {
     })
   })
 })
+
+describe('<LegoGrid.ItemContent />', () => {
+  describe('by default', () => {
+    const content = shallow(<LegoGrid.ItemContent />)
+
+    it('is a <div />', () => {
+      expect(content).to.have.tagName('div')
+    })
+
+    it('has a default class', () => {
+      expect(content).to.have.className('k-LegoGrid__item__content')
+    })
+  })
+
+  describe('with a custom class', () => {
+    const content = shallow(<LegoGrid.ItemContent className="custom__class" />)
+
+    it('has a custom class', () => {
+      expect(content).to.have.className('custom__class')
+    })
+  })
+
+  describe('with children', () => {
+    const content = shallow(
+      <LegoGrid.ItemContent>
+        Lorem ipsum…
+      </LegoGrid.ItemContent>
+    )
+
+    it('has text', () => {
+      expect(content).to.have.text('Lorem ipsum…')
+    })
+  })
+})

--- a/assets/javascripts/kitten/components/grid/lego-grid.test.js
+++ b/assets/javascripts/kitten/components/grid/lego-grid.test.js
@@ -54,8 +54,9 @@ describe('<LegoGrid.Item />', () => {
       expect(legoGridItem).to.have.tagName('div')
     })
 
-    it('has a default class', () => {
+    it('has a default classes', () => {
       expect(legoGridItem).to.have.className('k-LegoGrid__item')
+      expect(legoGridItem).to.have.descendants('.k-LegoGrid__item__content')
     })
   })
 
@@ -72,40 +73,6 @@ describe('<LegoGrid.Item />', () => {
 
     it('has text', () => {
       expect(legoGridItem).to.have.text('Lorem ipsum…')
-    })
-  })
-})
-
-describe('<LegoGrid.ItemContent />', () => {
-  describe('by default', () => {
-    const content = shallow(<LegoGrid.ItemContent />)
-
-    it('is a <div />', () => {
-      expect(content).to.have.tagName('div')
-    })
-
-    it('has a default class', () => {
-      expect(content).to.have.className('k-LegoGrid__item__content')
-    })
-  })
-
-  describe('with a custom class', () => {
-    const content = shallow(<LegoGrid.ItemContent className="custom__class" />)
-
-    it('has a custom class', () => {
-      expect(content).to.have.className('custom__class')
-    })
-  })
-
-  describe('with children', () => {
-    const content = shallow(
-      <LegoGrid.ItemContent>
-        Lorem ipsum…
-      </LegoGrid.ItemContent>
-    )
-
-    it('has text', () => {
-      expect(content).to.have.text('Lorem ipsum…')
     })
   })
 })

--- a/assets/javascripts/kitten/karl/grid/lego-grid.js
+++ b/assets/javascripts/kitten/karl/grid/lego-grid.js
@@ -29,10 +29,8 @@ export const KarlLegoGrid = () => {
           <LegoGrid masonryProps={ masonryProps }>
             { cards.map(card =>
               <LegoGrid.Item key={ card.key }>
-                <LegoGrid.ItemContent>
-                  <div className="karl-ProjectCard"
-                       style={ { height: card.height } } />
-                </LegoGrid.ItemContent>
+                <div className="karl-ProjectCard"
+                     style={ { height: card.height } } />
               </LegoGrid.Item>
             ) }
           </LegoGrid>

--- a/assets/javascripts/kitten/karl/grid/lego-grid.js
+++ b/assets/javascripts/kitten/karl/grid/lego-grid.js
@@ -29,8 +29,10 @@ export const KarlLegoGrid = () => {
           <LegoGrid masonryProps={ masonryProps }>
             { cards.map(card =>
               <LegoGrid.Item key={ card.key }>
-                <div className="karl-ProjectCard"
-                     style={ { height: card.height } } />
+                <LegoGrid.ItemContent>
+                  <div className="karl-ProjectCard"
+                       style={ { height: card.height } } />
+                </LegoGrid.ItemContent>
               </LegoGrid.Item>
             ) }
           </LegoGrid>

--- a/assets/stylesheets/kitten/components/grid/_lego-grid.scss
+++ b/assets/stylesheets/kitten/components/grid/_lego-grid.scss
@@ -36,4 +36,12 @@
       @include k-grid-colSize(4, $flexible: false);
     }
   }
+
+  .k-LegoGrid__item__content {
+    margin: 0 k-px-to-rem(20px) k-px-to-rem(20px);
+
+    @include k-media-min('s') {
+      margin: 0 k-px-to-rem(10px) k-px-to-rem(20px);
+    }
+  }
 }


### PR DESCRIPTION
PR qui permet d'ajouter des marges à l'intérieur des items. Pour éviter de l'ajouter du côté de l'élément à l'intérieur d'un item.

TODO:

- [x] Tests
- [x] Changelog
