### PR TITLE
Fix `LegoGrid` grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Fix `LegoGrid` grid.
+
 ## [11.3.0] - 2017-05-02
 
 Features:

--- a/assets/stylesheets/kitten/components/grid/_lego-grid.scss
+++ b/assets/stylesheets/kitten/components/grid/_lego-grid.scss
@@ -18,11 +18,6 @@
   .k-LegoGrid {
     @include k-grid;
     display: block;
-
-    @include k-media-max('xs') {
-      margin-left: k-px-to-rem(-20px);
-      margin-right: k-px-to-rem(-20px);
-    }
   }
 
   .k-LegoGrid__item {
@@ -38,10 +33,6 @@
   }
 
   .k-LegoGrid__item__content {
-    margin: 0 k-px-to-rem(20px) k-px-to-rem(20px);
-
-    @include k-media-min('s') {
-      margin: 0 k-px-to-rem(10px) k-px-to-rem(20px);
-    }
+    margin: 0 k-px-to-rem(10px) k-px-to-rem(20px);
   }
 }


### PR DESCRIPTION
PR qui fixe un scroll horizontale visible sur mobile, dû à une mauvaise gestion des gouttières sur cette media-query.

TODO:

- [x] Changelog
