### PR TITLE
Fix `parseHtml` helper when no value is passed as parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: fix `parseHtml` helper when no value is passed as parameter.
+
 ## [20.15.0] - 2018-06-05
 
 Features:

--- a/assets/javascripts/kitten/helpers/utils/parser.js
+++ b/assets/javascripts/kitten/helpers/utils/parser.js
@@ -1,5 +1,8 @@
 import HtmlToReact from 'html-to-react'
 
 // We add a span to make parseHtml works with strings.
-export const parseHtml = value =>
-  new HtmlToReact.Parser().parse(`<span>${value}</span>`).props.children
+export const parseHtml = value => {
+  if (!value) return
+
+  return new HtmlToReact.Parser().parse(`<span>${value}</span>`).props.children
+}


### PR DESCRIPTION
Dans certain cas, on se retrouve à faire du `parseHtml` sur une valeur `null` voir `undefined`.
Ces valeurs sont ensuite transformées en string et `parseHtml` renvoi `"null"` ou `"undefined"`.
Si aucune valeur n'est passée en paramètre de `parseHtml`, celui-ci ne doit rien renvoyer.