### PR TITLE
Fix re-render `ButtonIcon` state on `Carousel`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Fix re-render `ButtonIcon` state on `Carousel`.
+
 ## [21.0.1] - 2018-07-02
 
 Fix:

--- a/assets/javascripts/kitten/components/carousel/carousel.js
+++ b/assets/javascripts/kitten/components/carousel/carousel.js
@@ -219,6 +219,7 @@ class CarouselBase extends React.Component {
         <ButtonIcon
           modifier="beryllium"
           onClick={this.goPrevPage}
+          key={`left-${indexPageVisible}`}
           disabled={indexPageVisible < 1 || numPages < 1}
           style={styles.carouselButtonPagination}
         >
@@ -228,6 +229,7 @@ class CarouselBase extends React.Component {
         <ButtonIcon
           modifier="beryllium"
           onClick={this.goNextPage}
+          key={`right-${indexPageVisible}`}
           disabled={indexPageVisible >= numPages - 1}
           style={styles.carouselButtonPagination}
         >


### PR DESCRIPTION
### Le `hover` reste actif, quand on clic sur le button `prev` ou `next` du carousel

Screenshot:
![capture d ecran 2018-07-04 a 11 01 37](https://user-images.githubusercontent.com/11648042/42267615-ba18f0b8-7f79-11e8-9836-7fc967349476.png)


TODO:

- [ ] Tests
- [x] Changelog
- [ ] A11Y
- [ ] Stories
