### PR TITLE
Fix `align-items: center` ProjectCreatorCard

### DIFF
--- a/assets/stylesheets/kitten/components/cards/_project-creator-card.scss
+++ b/assets/stylesheets/kitten/components/cards/_project-creator-card.scss
@@ -44,6 +44,7 @@
   .k-ProjectCreatorCard__grid--flex {
     display: flex;
     justify-content: space-between;
+    align-items: center;
   }
 
   .k-ProjectCreatorCard__content {


### PR DESCRIPTION
Fix: Le texte dans la partie `link` était pas centré verticalement. 