### PR TITLE
Fix `SimpleUploader` responsive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Fix `SimpleUploader` responsive.
 - Feature: Add new `TooltipNew` component.
 - Feature: Add new `InfoWithTooltip` component.
 - Feature: Add new `ButtonInfoIcon` component.

--- a/assets/stylesheets/kitten/components/uploaders/_simple-uploader.scss
+++ b/assets/stylesheets/kitten/components/uploaders/_simple-uploader.scss
@@ -20,12 +20,13 @@
   }
 
   .k-SimpleUploader__button {
+    flex-shrink: 0;
     cursor: pointer;
   }
 
   .k-SimpleUploader__text {
     overflow: hidden;
-    max-width: k-px-to-rem(200px);
+    max-width: k-px-to-rem(140px);
     margin-left: k-px-to-rem(10px);
 
     @include k-typographyFont('source-sans-light');


### PR DESCRIPTION
PR qui fixe le rendu responsive du composant `SimpleUploader`.

## Avant en `xxs`

<img width="315" alt="capture d ecran 2017-07-04 a 11 28 53" src="https://user-images.githubusercontent.com/736319/27826299-c5d11dea-60b2-11e7-89b6-77ae2eea82a0.png">

## Après en `xxs`

<img width="312" alt="capture d ecran 2017-07-04 a 12 16 48" src="https://user-images.githubusercontent.com/736319/27826306-ccbcd9a0-60b2-11e7-8c40-e7f3c8003826.png">

## TODO

- [x] Changelog
