### PR TITLE
Add language attribute to html tag

### DIFF
--- a/app/views/layouts/kitten/application.html.erb
+++ b/app/views/layouts/kitten/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="k-VerticalGrid">
+<html lang="en" class="k-VerticalGrid">
 <head>
 <meta charset="utf-8">
 <meta http-equiv="x-ua-compatible" content="ie=edge">


### PR DESCRIPTION
Peut peut-être éviter que Chrome nous propose de traduire la page en latin.