### PR TITLE
Add webpack dependency

### DIFF
--- a/spec/dummy/package.json
+++ b/spec/dummy/package.json
@@ -16,6 +16,6 @@
     "hot-assets": "(cd client && npm run hot-assets)"
   },
   "devDependencies": {
-    "webpack-cli": "^1.3.1"
+    "webpack": "^2.5.1"
   }
 }

--- a/spec/dummy/package.json
+++ b/spec/dummy/package.json
@@ -14,5 +14,8 @@
     "build:dev": "(cd client && npm run build:dev)",
     "build": "(cd client && npm run build --silent)",
     "hot-assets": "(cd client && npm run hot-assets)"
+  },
+  "devDependencies": {
+    "webpack-cli": "^1.3.1"
   }
 }

--- a/spec/dummy/package.json
+++ b/spec/dummy/package.json
@@ -16,6 +16,6 @@
     "hot-assets": "(cd client && npm run hot-assets)"
   },
   "devDependencies": {
-    "webpack": "^2.5.1"
+    "kitten-launcher": "^1.0.0"
   }
 }


### PR DESCRIPTION
La commande `npm run build:dev` dépends de l'executable `webpack` pour fonctionner. J'ai donc l'impression qu'il faut installer webpack pour s'en servir. Je propose donc de l'ajouter comme dépendence via `kitten-launcher`.