### PR TITLE
Document unfocus detector

### DIFF
--- a/app/views/layouts/kitten/application.html.erb
+++ b/app/views/layouts/kitten/application.html.erb
@@ -44,6 +44,7 @@
   <%= yield %>
 <% end %>
 
+<%= react_component 'DocumentUnfocusDetector' %>
 <%= react_component 'DevGrid' %>
 
 <%= env_javascript_include_tag(static: 'application',

--- a/assets/javascripts/kitten/components/detectors/document-unfocus-detector.js
+++ b/assets/javascripts/kitten/components/detectors/document-unfocus-detector.js
@@ -7,18 +7,18 @@ export class DocumentUnfocusDetector extends React.Component {
   constructor(props) {
     super(props)
 
-    this.handleKeydown = this.handleKeydown.bind(this)
+    this.handleKeyDown = this.handleKeyDown.bind(this)
     this.handleMouseDown = this.handleMouseDown.bind(this)
   }
 
   componentDidMount() {
     document.addEventListener('mousedown', this.handleMouseDown)
-    document.addEventListener('keydown', this.handleKeydown)
+    document.addEventListener('keydown', this.handleKeyDown)
   }
 
   componentWillUnmount() {
     document.removeEventListener('mousedown', this.handleMouseDown)
-    document.removeEventListener('keydown', this.handleKeydown)
+    document.removeEventListener('keydown', this.handleKeyDown)
   }
 
   // We add our class if the mouse is beeing used.
@@ -28,7 +28,7 @@ export class DocumentUnfocusDetector extends React.Component {
 
   // On keydown, we consider that the user could be using his keyboard to tab
   // through elements, so we remove our class.
-  handleKeydown() {
+  handleKeyDown() {
     document.documentElement.classList.remove(this.props.className)
   }
 

--- a/assets/javascripts/kitten/components/detectors/document-unfocus-detector.js
+++ b/assets/javascripts/kitten/components/detectors/document-unfocus-detector.js
@@ -1,0 +1,42 @@
+import React from 'react'
+
+// Does not render HTML but listens for mouse and keyboard activity to add
+// a `is-unfocused` class to the `<html>` element when the user is using a
+// mouse.
+export class DocumentUnfocusDetector extends React.Component {
+  constructor(props) {
+    super(props)
+
+    this.handleKeydown = this.handleKeydown.bind(this)
+    this.handleMouseDown = this.handleMouseDown.bind(this)
+  }
+
+  componentDidMount() {
+    document.addEventListener('mousedown', this.handleMouseDown)
+    document.addEventListener('keydown', this.handleKeydown)
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('mousedown', this.handleMouseDown)
+    document.removeEventListener('keydown', this.handleKeydown)
+  }
+
+  // We add our class if the mouse is beeing used.
+  handleMouseDown() {
+    document.documentElement.classList.add(this.props.className)
+  }
+
+  // On keydown, we consider that the user could be using his keyboard to tab
+  // through elements, so we remove our class.
+  handleKeydown() {
+    document.documentElement.classList.remove(this.props.className)
+  }
+
+  render() {
+    return null
+  }
+}
+
+DocumentUnfocusDetector.defaultProps = {
+  className: 'k-u-unfocused',
+}

--- a/spec/dummy/client/entries/app-kitten.js
+++ b/spec/dummy/client/entries/app-kitten.js
@@ -202,7 +202,7 @@ ReactOnRails.register({
   // Cards
   ProjectCard,
 
-  // Detectors,
+  // Detectors
   DocumentUnfocusDetector,
 
   // Dev

--- a/spec/dummy/client/entries/app-kitten.js
+++ b/spec/dummy/client/entries/app-kitten.js
@@ -18,6 +18,9 @@ import { TagButton } from 'kitten/components/buttons/tag-button'
 // Cards
 import { ProjectCard } from 'kitten/components/cards/project-card'
 
+// Detectors
+import { DocumentUnfocusDetector } from 'kitten/components/detectors/document-unfocus-detector'
+
 // Dev
 import { DevGrid } from 'kitten/components/dev/dev-grid'
 
@@ -198,6 +201,9 @@ ReactOnRails.register({
 
   // Cards
   ProjectCard,
+
+  // Detectors,
+  DocumentUnfocusDetector,
 
   // Dev
   Checkbox,


### PR DESCRIPTION
Ajoute une classe `k-u-unfocused` quand l'utilisateur utilise une souris. Ça permettra de styler les éléments "focus" clavier uniquement sans prendre en compte les clics.

Par exemple `html:not(.k-u-unfocused) .foo:focus`.

Extrait de #252

- [ ] Changelog
- [ ] Tests