### PR TITLE
Prefer npm to yarn for postinstall script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Prefer `npm` to `yarn` in the postinstall script.
+
 ## [11.8.0] - 2017-05-17
 
 Feature:

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "webpack": "^2.5.1"
   },
   "scripts": {
-    "postinstall": "cd vendor/assets/stylesheets/kitten/sassy-maps && yarn install",
+    "postinstall": "cd vendor/assets/stylesheets/kitten/sassy-maps && npm install",
     "sassdoc": "sassdoc -d public/sassdoc assets/stylesheets",
     "stylelint": "stylelint --syntax scss 'assets/stylesheets/**/*.scss'",
     "build:dev": "(cd spec/dummy/client && yarn build:dev)",


### PR DESCRIPTION
Parce que sinon ça requiert `yarn` sur les apps.