### PR TITLE
Radio button set with state

### DIFF
--- a/assets/javascripts/kitten/components/form/radio-button-set-with-state.js
+++ b/assets/javascripts/kitten/components/form/radio-button-set-with-state.js
@@ -1,0 +1,52 @@
+import React, { Component } from 'react'
+import classNames from 'classnames'
+import { RadioButtonSet } from 'kitten/components/form/radio-button-set'
+
+export class RadioButtonSetWithState extends Component {
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      value: this.props.initialValue
+    }
+
+    this.itemProps = this.itemProps.bind(this)
+  }
+
+  itemProps(item) {
+    return {
+      ...item,
+      checked: this.state.value === item.value,
+      onChange: () => this.setState({ value: item.value }),
+    }
+  }
+
+  render() {
+    const { initialValue, items, others... } = this.props
+
+    return (
+      <RadioButtonSet
+        items={ items.map(itemProps) }
+        { ...others }
+      />
+    )
+  }
+}
+
+RadioButtonSetWithState.defaultProps = {
+  initialValue: 'yes',
+  items: [
+    {
+      text: 'Yes',
+      value: 'yes',
+      children: null,
+      id: 'radio-yes', // Replace by a real value
+    },
+    {
+      text: 'No',
+      value: 'no',
+      children: null,
+      id: 'radio-no', // Replace by a real value
+    },
+  ],
+}

--- a/assets/javascripts/kitten/components/form/radio-button-set.js
+++ b/assets/javascripts/kitten/components/form/radio-button-set.js
@@ -43,8 +43,8 @@ RadioButtonSet.defaultProps = {
   name: 'radioButtonSet',
   error: false,
   items: [{
-    text: 'filter 1',
-    children: 'lorem ipsum dolor',
+    text: 'Filter 1',
+    children: '',
     defaultChecked: true,
     id: 'myRadioButton' // Replace by a real value
   }],


### PR DESCRIPTION
Suite à une conversation avec @LanF3usT , il nous a semblé utile de créer un groupe de boutons radio qui sache gérer l'état de ses boutons radio enfants.

Dans cette PR voici un exemple de comment on pourrait s'en servir.

Une autre façon serait d'intégrer cette gestion d'état dans `RadioButtonSet` directement (sans avoir `*WithState`, en laissant toujours la possibilité de remplacer le `checked` des items.