### PR TITLE
Pass onRefreshClick prop to SimilarProjectCard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Pass `onRefreshClick` prop correctly to `SimilarProjectCard` component in
+  `SimilarProjectsCard` component.
+
 ## [13.6.1] - 2017-08-03
 
 Fix:

--- a/assets/javascripts/kitten/components/cards/similar-projects-card.js
+++ b/assets/javascripts/kitten/components/cards/similar-projects-card.js
@@ -63,7 +63,6 @@ export class SimilarProjectsCard extends Component {
   render() {
     const {
       projects,
-      onRefreshClick,
       onLeftArrowClick,
       onRightArrowClick,
       ...others,


### PR DESCRIPTION
La prop `onRefreshClick` n'était pas passée correctement au composant `SimilarProjectCard`.