### PR TITLE
Fix `TextInput` length for Firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Fix `TextInput` length for Firefox.
 - Fix: Update alignment on `InfoLines`.
 
 ## [14.2.1] - 2017-10-12

--- a/assets/stylesheets/kitten/components/form/_text-input.scss
+++ b/assets/stylesheets/kitten/components/form/_text-input.scss
@@ -52,7 +52,7 @@
   // Others
   $horizontal-padding: 15px;
   $vertical-padding: 10px;
-  $digit-length: 11px;
+  $digit-length: 15px;
 
   .k-TextInput {
     @include k-typographyFont($font);


### PR DESCRIPTION
Closes #870.
Refer to : https://github.com/KissKissBankBank/kisskissbankbank/issues/1768

Screenshot:
![image](https://user-images.githubusercontent.com/523306/31885378-9c362224-b7f0-11e7-9edc-d51710940db3.png)

TODO:

- [x] Changelog
