### PR TITLE
[Carousel] Add onClick method on prev/next page container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Feature: In `Carousel`, we can now change page by clicking prev/next page.
 - Fix: Fix `title` `min-height` on `CrowdfundingCard` component.
 - Fix: Fix re-render `ButtonIcon` state on `Carousel`.
 - Fix: Update [Sprockets Rails](https://github.com/rails/sprockets-rails)

--- a/assets/javascripts/kitten/components/carousel/__snapshots__/carousel.test.js.snap
+++ b/assets/javascripts/kitten/components/carousel/__snapshots__/carousel.test.js.snap
@@ -30,6 +30,7 @@ exports[`<Carousel /> by default on desktop is a <Grid /> 1`] = `
     >
       <div
         data-radium={true}
+        onClick={[Function]}
         style={
           Object {
             "flexShrink": 0,
@@ -185,6 +186,7 @@ exports[`<Carousel /> by default on mobile is not a <Grid /> 1`] = `
   >
     <div
       data-radium={true}
+      onClick={[Function]}
       style={
         Object {
           "flexShrink": 0,
@@ -347,6 +349,7 @@ exports[`<Carousel /> with withoutLeftOffset on desktop is a <Grid /> 1`] = `
     >
       <div
         data-radium={true}
+        onClick={[Function]}
         style={
           Object {
             "flexShrink": 0,

--- a/assets/javascripts/kitten/components/carousel/carousel-inner.js
+++ b/assets/javascripts/kitten/components/carousel/carousel-inner.js
@@ -149,7 +149,9 @@ class CarouselInnerBase extends React.Component {
   handleTouchStart = () => this.setState({ isTouched: true })
   handleTouchEnd = () => this.setState({ isTouched: false })
 
-  handlePageClick = index => {
+  handlePageClick = index => e => {
+    e.preventDefault()
+
     if (index !== this.props.indexPageVisible) {
       this.scrollToPage(index)
       document.activeElement.blur()
@@ -198,10 +200,7 @@ class CarouselInnerBase extends React.Component {
                 marginLeft: index ? itemMarginBetween : 0,
               },
             ]}
-            onClick={e => {
-              e.preventDefault()
-              this.handlePageClick(index)
-            }}
+            onClick={this.handlePageClick(index)}
           >
             <CarouselPage
               data={getDataForPage(data, index, numColumns)}

--- a/assets/javascripts/kitten/components/carousel/carousel-inner.js
+++ b/assets/javascripts/kitten/components/carousel/carousel-inner.js
@@ -149,6 +149,13 @@ class CarouselInnerBase extends React.Component {
   handleTouchStart = () => this.setState({ isTouched: true })
   handleTouchEnd = () => this.setState({ isTouched: false })
 
+  handlePageClick = index => {
+    if (index !== this.props.indexPageVisible) {
+      this.scrollToPage(index)
+      document.activeElement.blur()
+    }
+  }
+
   render() {
     const {
       data,
@@ -185,10 +192,16 @@ class CarouselInnerBase extends React.Component {
             key={index}
             style={[
               styles.carouselPageContainer,
+              index !== indexPageVisible &&
+                styles.carouselPageContainerClickable,
               {
                 marginLeft: index ? itemMarginBetween : 0,
               },
             ]}
+            onClick={e => {
+              e.preventDefault()
+              this.handlePageClick(index)
+            }}
           >
             <CarouselPage
               data={getDataForPage(data, index, numColumns)}
@@ -233,6 +246,9 @@ const styles = {
     flexShrink: 0,
     // snap only for browser that support snap without prefixes
     scrollSnapAlign: supportScrollSnap ? 'center' : 'none',
+  },
+  carouselPageContainerClickable: {
+    cursor: 'pointer',
   },
 }
 


### PR DESCRIPTION
Il est maintenant possible de changer de page en cliquant sur le container de la page d'avant/après visible sur tablette et mobile.