### PR TITLE
Add `withoutPointerEvents` prop to `Label` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Feature: Add `k-Label--withoutPointerEvents` prop to `Label` component.
 - Feature: Add `Loader` and `LoaderWithParagraph` components.
 - Feature: Add `icon` and `iconWithMinWidth` props to `Button` component.
 - Feature: Add social button icon components (`FacebookButtonIcon`, …).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
-- Feature: Add `k-Label--withoutPointerEvents` prop to `Label` component.
+- Feature: Add `withoutPointerEvents` prop to `Label` component.
 - Feature: Add `Loader` and `LoaderWithParagraph` components.
 - Feature: Add `icon` and `iconWithMinWidth` props to `Button` component.
 - Feature: Add social button icon components (`FacebookButtonIcon`, …).

--- a/assets/javascripts/kitten/components/form/label.js
+++ b/assets/javascripts/kitten/components/form/label.js
@@ -18,12 +18,25 @@ export class Label extends React.Component {
   }
 
   render() {
-    const { tag, className, children, focusId, size, ...other } = this.props
+    const {
+      tag,
+      className,
+      children,
+      focusId,
+      size,
+      withoutPointerEvents,
+      ...other,
+    } = this.props
+
     const Tag = tag
+
     const labelClassName = classNames(
       "k-Label",
       className,
-      { [`k-Label--${size}`]: size },
+      {
+        [`k-Label--${size}`]: size,
+        'k-Label--withoutPointerEvents': withoutPointerEvents,
+      },
     )
 
     return (
@@ -43,4 +56,5 @@ Label.defaultProps = {
   children: 'Label',
   focusId: null,
   size: null, // `tiny`
+  withoutPointerEvents: false,
 }

--- a/assets/javascripts/kitten/components/form/label.test.js
+++ b/assets/javascripts/kitten/components/form/label.test.js
@@ -53,4 +53,12 @@ describe('<Label />', () => {
       expect(input).to.be.equal(document.activeElement)
     })
   })
+
+  describe('with withoutPointerEvents props', () => {
+    const component = shallow(<Label withoutPointerEvents />)
+
+    it('has a good class', () => {
+      expect(component).to.have.className('k-Label--withoutPointerEvents')
+    })
+  })
 })

--- a/assets/javascripts/kitten/components/form/label.test.js
+++ b/assets/javascripts/kitten/components/form/label.test.js
@@ -54,7 +54,7 @@ describe('<Label />', () => {
     })
   })
 
-  describe('with withoutPointerEvents props', () => {
+  describe('with withoutPointerEvents prop', () => {
     const component = shallow(<Label withoutPointerEvents />)
 
     it('has a good class', () => {

--- a/assets/stylesheets/kitten/components/form/_label.scss
+++ b/assets/stylesheets/kitten/components/form/_label.scss
@@ -37,4 +37,8 @@
   .k-Label--tiny {
     @include k-typographyFontSize($font-step-tiny, $line-height-tiny);
   }
+
+  .k-Label--withoutPointerEvents {
+    pointer-events: none;
+  }
 }


### PR DESCRIPTION
PR qui permet de retirer le `hover`, `focus`, etc. sur un `Label`.

TODO:

- [x] Tests
- [x] Changelog
