### PR TITLE
Fix: Change `TagButton` background color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Change `TagButton` background.
+
 ## [11.10.0] - 2017-05-19
 
 Features:

--- a/assets/stylesheets/kitten/components/buttons/_tag-button.scss
+++ b/assets/stylesheets/kitten/components/buttons/_tag-button.scss
@@ -67,8 +67,8 @@
     ),
     is-selected: (
       color: #fff,
-      border-color: map-get($k-colors, 'primary-3'),
-      background-color: map-get($k-colors, 'primary-3'),
+      border-color: map-get($k-colors, 'primary-1'),
+      background-color: map-get($k-colors, 'primary-1'),
     ),
     disabled: (
       color: map-get($k-colors, 'font-2'),


### PR DESCRIPTION
Closes #https://github.com/KissKissBankBank/kisskissbankbank/issues/1156.

Screenshot:
![image](https://cloud.githubusercontent.com/assets/523306/26258127/96b0faca-3cc3-11e7-9c93-68a4ce3442ae.png)


TODO:

- [x] Changelog
