### PR TITLE
[Browsing] Add textProps to Checkbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Feature: Add `textProps` to `Checkbox`.
+
 ## [20.1.0] - 2018-03-14
 
 Fixes:

--- a/assets/javascripts/kitten/components/form/checkbox.js
+++ b/assets/javascripts/kitten/components/form/checkbox.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
+import { Text } from 'kitten/components/typography/text'
 
 export class Checkbox extends Component {
   render() {
@@ -32,7 +33,9 @@ export class Checkbox extends Component {
           htmlFor={ id }
           className="k-Checkbox__label"
         >
-          { children }
+          <Text { ...this.props.textProps }>
+            { children }
+          </Text>
         </label>
       </div>
     )
@@ -41,4 +44,5 @@ export class Checkbox extends Component {
 
 Checkbox.defaultProps = {
   children: 'Filter 1',
+  textProps: {},
 }

--- a/assets/javascripts/kitten/components/form/checkbox.test.js
+++ b/assets/javascripts/kitten/components/form/checkbox.test.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Checkbox } from 'kitten/components/form/checkbox'
+import { Text } from 'kitten/components/typography/text'
 
 describe('<Checkbox />', () => {
   describe('By default', () => {
@@ -15,6 +16,10 @@ describe('<Checkbox />', () => {
     it('renders a label.k-Checkbox__label', () => {
       expect(label.type()).toBe('label')
       expect(label.hasClass('k-Checkbox__label')).toBe(true)
+    })
+
+    it('renders a <Text />', () => {
+      expect(label.find(Text)).toHaveLength(1)
     })
   })
 
@@ -42,10 +47,23 @@ describe('<Checkbox />', () => {
         <svg />
       </Checkbox>
     )
-    const labelChildren = component.find('label').children()
+    const labelChildren = component.find(Text).children()
 
     it('passes the right props to the `label` component', () => {
       expect(labelChildren.type()).toBe('svg')
+    })
+  })
+
+  describe('textProps prop', () => {
+    const component = shallow(
+      <Checkbox textProps={ { weight: 'regular' } }>
+        Lorem ipsum…
+      </Checkbox>
+    )
+    const labelText = component.find(Text)
+
+    it('passes the right props to the `Text` component', () => {
+      expect(labelText.prop('weight')).toBe('regular')
     })
   })
 })


### PR DESCRIPTION
PR qui permet de gérer les styles du texte présent dans une `Checkbox`.

<img width="562" alt="capture d ecran 2018-03-15 a 12 24 13" src="https://user-images.githubusercontent.com/736319/37460597-fc764bb6-284b-11e8-9cfc-d3c9a8eb0ea3.png">