### PR TITLE
Remove border-top in HorizontalNav

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
-- Feature: Remove `borderTop` in `HorizontalNav` component.
 - Feature: Update all `TextInput` to manage input radius.
 - Feature: Add `rounded` prop in `ButtonIcon` component.
 - Feature: Update `QuestionMarkIcon` component with styleguide V2.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Feature: Remove `borderTop` in `HorizontalNav` component.
 - Feature: Update all `TextInput` to manage input radius.
 - Feature: Add `rounded` prop in `ButtonIcon` component.
 - Feature: Update `QuestionMarkIcon` component with styleguide V2.

--- a/KARL_CHANGELOG.md
+++ b/KARL_CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Feature: Remove `borderTop` in `KarlBrowsingHorizontalNav` example.
 - Feature: Rename `KarlButtonIconMicro` to `KarlButtonIconNano` examples.
 
 ## [17.1.0] - 2018-01-03

--- a/assets/javascripts/kitten/karl/navigation/horizontal-nav.js
+++ b/assets/javascripts/kitten/karl/navigation/horizontal-nav.js
@@ -18,7 +18,6 @@ export const KarlHorizontalNav = props => {
 export const KarlBrowsingHorizontalNav = props => {
   const rowStyles = {
     backgroundColor: '#f6f6f6',
-    borderTop: '1px solid #eee',
   }
 
   const horizontalNavItems = [

--- a/assets/stylesheets/kitten/components/grid/_row.scss
+++ b/assets/stylesheets/kitten/components/grid/_row.scss
@@ -38,7 +38,7 @@
     $dark-text-color: k-color-definition(
       k-default(
         map-get($colors, 'dark-text'),
-        #fff
+        map-get($colors, 'background-1')
       )
     );
     $light-bottom-border-color: k-color-definition(


### PR DESCRIPTION
Comme le `Header` et l'`HorizontalNav` sont collés sur la maquette, je voyais un `borderTop` mais en fait non c'était `borderBottom` du `Header`.

TODO:

- [x] Changelog

  