### PR TITLE
Fix `:focus` `border-color` on `TextInputWithUnit`, `Select` et `LocationInput` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Fix `:focus` `border-color` on `TextInputWithUnit` component.
 - Feature: Update `Tooltip`, `TooltipNew` and `StaticTooltip` components with styleguide V2.
 - Feature: Update `LinkBox` and `InformationBox` components with styleguide V2
   new design.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
-- Fix: Fix `:focus` `border-color` on `TextInputWithUnit` component.
+- Fix: Fix `:focus` `border-color` on `TextInputWithUnit`, `Select` and
+  `LocationInput` component.
 - Feature: Update `Tooltip`, `TooltipNew` and `StaticTooltip` components with styleguide V2.
 - Feature: Update `LinkBox` and `InformationBox` components with styleguide V2
   new design.

--- a/assets/javascripts/kitten/components/form/text-input-with-unit.js
+++ b/assets/javascripts/kitten/components/form/text-input-with-unit.js
@@ -18,7 +18,7 @@ export class TextInputWithUnit extends Component {
       tiny,
       disabled,
       digits,
-      ...others
+      ...others,
     } = this.props
 
     const textInputClassName = classNames(

--- a/assets/javascripts/kitten/components/form/text-input-with-unit.js
+++ b/assets/javascripts/kitten/components/form/text-input-with-unit.js
@@ -8,16 +8,18 @@ export class TextInputWithUnit extends Component {
   }
 
   render() {
-    const { className,
-            valid,
-            error,
-            type,
-            unit,
-            unitWord,
-            tiny,
-            disabled,
-            digits,
-            ...others } = this.props
+    const {
+      className,
+      valid,
+      error,
+      type,
+      unit,
+      unitWord,
+      tiny,
+      disabled,
+      digits,
+      ...others
+    } = this.props
 
     const textInputClassName = classNames(
       'k-TextInputWithUnit__input',

--- a/assets/stylesheets/kitten/components/form/_location-input.scss
+++ b/assets/stylesheets/kitten/components/form/_location-input.scss
@@ -38,7 +38,7 @@
   $background-color-active: map-get($k-colors, 'background-3');
 
   // Focus
-  $border-color-focus: map-get($k-colors, 'primary-1');
+  $border-color-focus: map-get($k-colors, 'line-2');
 
   // Disabled
   $color-disabled: map-get($k-colors, 'background-1');

--- a/assets/stylesheets/kitten/components/form/_select.scss
+++ b/assets/stylesheets/kitten/components/form/_select.scss
@@ -152,7 +152,7 @@
   }
 
   .Select.is-focused:not(.is-open) .Select-arrow-zone {
-    border-left-color: map-get($k-colors, 'primary-1');
+    border-left-color: map-get($k-colors, 'line-2');
   }
 
   .Select.is-open .Select-arrow-zone {
@@ -185,7 +185,7 @@
   // control options
 
   $select-input-border-color: map-get($k-colors, 'line-1');
-  $select-input-border-focus: map-get($k-colors, 'primary-1');
+  $select-input-border-focus: map-get($k-colors, 'line-2');
   $select-input-border-width: k-map-fetch($options,
                                           'select-input-border-width');
   $select-input-height: k-default(map-get($options,

--- a/assets/stylesheets/kitten/components/form/_text-input-with-unit.scss
+++ b/assets/stylesheets/kitten/components/form/_text-input-with-unit.scss
@@ -32,6 +32,7 @@
 
   // Border
   $unit-color: map-get($k-colors, 'primary-1');
+  $unit-color-focus: map-get($k-colors, 'line-2');
   $unit-color-is-valid: map-get($k-colors, 'tertiary-2');
   $unit-color-is-error: map-get($k-colors, 'error-3');
   $unit-color-is-inactive: map-get($k-colors, 'font-2');
@@ -62,7 +63,7 @@
     @include k-formRemoveNumberSpinner;
 
     &:focus ~ .k-TextInputWithUnit__unit {
-      border-color: $unit-color;
+      border-color: $unit-color-focus;
       color: $color;
     }
 


### PR DESCRIPTION
A vérifier si l'état `: focus` du `Select` se retire quand `is-open` est a `true`.
Je sais pas si c'est son état normal.

TODO:
- [x] Changelog
