### PR TITLE
[Browsing] Fix title truncate to CrowdfundingCard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
-- Fix: Fix truncate title styles at `CrowdfundingCard`.
+- Fix: Fix truncated title styles on `CrowdfundingCard`.
 
 ## [20.0.1] - 2018-03-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Fix truncate title styles at `CrowdfundingCard`.
+
 ## [20.0.1] - 2018-03-05
 
 Fixes:

--- a/assets/javascripts/kitten/components/cards/__snapshots__/crowdfunding-card.test.js.snap
+++ b/assets/javascripts/kitten/components/cards/__snapshots__/crowdfunding-card.test.js.snap
@@ -131,7 +131,13 @@ exports[`<CrowdfundingCard /> by default matches with snapshot 1`] = `
           className="k-Title k-Card__title k-Title--senary k-Title--withoutMargin"
           data-radium={true}
         >
-          <span>
+          <span
+            style={
+              Object {
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
             <span />
             <span />
             <span
@@ -539,7 +545,13 @@ exports[`<CrowdfundingCard /> with some props matches with snapshot 1`] = `
           className="k-Title k-Card__title k-Title--senary k-Title--withoutMargin"
           data-radium={true}
         >
-          <span>
+          <span
+            style={
+              Object {
+                "whiteSpace": "nowrap",
+              }
+            }
+          >
             <span />
             <span>
               Custom title

--- a/assets/javascripts/kitten/components/cards/crowdfunding-card.js
+++ b/assets/javascripts/kitten/components/cards/crowdfunding-card.js
@@ -167,7 +167,7 @@ class CrowdfundingCardComponent extends Component {
             className={ className }
           >
             { this.props.titleTruncate &&
-              <Truncate lines={ 2 }>
+              <Truncate lines={ 2 } style={ styles.title.truncate }>
                 { this.props.cardTitle }
               </Truncate>
             }
@@ -382,6 +382,10 @@ const styles = {
   title: {
     padding: `0 ${COMPONENT_GUTTER}px`,
     lineHeight: '1',
+
+    truncate: {
+      whiteSpace: 'nowrap',
+    },
 
     loading: {
       display: 'block',


### PR DESCRIPTION
Il y avait un problème de rendu au niveau du truncate qui affichait 3 lignes à la place de 2 souhaitées. C'est dû à la font qui se charge bien après le calcul de la place dispo.