### PR TITLE
[ProjectPage] Don't erase styles in BackerCard component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Merge styles with `style` prop in `BackerCard`.
+
 ## [20.14.0] - 2018-05-29
 
 Features:

--- a/assets/javascripts/kitten/components/cards/backer-card.js
+++ b/assets/javascripts/kitten/components/cards/backer-card.js
@@ -12,7 +12,7 @@ export const BackerCard = ({
   description,
   ...others
 }) => (
-  <div style={{ ...styles.card, ...others.style }} {...others}>
+  <div {...others} style={{ ...styles.card, ...others.style }}>
     <Marger top="4" bottom="1">
       <Text color="primary1" weight="regular" lineHeight="normal">
         {title}


### PR DESCRIPTION
PR qui fixe un problème d'écrasement des styles de `BackerCard` quand la prop `style` est présente.