### PR TITLE
Fix null value on `SelectWithState`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Fix `null` value in `SelectWithState` component.
+
 ## [16.3.0] - 2017-11-27
 
 Features:

--- a/assets/javascripts/kitten/components/form/select-with-state.js
+++ b/assets/javascripts/kitten/components/form/select-with-state.js
@@ -26,7 +26,7 @@ export class SelectWithState extends Component {
   }
 
   handleChange(val) {
-    const value = val.value
+    const value = val && val.value
       ? val
       : { value: null, label: null }
 

--- a/assets/javascripts/kitten/components/form/select-with-state.test.js
+++ b/assets/javascripts/kitten/components/form/select-with-state.test.js
@@ -161,7 +161,7 @@ describe('<SelectWithState />', () => {
         />
       )
 
-      select.instance().handleChange([])
+      select.instance().handleChange(null)
     })
 
     it('calls onChange prop with empty value', () => {


### PR DESCRIPTION
Suite à la nouvelle version, le composant retourne `null` quand on supprime la sélection. Pour l'instant je retourne le même genre d'objet à l'app. À voir si null peut suffire !

TODO:

- [x] Tests
- [x] Changelog
