### PR TITLE
Allow to hide tooltip in `SliderWithTooltipAndPower`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Feature: Allow to hide tooltip in `SliderWithTooltipAndPower`.
 - Feature: Add new `MasterCardIcon` and `CbIcon` components.
 - Feature: Add `.k-TagButton__icon` class to adds icons to tag buttons.
 

--- a/assets/javascripts/kitten/components/sliders/slider-with-tooltip-and-power.js
+++ b/assets/javascripts/kitten/components/sliders/slider-with-tooltip-and-power.js
@@ -92,13 +92,21 @@ export class SliderWithTooltipAndPower extends React.Component {
     return Math.round(value / step) * step
   }
 
+  renderTooltip() {
+    if (!this.props.tooltipText) return
+
+    return (
+      <SliderTooltip className={ this.props.tooltipClass }
+                     percentage={ this.ratio() * 100 + '%' }>
+        { this.props.tooltipText }
+      </SliderTooltip>
+    )
+  }
+
   render() {
     return (
       <div>
-        <SliderTooltip className={ this.props.tooltipClass }
-                       percentage={ this.ratio() * 100 + '%' }>
-          { this.props.tooltipText }
-        </SliderTooltip>
+        { this.renderTooltip() }
         <SliderBar onAction={ this.props.onAction }
                    onMove={ this.props.onMove }
                    name={ this.props.name }

--- a/assets/javascripts/kitten/components/sliders/slider-with-tooltip-and-power.js
+++ b/assets/javascripts/kitten/components/sliders/slider-with-tooltip-and-power.js
@@ -130,6 +130,7 @@ SliderWithTooltipAndPower.defaultProps = {
   max: 100,
   step: 1,
   power: 1,
+  tooltipText: null,
   onChange: function() {},
   onChangeEnd: function() {},
 }


### PR DESCRIPTION
PR qui permet de ne pas afficher la tooltip si on ne donne pas de texte dans la prop `tooltipText`.

Screenshot:

<img width="391" alt="capture d ecran 2017-05-10 a 11 47 01" src="https://cloud.githubusercontent.com/assets/736319/25892967/6cfe300c-3576-11e7-84a5-c7a7eb54656b.png">

TODO:

- [x] Changelog
- [ ] Tests (Ca serait bien de les écrire dans une PR dédiée)
