### PR TITLE
[Tools] Remove Storybook iFrame margin

### DIFF
--- a/.storybook/stylesheets/app-kitten.scss
+++ b/.storybook/stylesheets/app-kitten.scss
@@ -7,3 +7,8 @@
 // Components instanciation
 @import 'kitten/components';
 @import 'kitten/utilities';
+
+// Custom styles for StoryBook iFrame.
+body {
+  margin: 0;
+}


### PR DESCRIPTION
Pour que la grille colle bien l'iFrame de Storybook, il faut supprimer les marges par défaut sur le body.