### PR TITLE
[Footer] Enable button type attribute override on TextInputWithButton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Can overwrite button type in `TextInputWithButton`.
+
 ## [19.4.0] - 2018-02-02
 
 Features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
-- Fix: Can overwrite button type in `TextInputWithButton`.
+- Fix: Enable button type attribute override on `TextInputWithButton`.
 
 ## [19.4.0] - 2018-02-02
 

--- a/assets/javascripts/kitten/components/form/text-input-with-button.js
+++ b/assets/javascripts/kitten/components/form/text-input-with-button.js
@@ -45,10 +45,10 @@ export class TextInputWithButton extends Component {
           className={ textInputWithButtonInputClassName }
         />
         <button
+          type="button"
           { ...buttonProps }
           disabled={ disabled }
           className={ textInputWithButtonButtonClassName }
-          type="button"
         >
           { value }
         </button>

--- a/assets/javascripts/kitten/components/form/text-input-with-button.test.js
+++ b/assets/javascripts/kitten/components/form/text-input-with-button.test.js
@@ -98,4 +98,19 @@ describe('<TextInputWithButton />', () => {
       expect(button.text()).toBe('custom-button')
     })
   })
+
+  describe('with buttonProps prop', () => {
+    const component = mount(
+      <TextInputWithButton
+        buttonProps={{
+          type: 'submit',
+        }}
+      />
+    )
+    const button = component.find('.k-TextInputWithButton__button')
+
+    it('renders a button with submit type', () => {
+      expect(button.prop('type')).toBe('submit')
+    })
+  })
 })


### PR DESCRIPTION
PR qui fixe la possibilité d'écraser le type du bouton.