### PR TITLE
Better kitten path in example package

### DIFF
--- a/spec/dummy/client/package.json
+++ b/spec/dummy/client/package.json
@@ -9,7 +9,7 @@
     "hot-assets": "babel-node bin/webpack-dev-server.js"
   },
   "dependencies": {
-    "kitten-components": "file:../../../../kitten",
+    "kitten-components": "file:../../..",
     "kitten-launcher": "^1.0.0",
     "react-on-rails": "~6.10.1"
   }


### PR DESCRIPTION
Permets d'avoir un dossier où se trouve `kitten` qui soit nommé différemment (pour installer l'app dans Docker par exemple #663). 