### PR TITLE
Update react-places-autocomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   `k-ProjectCard__status--validBackground`.
 - Feature: Update `ProjectCard` component with styleguide V2.
 - Feature: Add `k-buttonColors` helper to manage button colors by modifier.
+- Feature: Update `react-places-autocomplete` module to add `autocomplete="off"`
+  on `LocationInput` component.
 
 ## [16.1.0] - 2017-11-20
 

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "react-markdown": "^2.4.4",
     "react-masonry-component": "^5.0.3",
     "react-modal": "^2.1.0",
-    "react-places-autocomplete": "^5.0.0",
+    "react-places-autocomplete": "^5.4.3",
     "react-prop-types": "^0.4.0",
     "react-select": "^1.0.0-rc.1",
     "react-tooltip": "^3.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4263,13 +4263,12 @@ react-modal@^2.1.0:
     prop-types "^15.5.10"
     react-dom-factories "^1.0.0"
 
-react-places-autocomplete@^5.0.0:
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/react-places-autocomplete/-/react-places-autocomplete-5.3.1.tgz#f37e737eec05c53d8a9ba38b0106bac522f3ee99"
+react-places-autocomplete@^5.4.3:
+  version "5.4.3"
+  resolved "https://registry.yarnpkg.com/react-places-autocomplete/-/react-places-autocomplete-5.4.3.tgz#321166247a9279b93ff21ee59112836058dda0ba"
   dependencies:
     lodash.debounce "^4.0.8"
     prop-types "^15.5.8"
-    react "^15.3.0"
 
 react-prop-types@^0.4.0:
   version "0.4.0"
@@ -4291,7 +4290,7 @@ react-tooltip@^3.2.2:
     classnames "^2.2.0"
     prop-types "^15.5.8"
 
-react@^15.3.0, react@^15.3.1:
+react@^15.3.1:
   version "15.5.4"
   resolved "https://registry.yarnpkg.com/react/-/react-15.5.4.tgz#fa83eb01506ab237cdc1c8c3b1cea8de012bf047"
   dependencies:


### PR DESCRIPTION
Related to https://github.com/KissKissBankBank/kisskissbankbank/issues/2034.

Cette PR met à jour le module `react-places-autocomplete` afin de pouvoir ajouter l'attribut `autocomplete="off"` sur l'input de `LocationInput`.