### PR TITLE
Release Kitten with annotated tags

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -30,8 +30,8 @@ task :sassdoc do
 end
 
 desc "Generate documentation, commit, create tag v#{Kitten::VERSION}, " \
-     'build and push (make sure you update version.rb and CHANGELOG.md ' \
-     'beforehand)'
+     'build and push (make sure you update version.rb, package.json ' \
+     'and CHANGELOG.md beforehand)'
 task kitten_release: [:sassdoc, :build] do
   sh 'bundle install'
   sh 'yarn install'
@@ -40,7 +40,7 @@ task kitten_release: [:sassdoc, :build] do
   sh 'git add lib/kitten/version.rb *CHANGELOG.md public/sassdoc/index.html ' \
      'package.json spec/dummy/client/yarn.lock Gemfile.lock'
   sh "git commit -m v#{Kitten::VERSION}"
-  sh "git tag v#{Kitten::VERSION}"
+  sh "git tag -a v#{Kitten::VERSION} 'Version #{Kitten::VERSION}'"
   sh 'git push origin master'
   sh 'git push origin --tags'
 

--- a/Rakefile
+++ b/Rakefile
@@ -30,8 +30,8 @@ task :sassdoc do
 end
 
 desc "Generate documentation, commit, create tag v#{Kitten::VERSION}, " \
-     'build and push (make sure you update version.rb, package.json ' \
-     'and CHANGELOG.md beforehand)'
+     'build and push (make sure you update version.rb, package.json, ' \
+     'CHANGELOG.md and KARL_CHANGELOG.md beforehand)'
 task kitten_release: [:sassdoc, :build] do
   sh 'bundle install'
   sh 'yarn install'


### PR DESCRIPTION
Annote les tags de versions.

> A lightweight tag is very much like a branch that doesn’t change – it’s just a pointer to a specific commit.
>
> Annotated tags, however, are stored as full objects in the Git database. They’re checksummed; contain the tagger name, email, and date; have a tagging message; and can be signed and verified with GNU Privacy Guard (GPG). It’s generally recommended that you create annotated tags so you can have all this information; but if you want a temporary tag or for some reason don’t want to keep the other information, lightweight tags are available too.
> — https://git-scm.com/book/en/v2/Git-Basics-Tagging
