### PR TITLE
[AgricultureLanding] Fix `name` attribute on `TextInput` textarea version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Add `name` value on `TextInput` textarea version.
 - Fix: Fix `HorizontalNav` vertical alignment.
 - Feature: Add `markdown` prop to ignore `Markdown` transformation.
 - Feature: Add `Italic` props on `Title` component.

--- a/assets/javascripts/kitten/components/form/text-input.js
+++ b/assets/javascripts/kitten/components/form/text-input.js
@@ -40,6 +40,7 @@ export class TextInput extends Component {
             className={textInputClassName}
             ref={input => (this.input = input)}
             disabled={disabled}
+            name={name}
             {...others}
           />
           <div className="k-TextAreaWrapper__gradient" />

--- a/assets/javascripts/kitten/components/form/text-input.test.js
+++ b/assets/javascripts/kitten/components/form/text-input.test.js
@@ -56,10 +56,18 @@ describe('Text-input with default props', () => {
       })
     })
 
+    describe('text-input with name prop', () => {
+      const componentWithTinyClass = shallow(<TextInput name="foobar" />)
+
+      it('has a name prop', () => {
+        expect(componentWithTinyClass.props().name).toBe('foobar')
+      })
+    })
+
     describe('text-input with textarea tag', () => {
-      const textArea = shallow(<TextInput tag="textarea" rows="7" />).find(
-        'textarea',
-      )
+      const textArea = shallow(
+        <TextInput tag="textarea" rows="7" name="foobar" />,
+      ).find('textarea')
 
       it('has a textarea tag', () => {
         expect(textArea.is('textarea')).toBe(true)
@@ -67,6 +75,10 @@ describe('Text-input with default props', () => {
 
       it('has 7 rows', () => {
         expect(textArea.props().rows).toBe('7')
+      })
+
+      it('has a name prop', () => {
+        expect(textArea.props().name).toBe('foobar')
       })
     })
 


### PR DESCRIPTION
Un bug a été introduit sur la PR suivante => https://github.com/KissKissBankBank/kitten/pull/1112/files#diff-d696025ce0725d2a8c40c18f5875074e

Pour la version `textarea` du `TextInput` le name n'était plus propagé :/