### PR TITLE
Fix react on rails error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Fix error with `Object.assign` in `RichTextInput` component to prevent
+  error in react on rails *(`Object function […] has no method 'assign'`)*.
+
 ## [12.0.0] - 2017-05-30
 
 Features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [unreleased]
 
 - Fix: Fix error with `Object.assign` in `RichTextInput` component to prevent
-  error in react on rails *(`Object function […] has no method 'assign'`)*.
+  error in React on Rails *(`Object function […] has no method 'assign'`)*.
 
 ## [12.0.0] - 2017-05-30
 

--- a/assets/javascripts/kitten/components/form/rich-text-input.js
+++ b/assets/javascripts/kitten/components/form/rich-text-input.js
@@ -22,14 +22,11 @@ export class RichTextInput extends React.Component {
   }
 
   config() {
-    const config = Object.assign(
-      {},
-      this.props.config,
-      {
-        defaultLanguage: this.props.locale,
-        toolbar: this.props.toolbar,
-      }
-    )
+    const config = {
+      ...this.props.config,
+      defaultLanguage: this.props.locale,
+      toolbar: this.props.toolbar,
+    }
 
     return config
   }


### PR DESCRIPTION
While merging object with `Object.assign`, react on rails raise an error because `Object` has no method `assign`.
Merge object with spread properties (es6 way) to prevent this error.
![image](https://cloud.githubusercontent.com/assets/523306/26623456/0d7f371a-45ee-11e7-9573-a5a8f0d76144.png)
