### PR TITLE
Force version of `method_source` for example app

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,3 +13,7 @@ gem 'rubocop', '~> 0.49.0', require: false
 gem 'foreman'
 
 gem 'sass'
+
+# Forced version of method_source to match KissKissBankBank's to avoid zeus
+# errors.
+gem 'method_source', '0.8.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,13 +84,14 @@ GEM
     highline (1.7.10)
     i18n (0.9.1)
       concurrent-ruby (~> 1.0)
+    libv8 (3.16.14.19)
     libv8 (3.16.14.19-x86_64-darwin-16)
     loofah (2.1.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.0)
       mini_mime (>= 0.1.1)
-    method_source (0.9.0)
+    method_source (0.8.2)
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.11.0)
@@ -103,9 +104,9 @@ GEM
     parser (2.4.0.2)
       ast (~> 2.3)
     powerpack (0.1.1)
-    pry (0.11.3)
+    pry (0.11.0)
       coderay (~> 1.1.0)
-      method_source (~> 0.9.0)
+      method_source (~> 0.8.1)
     public_suffix (3.0.1)
     rack (1.6.8)
     rack-test (0.6.3)
@@ -205,6 +206,7 @@ DEPENDENCIES
   foreman
   gemfury
   kitten!
+  method_source (= 0.8.2)
   pry
   rake (~> 10.0)
   rspec-rails


### PR DESCRIPTION
Petit fix qui évite de devoir désinstaller `method_source` sur KissKissBankBank à chaque fois qu'on veut utiliser `zeus`.