### PR TITLE
[Stability] Update React on Rails

### DIFF
--- a/kitten.gemspec
+++ b/kitten.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'railties', ['> 3.0.0', '< 5.0.0']
 
   # Render react components easily on client and server side.
-  s.add_dependency 'react_on_rails', '~> 11.1.6'
+  s.add_dependency 'react_on_rails', '11.1.8'
 
   # Render react components with execjs on server side by react_on_rails.
   s.add_dependency 'therubyracer'

--- a/spec/dummy/client/package.json
+++ b/spec/dummy/client/package.json
@@ -11,6 +11,6 @@
   "dependencies": {
     "kitten-components": "file:../../..",
     "kitten-launcher": "^1.0.0",
-    "react-on-rails": "11.1.6"
+    "react-on-rails": "11.1.8"
   }
 }


### PR DESCRIPTION
### [Stability] Mise à jour mineure de React on Rails

Les dépendances à la gem React on Rails et au module npm doivent se suivre. J'ai donc fixé la version dans le `kitten.gemspec` (comme ce qui est déjà le cas dans le `package.json`). J'en ai profité pour mettre la version qu'ils ont sorti hier.