### PR TITLE
Remove ruby's verification in installation script

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -1,26 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-# Install ruby with brew and rbenv
-if hash brew 2> /dev/null && hash rbenv 2> /dev/null; then
-
-  # Install or upgrade rbenv
-  if brew list -1 | grep -q '^ruby-build'; then
-    if brew outdated -1 | grep -q '^ruby-build'; then
-      brew upgrade ruby-build
-    fi
-  else
-    brew install ruby-build
-  fi
-
-  # Install ruby
-  rbenv install --skip-existing
-
-# Install ruby with rvm
-elif hash rvm 2> /dev/null; then
-  rvm use `cat .ruby-version`
-fi
-
 # Force node version
 if hash nvm 2> /dev/null; then
   nvm use 6.9.5


### PR DESCRIPTION
Cette PR fixe un problème de version de Ruby quand on lance `bundle exec rake kitten_release`.