### PR TITLE
[Carousel] Fix click on current page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Don't cancel click on current page of `Carousel`.
+
 ## [21.3.0] - 2018-08-01
 
 Feature:

--- a/KARL_CHANGELOG.md
+++ b/KARL_CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Update an `Carousel` example with links.
+
 ## [21.3.0] - 2018-08-01
 
 No changes.

--- a/app/views/kitten/components/carousel/carousel.html.erb
+++ b/app/views/kitten/components/carousel/carousel.html.erb
@@ -44,11 +44,11 @@
 <%= example 'Five' do %>
   <%= react_component('KarlCarouselProjectCard', props: {
     data: [
-      { id: 1, title: "A" },
-      { id: 2, title: "B" },
-      { id: 3, title: "C" },
-      { id: 4, title: "D" },
-      { id: 5, title: "E" }
+      { id: 1, title: "A", linkHref: "#A" },
+      { id: 2, title: "B", linkHref: "#B" },
+      { id: 3, title: "C", linkHref: "#C" },
+      { id: 4, title: "D", linkHref: "#D" },
+      { id: 5, title: "E", linkHref: "#E" }
     ],
   }) %>
 <% end %>

--- a/assets/javascripts/kitten/components/carousel/carousel-inner.js
+++ b/assets/javascripts/kitten/components/carousel/carousel-inner.js
@@ -150,9 +150,8 @@ class CarouselInnerBase extends React.Component {
   handleTouchEnd = () => this.setState({ isTouched: false })
 
   handlePageClick = index => e => {
-    e.preventDefault()
-
     if (index !== this.props.indexPageVisible) {
+      e.preventDefault()
       this.scrollToPage(index)
       document.activeElement.blur()
     }

--- a/assets/javascripts/kitten/karl/carousel/carousel.js
+++ b/assets/javascripts/kitten/karl/carousel/carousel.js
@@ -16,7 +16,7 @@ export const KarlCarouselProjectCard = props => {
         itemMinWidth={ProjectCardMinWidth}
         baseItemMarginBetween={ProjectCardMarginBetween}
         renderItem={({ item }) => {
-          return <ProjectCard title={item.title} />
+          return <ProjectCard linkHref={item.linkHref} title={item.title} />
         }}
         {...props}
       />


### PR DESCRIPTION
Actuellement les cards dans les carrousels ne fonctionnent plus à cause d'un `preventDefault` qui s'applique à toutes les pages à la place d'être sur les pages avant/après.