### PR TITLE
[MediaQueries] add withMediaQueries hoc and custom view port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fix: Fix `Comment` propType warning.
 - Add composable `withMediaQueries` hoc to `media-queries`
 - Add custom `media-query` to `mediaQueries` hoc: 
-  `mediaQueries(Component, { viewPortCustom: '(min-width: 1440px)'})`
+  `mediaQueries(Component, { myCustomViewport: '(min-width: 1440px)'})`
 
 ## [20.16.0] - 2018-06-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fix: Disable textarea resize in `CommentForm`.
 - Fix: Fix `Comment` propType warning.
 - Add composable `withMediaQueries` hoc to `media-queries`
-- Add custom `media-query` to `mediaQueries` hoc
-  : `mediaQueries(Component, { viewPortCustom: '(min-width: 1440px)'})`
+- Add custom `media-query` to `mediaQueries` hoc: 
+  `mediaQueries(Component, { viewPortCustom: '(min-width: 1440px)'})`
 
 ## [20.16.0] - 2018-06-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [unreleased]
 
 - Fix: Fix `Comment` propType warning.
+- Add composable `withMediaQueries` hoc to `media-queries`
+- Add custom `media-query` to `mediaQueries` hoc
+  : `mediaQueries(Component, { viewPortCustom: '(min-width: 1440px)'})`
 
 ## [20.16.0] - 2018-06-06
 

--- a/assets/javascripts/kitten/hoc/media-queries.js
+++ b/assets/javascripts/kitten/hoc/media-queries.js
@@ -84,7 +84,6 @@ export const mediaQueries = (WrappedComponent, hocProps = {}) =>
       }
 
       Object.keys(this.customProps).forEach(prop => {
-        this.setState({ [prop]: false })
         this.custom[prop] = createMatchMedia(this.customProps[prop])
         this.custom[prop].cb = event => this.setState({ [prop]: event.matches })
         this.custom[prop].addListener(this.custom[prop].cb)

--- a/assets/javascripts/kitten/hoc/media-queries.test.js
+++ b/assets/javascripts/kitten/hoc/media-queries.test.js
@@ -120,7 +120,7 @@ describe('mediaQueries()', () => {
     it('pushes media queries props to wrapped component', () => {
       const wrappedComponent = component.find(SimpleComponent).first()
 
-      expect(wrappedComponent.prop('myCustomMediaQuery')).toBeFalsy()
+      expect(wrappedComponent.prop('myCustomMediaQuery')).toBeDefined()
       expect(wrappedComponent.prop('viewportIsMobile')).toBeFalsy()
       expect(wrappedComponent.prop('viewportIsTabletOrLess')).toBeFalsy()
       expect(wrappedComponent.prop('viewportIsSOrLess')).toBeFalsy()

--- a/assets/javascripts/kitten/hoc/media-queries.test.js
+++ b/assets/javascripts/kitten/hoc/media-queries.test.js
@@ -6,6 +6,7 @@ const SimpleComponent = ({
   viewportIsMobile,
   viewportIsTabletOrLess,
   viewportIsSOrLess,
+  myCustomMediaQuery,
   ...props
 }) => {
   return <div title="Test me!" {...props} />
@@ -104,6 +105,25 @@ describe('mediaQueries()', () => {
       expect(wrappedComponent.prop('viewportIsMobile')).toBeFalsy()
       expect(wrappedComponent.prop('viewportIsTabletOrLess')).toBeFalsy()
       expect(wrappedComponent.prop('viewportIsSOrLess')).toBeTruthy()
+    })
+  })
+
+  describe('with custom media query', () => {
+    beforeEach(() => {
+      window.matchMedia = createMockMediaMatcher(true)
+      SimpleComponentWithMediaQueries = mediaQueries(SimpleComponent, {
+        myCustomMediaQuery: '(min-width: 1140px)',
+      })
+      component = mount(<SimpleComponentWithMediaQueries />)
+    })
+
+    it('pushes media queries props to wrapped component', () => {
+      const wrappedComponent = component.find(SimpleComponent).first()
+
+      expect(wrappedComponent.prop('myCustomMediaQuery')).toBeFalsy()
+      expect(wrappedComponent.prop('viewportIsMobile')).toBeFalsy()
+      expect(wrappedComponent.prop('viewportIsTabletOrLess')).toBeFalsy()
+      expect(wrappedComponent.prop('viewportIsSOrLess')).toBeFalsy()
     })
   })
 })


### PR DESCRIPTION
J'ai rajouté un `hoc` qu'on peut utiliser pour faire de la composition : `withMediaQueries`. L'autre est toujours utilisable mais il faudrait le déprécier à terme.

J'ai rajouté la possibilité de mettre un *viewport custom* du style : 
```javascript
export default compose(
    connect(mapStateToProps),
    withMediaQueries({
      viewportIsMobile: true,
      viewportIsTabletOrLess: true,
      viewPortCustom: '(min-width: 1440px)',
    }),
  )(Navigation)
```

ça enverra la *prop* `viewPortCustom` dans le `Component` pour gérer ce *breakpoint*.
