### PR TITLE
Remove `textProps` props from `inputProps`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Remove `textProps` props from `inputProps` CheckBox component.
+
 ## [20.3.0] - 2018-03-22
 
 Features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
-- Fix: Remove `textProps` props from `inputProps` CheckBox component.
+- Fix: Remove `textProps` props from `inputProps` Checkbox component.
 
 ## [20.3.0] - 2018-03-22
 

--- a/assets/javascripts/kitten/components/form/checkbox.js
+++ b/assets/javascripts/kitten/components/form/checkbox.js
@@ -34,7 +34,7 @@ export class Checkbox extends Component {
           htmlFor={ id }
           className="k-Checkbox__label"
         >
-          <Text { ...this.props.textProps }>
+          <Text { ...textProps }>
             { children }
           </Text>
         </label>

--- a/assets/javascripts/kitten/components/form/checkbox.js
+++ b/assets/javascripts/kitten/components/form/checkbox.js
@@ -11,6 +11,7 @@ export class Checkbox extends Component {
       children,
       inputClassName,
       error,
+      textProps,
       ...inputProps,
     } = this.props
 


### PR DESCRIPTION
Corrige le warning indiquant que l'input du composant `CheckBox` ne reconnait pas la prop `textProps`.

Screenshot:
![image](https://user-images.githubusercontent.com/523306/37828083-222ee788-2e9a-11e8-8fad-c119792b85c8.png)

TODO:

- [x] Changelog
