### PR TITLE
Handle `onChange` prop in reset event in `ImageCropper` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Feature: Handle `onChange` prop in reset event in `ImageCropper` component.
+
 ## [14.4.0] - 2017-11-08
 
 Features:

--- a/assets/javascripts/kitten/components/images/image-cropper.js
+++ b/assets/javascripts/kitten/components/images/image-cropper.js
@@ -77,6 +77,11 @@ export class ImageCropper extends React.Component {
 
   handleUploaderReset() {
     this.setState(this.initialState())
+
+    this.props.onChange({
+      value: null,
+      name: null,
+    })
   }
 
   handleSliderChange(value) {


### PR DESCRIPTION
PR qui lance la prop `onChange` dans le traitement du reset. Ca permet ensuite d'avoir l'information qu'il faut supprimer l'image.
