### PR TITLE
[Storybook] Add storybook section on README for release guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,3 +322,9 @@ $ bundle exec rake kitten_release
 - Update
   [our private project kanban](https://github.com/orgs/KissKissBankBank/projects/5):
   move cards that are released from `done` column to `released` column.
+
+### Storybook
+- To release `Storybook` simply run this command:
+```sh
+yarn deploy-storybook
+```


### PR DESCRIPTION
On a une commande dans notre `package.json` pour déployer storybook sur [https://kisskissbankbank.github.io/kitten](https://kisskissbankbank.github.io/kitten)
On utilise la lib `storybook-to-ghpages` [comme ceci](https://github.com/KissKissBankBank/kitten/blob/e942a73b998f5799aa5fb1a3c9fd643e699b8fca/package.json#L108) 

Il suffit donc de lancer la commande `yarn deploy-storybook` sur `master`.

J'ai rajouté une section `Storybook` dans le `README.md` pour l'expliquer. 