### PR TITLE
[ProjectPage] Fix `HorizontalNav` vertical alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Fix `HorizontalNav` vertical alignment.
+- Feature: Add `markdown` prop to ignore `Markdown` transformation.
 - Feature: Update svg size and color on `IconBadge` component.
 - Feature: Add `viewportIsSOrLess` on `mediaQueries` HOC.
 - Feature: Show `LegoGrid` only when DOM is loaded.

--- a/assets/javascripts/kitten/components/navigation/horizontal-nav.js
+++ b/assets/javascripts/kitten/components/navigation/horizontal-nav.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { Component, Fragment } from 'react'
 import { Badge } from 'kitten/components/notifications/badge'
 import classNames from 'classnames'
 import Markdown from 'react-markdown'
@@ -11,6 +11,7 @@ export class HorizontalNav extends Component {
   }
 
   renderItem(item) {
+    const { markdown } = this.props
     const { className, selected, text, badge, key, href, ...others } = item
 
     const itemClassName = classNames('k-HorizontalNav__item', className, {
@@ -18,13 +19,17 @@ export class HorizontalNav extends Component {
     })
 
     const renderBadge = (
-      <div className="k-HorizontalNav__item__badge">
+      <Fragment>
         {text}
         <Badge className="k-HorizontalNav__badge">{badge}</Badge>
-      </div>
+      </Fragment>
     )
 
-    const renderMarkdown = <Markdown softBreak="br" source={text} />
+    const renderMarkdown = markdown ? (
+      <Markdown softBreak="br" source={text} />
+    ) : (
+      text
+    )
 
     const renderText = badge ? renderBadge : renderMarkdown
 
@@ -73,4 +78,5 @@ HorizontalNav.defaultProps = {
   center: false,
   elementClassName: null,
   items: [], // Eg: [{ key: …, text: …, href: …, selected: …, badge: … }]
+  markdown: true,
 }

--- a/assets/javascripts/kitten/components/navigation/horizontal-nav.test.js
+++ b/assets/javascripts/kitten/components/navigation/horizontal-nav.test.js
@@ -105,7 +105,7 @@ describe('<HorizontalNav />', () => {
         />,
       )
 
-      it("don't transform ** with <strong />", () => {
+      it("doesn't transform ** with <strong />", () => {
         expect(component.find('.item-1').html()).not.toMatch(
           /<strong>Nav<\/strong>/,
         )

--- a/assets/javascripts/kitten/components/navigation/horizontal-nav.test.js
+++ b/assets/javascripts/kitten/components/navigation/horizontal-nav.test.js
@@ -96,5 +96,20 @@ describe('<HorizontalNav />', () => {
         expect(component.find('.item-1').html()).toMatch(/Nav<br\/>1/)
       })
     })
+
+    describe('with markdown prop to false', () => {
+      const component = shallow(
+        <HorizontalNav
+          markdown={false}
+          items={[{ key: 'item-1', text: '**Nav**', className: 'item-1' }]}
+        />,
+      )
+
+      it("don't transform ** with <strong />", () => {
+        expect(component.find('.item-1').html()).not.toMatch(
+          /<strong>Nav<\/strong>/,
+        )
+      })
+    })
   })
 })

--- a/assets/stylesheets/kitten/components/navigation/_horizontal-nav.scss
+++ b/assets/stylesheets/kitten/components/navigation/_horizontal-nav.scss
@@ -69,13 +69,9 @@
     flex-shrink: 0;
   }
 
- .k-HorizontalNav__item__badge {
-    display: flex;
-    align-items: center;
-  }
-
   .k-HorizontalNav__item {
     display: flex;
+    align-items: center;
 
     margin: 0 $margin;
     border-bottom: $border-width solid transparent;


### PR DESCRIPTION
Actuellement, l'alignement vertical des items n'est pas centré quand on utilise la version avec `Markdown` et qu'on fixe une hauteur spécifique. Cette PR corrige l'alignement pour tous les cas et offre une option pour désactiver le rendu en markdown si on en a pas besoin.

Screenshot:
<img width="490" alt="capture d ecran 2018-04-20 a 10 25 33" src="https://user-images.githubusercontent.com/736319/39040715-f78baf80-4487-11e8-9524-167193397e3f.png">
