### PR TITLE
Fix `captionProps` prop warning to `ImageWithCaption`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [unreleased]
 
 - Feature: Change `font-size: 1rem` on `k-Button--big`.
+- Fix: Fix `captionProps` prop warning to `ImageWithCaption`.
 
 ## [18.1.0] - 2018-01-09
 

--- a/KARL_CHANGELOG.md
+++ b/KARL_CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Fix warnings to `ImageWithCaption` examples.
+
 ## [18.1.0] - 2018-01-09
 
 No changes.

--- a/assets/javascripts/kitten/components/images/image-with-caption.js
+++ b/assets/javascripts/kitten/components/images/image-with-caption.js
@@ -27,6 +27,7 @@ export class ImageWithCaption extends Component {
       imageAlt,
       imageWidth,
       imageHeight,
+      captionProps,
       ...others,
     } = this.props
 

--- a/assets/javascripts/kitten/karl/images/image-with-caption.js
+++ b/assets/javascripts/kitten/karl/images/image-with-caption.js
@@ -7,7 +7,7 @@ export const KarlImageWithCaption = () => {
     <ImageWithCaption>
       <Text
         size="default"
-        color="font-1"
+        color="font1"
       >
         <span className="k-u-weight-bold">
           Lorem ipsum dolor{' '}


### PR DESCRIPTION
<img width="857" alt="capture d ecran 2018-01-15 a 12 07 22" src="https://user-images.githubusercontent.com/736319/34939607-b0056ea2-f9ec-11e7-944f-a6f0ae0673c9.png">

TODO:

- [x] Changelog
