### PR TITLE
Create viewport `SOrLess`

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,1 +1,2 @@
+<meta name="robots" content="noindex">
 <link rel="stylesheet" type="text/css" href="https://s3-eu-west-1.amazonaws.com/kkbb-fonts/maax/maax.css">

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Feature: Add `viewportIsSOrLess` on `mediaQueries` HOC.
 - Feature: Show `LegoGrid` only when DOM is loaded.
 - Fix: Update `ArrowIcon` size on `Pagination` component.
 - Fix: Remove `hover` state when `ButtonIcon` is `active` state on `Pagination.

--- a/assets/javascripts/kitten/hoc/__snapshots__/media-queries.test.js.snap
+++ b/assets/javascripts/kitten/hoc/__snapshots__/media-queries.test.js.snap
@@ -3,5 +3,6 @@
 exports[`mediaQueries() by default renders the wrapped component 1`] = `
 <div
   title="Test me!"
+  viewportIsSOrLess={undefined}
 />
 `;

--- a/assets/javascripts/kitten/hoc/media-queries.js
+++ b/assets/javascripts/kitten/hoc/media-queries.js
@@ -2,8 +2,8 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { createMatchMediaMax } from 'kitten/helpers/utils/media-queries'
 import {
-  SCREEN_SIZE_S,
   SCREEN_SIZE_XS,
+  SCREEN_SIZE_S,
   SCREEN_SIZE_M,
 } from 'kitten/constants/screen-config'
 

--- a/assets/javascripts/kitten/hoc/media-queries.js
+++ b/assets/javascripts/kitten/hoc/media-queries.js
@@ -14,14 +14,14 @@ export const mediaQueries = (WrappedComponent, hocProps = {}) =>
 
       this.state = {}
 
-      if (this.sMediaQueryEnabled()) {
-        this.mqSOrLess = createMatchMediaMax(SCREEN_SIZE_S)
-        this.state = { ...this.state, viewportIsSOrLess: false }
-      }
-
       if (this.mobileMediaQueryEnabled()) {
         this.mqMobile = createMatchMediaMax(SCREEN_SIZE_XS)
         this.state = { ...this.state, viewportIsMobile: false }
+      }
+
+      if (this.sMediaQueryEnabled()) {
+        this.mqSOrLess = createMatchMediaMax(SCREEN_SIZE_S)
+        this.state = { ...this.state, viewportIsSOrLess: false }
       }
 
       if (this.tabletOrLessMediaQueryEnabled()) {
@@ -30,14 +30,14 @@ export const mediaQueries = (WrappedComponent, hocProps = {}) =>
       }
     }
 
-    sMediaQueryEnabled = () =>
-      typeof hocProps.viewportIsSOrLess !== 'undefined'
-        ? hocProps.viewportIsSOrLess
-        : false
-
     mobileMediaQueryEnabled = () =>
       typeof hocProps.viewportIsMobile !== 'undefined'
         ? hocProps.viewportIsMobile
+        : false
+
+    sMediaQueryEnabled = () =>
+      typeof hocProps.viewportIsSOrLess !== 'undefined'
+        ? hocProps.viewportIsSOrLess
         : false
 
     tabletOrLessMediaQueryEnabled = () =>
@@ -46,14 +46,14 @@ export const mediaQueries = (WrappedComponent, hocProps = {}) =>
         : false
 
     componentDidMount() {
-      if (this.mqSOrLess) {
-        this.mqSOrLess.addListener(this.onSMQ)
-        this.onSMQ(this.mqSOrLess)
-      }
-
       if (this.mqMobile) {
         this.mqMobile.addListener(this.onMobileMQ)
         this.onMobileMQ(this.mqMobile)
+      }
+
+      if (this.mqSOrLess) {
+        this.mqSOrLess.addListener(this.onSMQ)
+        this.onSMQ(this.mqSOrLess)
       }
 
       if (this.mqTabletOrLess) {
@@ -63,12 +63,12 @@ export const mediaQueries = (WrappedComponent, hocProps = {}) =>
     }
 
     componentWillUnmount() {
-      if (this.mqSOrLess) {
-        this.mqS.removeListener(this.onSMQ)
-      }
-
       if (this.mqMobile) {
         this.mqMobile.removeListener(this.onMobileMQ)
+      }
+
+      if (this.mqSOrLess) {
+        this.mqS.removeListener(this.onSMQ)
       }
 
       if (this.mqTabletOrLess) {
@@ -76,12 +76,12 @@ export const mediaQueries = (WrappedComponent, hocProps = {}) =>
       }
     }
 
-    onSMQ = event => {
-      this.setState({ viewportIsSOrLess: event.matches })
-    }
-
     onMobileMQ = event => {
       this.setState({ viewportIsMobile: event.matches })
+    }
+
+    onSMQ = event => {
+      this.setState({ viewportIsSOrLess: event.matches })
     }
 
     onTabletMQ = event => {
@@ -93,8 +93,8 @@ export const mediaQueries = (WrappedComponent, hocProps = {}) =>
         <WrappedComponent
           {...this.props}
           viewportIsMobile={this.state.viewportIsMobile}
-          viewportIsTabletOrLess={this.state.viewportIsTabletOrLess}
           viewportIsSOrLess={this.state.viewportIsSOrLess}
+          viewportIsTabletOrLess={this.state.viewportIsTabletOrLess}
         />
       )
     }

--- a/assets/javascripts/kitten/hoc/media-queries.js
+++ b/assets/javascripts/kitten/hoc/media-queries.js
@@ -1,7 +1,11 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { createMatchMediaMax } from 'kitten/helpers/utils/media-queries'
-import { SCREEN_SIZE_XS, SCREEN_SIZE_M } from 'kitten/constants/screen-config'
+import {
+  SCREEN_SIZE_S,
+  SCREEN_SIZE_XS,
+  SCREEN_SIZE_M,
+} from 'kitten/constants/screen-config'
 
 export const mediaQueries = (WrappedComponent, hocProps = {}) =>
   class extends Component {
@@ -9,6 +13,11 @@ export const mediaQueries = (WrappedComponent, hocProps = {}) =>
       super(props)
 
       this.state = {}
+
+      if (this.sMediaQueryEnabled()) {
+        this.mqSOrLess = createMatchMediaMax(SCREEN_SIZE_S)
+        this.state = { ...this.state, viewportIsSOrLess: false }
+      }
 
       if (this.mobileMediaQueryEnabled()) {
         this.mqMobile = createMatchMediaMax(SCREEN_SIZE_XS)
@@ -21,6 +30,11 @@ export const mediaQueries = (WrappedComponent, hocProps = {}) =>
       }
     }
 
+    sMediaQueryEnabled = () =>
+      typeof hocProps.viewportIsSOrLess !== 'undefined'
+        ? hocProps.viewportIsSOrLess
+        : false
+
     mobileMediaQueryEnabled = () =>
       typeof hocProps.viewportIsMobile !== 'undefined'
         ? hocProps.viewportIsMobile
@@ -32,6 +46,11 @@ export const mediaQueries = (WrappedComponent, hocProps = {}) =>
         : false
 
     componentDidMount() {
+      if (this.mqSOrLess) {
+        this.mqSOrLess.addListener(this.onSMQ)
+        this.onSMQ(this.mqSOrLess)
+      }
+
       if (this.mqMobile) {
         this.mqMobile.addListener(this.onMobileMQ)
         this.onMobileMQ(this.mqMobile)
@@ -44,6 +63,10 @@ export const mediaQueries = (WrappedComponent, hocProps = {}) =>
     }
 
     componentWillUnmount() {
+      if (this.mqSOrLess) {
+        this.mqS.removeListener(this.onSMQ)
+      }
+
       if (this.mqMobile) {
         this.mqMobile.removeListener(this.onMobileMQ)
       }
@@ -51,6 +74,10 @@ export const mediaQueries = (WrappedComponent, hocProps = {}) =>
       if (this.mqTabletOrLess) {
         this.mqTabletOrLess.removeListener(this.onTabletMQ)
       }
+    }
+
+    onSMQ = event => {
+      this.setState({ viewportIsSOrLess: event.matches })
     }
 
     onMobileMQ = event => {
@@ -67,6 +94,7 @@ export const mediaQueries = (WrappedComponent, hocProps = {}) =>
           {...this.props}
           viewportIsMobile={this.state.viewportIsMobile}
           viewportIsTabletOrLess={this.state.viewportIsTabletOrLess}
+          viewportIsSOrLess={this.state.viewportIsSOrLess}
         />
       )
     }


### PR DESCRIPTION
- Ajoute le `viewport` `S`. Permet de gérer l'état entre le mobile et la tablette.

TODO:

- [x] Tests
- [x] Changelog
- [ ] A11Y
- [ ] Stories
