### PR TITLE
Fix/similar project card buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Add `type` attribute to navigation buttons in `SimilarProjectCard`
+  component.
+
 ## [13.6.0] - 2017-08-01
 
 Features:

--- a/assets/javascripts/kitten/components/cards/project-similar-card.js
+++ b/assets/javascripts/kitten/components/cards/project-similar-card.js
@@ -40,6 +40,7 @@ class SimilarProjectCardComponent extends Component {
     return(
       <ButtonIcon
         size="tiny"
+        type="button"
         verticalArrow
         disabled={ this.props.leftArrowDisabled }
         onClick={ this.props.onLeftArrowClick }>
@@ -54,6 +55,7 @@ class SimilarProjectCardComponent extends Component {
     return (
       <ButtonIcon
         size="tiny"
+        type="button"
         verticalArrow
         disabled={ this.props.rightArrowDisabled }
         onClick={ this.props.onRightArrowClick }>

--- a/assets/javascripts/kitten/components/cards/project-similar-card.test.js
+++ b/assets/javascripts/kitten/components/cards/project-similar-card.test.js
@@ -24,12 +24,24 @@ describe('<SimilarProjectCard />', () => {
       expect(similarProjectCard).to.have.className('k-ProjectSimilarCard')
     })
 
-    it('has a disabled left arrow', () => {
-      expect(leftArrowButton).to.have.attr('disabled')
+    describe('left arrow', () => {
+      it('is disabled', () => {
+        expect(leftArrowButton).to.have.attr('disabled')
+      })
+
+      it('has a button type', () => {
+        expect(leftArrowButton).to.have.attr('type', 'button')
+      })
     })
 
-    it('has a disabled right arrow', () => {
-      expect(rightArrowButton).to.have.attr('disabled')
+    describe('right arrow', () => {
+      it('is disabled', () => {
+        expect(rightArrowButton).to.have.attr('disabled')
+      })
+
+      it('has a button type', () => {
+        expect(rightArrowButton).to.have.attr('type', 'button')
+      })
     })
   })
 


### PR DESCRIPTION
Afin d'empêcher la soumission du formulaire lorsque le composant `SimilarProjectCard` est intégré au sein d'un formulaire, il faut ajouter `type="button"` sur les deux éléments de navigation de ce composant.
