### PR TITLE
Move `href` prop on link items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Add `href` prop on link items in `HorizontalNav` component.
+
 ## [17.0.0] - 2018-01-02
 
 Breaking changes:

--- a/assets/javascripts/kitten/components/navigation/horizontal-nav.js
+++ b/assets/javascripts/kitten/components/navigation/horizontal-nav.js
@@ -15,6 +15,7 @@ export class HorizontalNav extends Component {
       selected,
       text,
       key,
+      href,
       ...others,
     } = item
 
@@ -33,6 +34,7 @@ export class HorizontalNav extends Component {
         { ...others }
       >
         <a
+          href={ href }
           className={ itemClassName }
           style={ {
             height: this.props.height,

--- a/assets/javascripts/kitten/components/navigation/horizontal-nav.test.js
+++ b/assets/javascripts/kitten/components/navigation/horizontal-nav.test.js
@@ -7,13 +7,14 @@ describe('<HorizontalNav />', () => {
   const component = shallow(
     <HorizontalNav
       items={ [
-        { text: 'Nav link 1' },
-        { text: 'Nav link 2' },
-        { text: 'Nav link 3' },
-        { text: 'Nav link 4' },
+        { text: 'Nav link 1', href: '#foobar' },
+        { text: 'Nav link 2', href: '#foobar' },
+        { text: 'Nav link 3', href: '#foobar' },
+        { text: 'Nav link 4', href: '#foobar' },
       ] }
     />
   )
+  const link = component.find('.k-HorizontalNav__item').first()
 
   it('renders a <div class="k-HorizontalNav" />', () => {
     expect(component).to.have.className('k-HorizontalNav')
@@ -25,6 +26,10 @@ describe('<HorizontalNav />', () => {
 
   it('renders items', () => {
     expect(component.find('.k-HorizontalNav__item')).to.have.length(4)
+  })
+
+  it('has an item with clickable link', () => {
+    expect(link).to.have.attr('href', '#foobar')
   })
 
   describe('center props', () => {


### PR DESCRIPTION
Corrige une erreur sur `HorizontalNav`. Le `href` était mis sur le `<li>` à la place d'être sur le `<a>`.

TODO:

- [x] Tests
- [x] Changelog
