### PR TITLE
Fix `LinkBox` paragraph container size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix `LinkBox` paragraph container size.
+
 ## [14.2.0] - 2017-10-04
 
 Feature:

--- a/assets/stylesheets/kitten/components/box/_link-box.scss
+++ b/assets/stylesheets/kitten/components/box/_link-box.scss
@@ -113,6 +113,7 @@
   .k-LinkBox__paragraph {
     display: flex;
     flex-direction: column;
+    flex-grow: 1;
     justify-content: center;
     padding: k-px-to-rem(10px)
              k-px-to-rem(10px)


### PR DESCRIPTION
Linked to https://github.com/KissKissBankBank/kisskissbankbank/issues/1704

Screenshot:
![image](https://user-images.githubusercontent.com/523306/31491042-3e437458-af46-11e7-896a-a7cde1b3c610.png)

TODO:

- [x] Changelog
