### PR TITLE
Remove `Line` and `Line.Item` on `KarlPaymentButtons` example

### DIFF
--- a/KARL_CHANGELOG.md
+++ b/KARL_CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Remove `Line` and `Line.Item` on `KarmPaymentButtons` example.
 - Fix: `Hero` example relooking.
 - Feature: Add `TagButton` with large word example.
 - Fix: Update `UserMenu` and `PlatformSwitch` components with `dropdown` component.

--- a/KARL_CHANGELOG.md
+++ b/KARL_CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
-- Fix: Remove `Line` and `Line.Item` on `KarmPaymentButtons` example.
+- Fix: Remove `Line` and `Line.Item` on `KarlPaymentButtons` example.
 - Fix: `Hero` example relooking.
 - Feature: Add `TagButton` with large word example.
 - Fix: Update `UserMenu` and `PlatformSwitch` components with `dropdown` component.

--- a/assets/javascripts/kitten/karl/buttons/payment-button.js
+++ b/assets/javascripts/kitten/karl/buttons/payment-button.js
@@ -22,20 +22,12 @@ const paymentButtonWrapper = (WrappedComponent, props) => {
 }
 
 export const KarlPaymentButtons = () => (
-  <Line>
-    <Line.Item>
-      <KarlPaymentButtonVisa />
-    </Line.Item>
-    <Line.Item>
-      <KarlPaymentButtonMasterCard />
-    </Line.Item>
-    <Line.Item>
-      <KarlPaymentButtonCb />
-    </Line.Item>
-    <Line.Item>
-      <KarlPaymentButtonBankTransfer />
-    </Line.Item>
-  </Line>
+  <div>
+    <KarlPaymentButtonVisa />
+    <KarlPaymentButtonMasterCard />
+    <KarlPaymentButtonCb />
+    <KarlPaymentButtonBankTransfer />
+  </div>
 )
 
 const KarlPaymentButtonVisa = paymentButtonWrapper(VisaIcon, {
@@ -58,6 +50,6 @@ const KarlPaymentButtonBankTransfer = props => {
 
   return (
     <RadioButton text={ text }
-                 name='payment-button-1' />
+                 name="payment-button-1" />
   )
 }


### PR DESCRIPTION
Voir #647 

Finalement on a décidé avec les hautes autorités que l'on retire les composants `<Line> et <Line.Item>

- [x] changelog