### PR TITLE
[ProjectPage] Split `RewardCard` into several components

### DIFF
--- a/assets/javascripts/kitten/components/cards/reward-card.js
+++ b/assets/javascripts/kitten/components/cards/reward-card.js
@@ -45,6 +45,7 @@ class RewardCardComponent extends Component {
     version: PropTypes.oneOf(['default', 'tiny']),
     viewportIsMobile: PropTypes.bool,
     viewportIsSOrLess: PropTypes.bool,
+    viewportIsTabletOrLess: PropTypes.bool,
 
     // Deprecated props
     titleDescription: deprecated(
@@ -63,6 +64,10 @@ class RewardCardComponent extends Component {
     manageContribution: deprecated(
       PropTypes.string,
       'Use `manageContributionLinkLabel` prop instead',
+    ),
+    manageContributionLink: deprecated(
+      PropTypes.string,
+      'Use `manageContributionLinkHref` prop instead',
     ),
     button: deprecated(PropTypes.string, 'Use `buttonLabel` prop instead'),
     titleContributors: deprecated(PropTypes.string, 'Use `infos` prop instead'),
@@ -106,25 +111,34 @@ class RewardCardComponent extends Component {
   }
 
   render() {
-    // Part of destructuration is needed to handle retro-compatibility with
-    // deprecated props.
+    // We need to destructure the props to prevent them to hydrate children components.
     const {
-      viewportIsTabletOrLess,
-      titleDescription,
-      textDescription,
+      titleAmount,
       titleTag,
-      textTag,
-      description,
       subtitle,
       subtitleTag,
-      button,
-      buttonLabel,
-      myContribution,
-      manageContribution,
-      manageContributionLink,
+      description,
       manageContributionDescription,
       manageContributionLinkLabel,
       manageContributionLinkHref,
+      buttonLabel,
+      buttonOnMouseEnter,
+      buttonOnMouseLeave,
+      buttonOnClick,
+      isDisabled,
+      starred,
+      starLabel,
+      version,
+      viewportIsMobile,
+      viewportIsSOrLess,
+      viewportIsTabletOrLess,
+      titleDescription,
+      textDescription,
+      textTag,
+      myContribution,
+      manageContribution,
+      manageContributionLink,
+      button,
       titleContributors,
       titleDelivery,
       titleAvailability,

--- a/assets/javascripts/kitten/components/cards/reward-card.js
+++ b/assets/javascripts/kitten/components/cards/reward-card.js
@@ -134,11 +134,6 @@ class RewardCardComponent extends Component {
           'offset-s': 1,
         }
 
-    // Retro-compatibility for deprecated props
-    const subtitleText = subtitle || titleDescription
-    const subtitleTagname = subtitleTag || textTag
-    const descriptionText = description || textDescription
-
     return (
       <StyleRoot {...others} style={styleCard}>
         <Marger
@@ -154,9 +149,9 @@ class RewardCardComponent extends Component {
 
               <RewardCardInfos
                 {...this.props}
-                subtitle={subtitleText}
-                subtitleTag={subtitleTagname}
-                description={descriptionText}
+                subtitle={subtitle || titleDescription}
+                subtitleTag={subtitleTag || textTag}
+                description={description || textDescription}
                 isTinyVersion={this.isTinyVersion()}
                 viewportIsTabletOrLess={viewportIsTabletOrLess}
               />

--- a/assets/javascripts/kitten/components/cards/reward-card.js
+++ b/assets/javascripts/kitten/components/cards/reward-card.js
@@ -65,12 +65,45 @@ class RewardCardComponent extends Component {
       'Use `manageContributionLinkLabel` prop instead',
     ),
     button: deprecated(PropTypes.string, 'Use `buttonLabel` prop instead'),
+    titleContributors: deprecated(PropTypes.string, 'Use `infos` prop instead'),
+    titleDelivery: deprecated(PropTypes.string, 'Use `infos` prop instead'),
+    titleAvailability: deprecated(PropTypes.string, 'Use `infos` prop instead'),
+    valueContributors: deprecated(PropTypes.string, 'Use `infos` prop instead'),
+    valueDelivery: deprecated(PropTypes.string, 'Use `infos` prop instead'),
+    valueAvailability: deprecated(PropTypes.string, 'Use `infos` prop instead'),
   }
 
   isTinyVersion = () =>
     this.props.version === 'tiny' || this.props.viewportIsMobile
 
   isSOrLessVersion = () => this.isTinyVersion() || this.props.viewportIsSOrLess
+
+  legacyInfos = () => {
+    const {
+      titleContributors,
+      titleDelivery,
+      titleAvailability,
+      valueContributors,
+      valueDelivery,
+      valueAvailability,
+    } = this.props
+
+    const infos = []
+
+    if (titleContributors) {
+      infos.push({ label: titleContributors, value: valueContributors })
+    }
+
+    if (titleDelivery) {
+      infos.push({ label: titleDelivery, value: valueDelivery })
+    }
+
+    if (titleAvailability) {
+      infos.push({ label: titleAvailability, value: valueAvailability })
+    }
+
+    return infos
+  }
 
   render() {
     // Part of destructuration is needed to handle retro-compatibility with
@@ -92,6 +125,12 @@ class RewardCardComponent extends Component {
       manageContributionDescription,
       manageContributionLinkLabel,
       manageContributionLinkHref,
+      titleContributors,
+      titleDelivery,
+      titleAvailability,
+      valueContributors,
+      valueDelivery,
+      valueAvailability,
       imageProps,
       ...others
     } = this.props
@@ -132,14 +171,15 @@ class RewardCardComponent extends Component {
             <GridCol {...leftColumnProps}>
               <RewardCardContent
                 {...this.props}
+                subtitle={subtitle || titleDescription}
+                subtitleTag={subtitleTag || textTag}
+                description={description || textDescription}
                 isTinyVersion={this.isTinyVersion()}
               />
 
               <RewardCardInfos
+                infos={this.legacyInfos()}
                 {...this.props}
-                subtitle={subtitle || titleDescription}
-                subtitleTag={subtitleTag || textTag}
-                description={description || textDescription}
                 isTinyVersion={this.isTinyVersion()}
                 viewportIsTabletOrLess={viewportIsTabletOrLess}
               />

--- a/assets/javascripts/kitten/components/cards/reward-card.js
+++ b/assets/javascripts/kitten/components/cards/reward-card.js
@@ -8,8 +8,6 @@ import {
   GridCol as GridColBase,
 } from 'kitten/components/grid/grid'
 import { StarIcon } from 'kitten/components/icons/star-icon'
-import { IconBadge as IconBadgeBase } from 'kitten/components/notifications/icon-badge'
-import { CheckedIcon } from 'kitten/components/icons/checked-icon'
 import COLORS from 'kitten/constants/colors-config'
 import { ScreenConfig } from 'kitten/constants/screen-config'
 import { mediaQueries } from 'kitten/hoc/media-queries'
@@ -22,7 +20,6 @@ import {
 
 const Grid = Radium(GridBase)
 const GridCol = Radium(GridColBase)
-const IconBadge = Radium(IconBadgeBase)
 
 class RewardCardComponent extends Component {
   static propTypes = {
@@ -195,14 +192,6 @@ class RewardCardComponent extends Component {
           )}
         </Marger>
       </StyleRoot>
-    )
-  }
-
-  renderIconBadge() {
-    return (
-      <IconBadge valid style={styles.iconBadge}>
-        <CheckedIcon className="k-IconBadge__svg" />
-      </IconBadge>
     )
   }
 

--- a/assets/javascripts/kitten/components/cards/reward-card.js
+++ b/assets/javascripts/kitten/components/cards/reward-card.js
@@ -27,14 +27,19 @@ const IconBadge = Radium(IconBadgeBase)
 
 class RewardCardComponent extends Component {
   static propTypes = {
+    titleDescription: deprecated(
+      PropTypes.string,
+      'Use `subtitle` prop instead',
+    ),
+    textDescription: deprecated(
+      PropTypes.string,
+      'Use `description` prop instead',
+    ),
+    textTag: deprecated(PropTypes.string, 'Use `subtitleTag` prop instead'),
     button: PropTypes.string,
     buttonOnMouseEnter: PropTypes.func,
     buttonOnMouseLeave: PropTypes.func,
     buttonOnClick: PropTypes.func,
-
-    myContribution: PropTypes.string,
-    manageContribution: PropTypes.string,
-    manageContributionLink: PropTypes.string,
 
     isDisabled: PropTypes.bool,
     starred: PropTypes.bool,
@@ -79,6 +84,9 @@ class RewardCardComponent extends Component {
       titleAmount,
       titleDescription,
       textDescription,
+      description,
+      subtitle,
+      subtitleTag,
       titleContributors,
       titleDelivery,
       titleAvailability,
@@ -126,6 +134,11 @@ class RewardCardComponent extends Component {
           'offset-s': 1,
         }
 
+    // Retro-compatibility for deprecated props
+    const subtitleText = subtitle || titleDescription
+    const subtitleTagname = subtitleTag || textTag
+    const descriptionText = description || textDescription
+
     return (
       <StyleRoot {...others} style={styleCard}>
         <Marger
@@ -141,6 +154,9 @@ class RewardCardComponent extends Component {
 
               <RewardCardInfos
                 {...this.props}
+                subtitle={subtitleText}
+                subtitleTag={subtitleTagname}
+                description={descriptionText}
                 isTinyVersion={this.isTinyVersion()}
                 viewportIsTabletOrLess={viewportIsTabletOrLess}
               />
@@ -165,39 +181,6 @@ class RewardCardComponent extends Component {
 
   renderChoiceButton() {
     const { myContribution, button } = this.props
-
-    if (!button && !myContribution) return
-
-    return (
-      <Fragment>
-        {this.isSOrLessVersion() && (
-          <Fragment>
-            {myContribution && (
-              <Marger
-                top={
-                  !this.props.imageProps.src || !this.isTinyVersion() ? 0 : 2
-                }
-                bottom={!myContribution ? 0 : 2}
-              >
-                {this.renderMyContribution()}
-              </Marger>
-            )}
-            {this.renderButton()}
-          </Fragment>
-        )}
-
-        {!this.isSOrLessVersion() && (
-          <Marger top="3">
-            {this.renderButton()}
-            {myContribution && (
-              <Marger top={!myContribution ? 0 : 2}>
-                {this.renderMyContribution()}
-              </Marger>
-            )}
-          </Marger>
-        )}
-      </Fragment>
-    )
   }
 
   renderButton() {
@@ -241,70 +224,7 @@ class RewardCardComponent extends Component {
     )
   }
 
-  renderMyContribution() {
-    const {
-      isDisabled,
-      myContribution,
-      manageContribution,
-      manageContributionLink,
-    } = this.props
-
-    if (!myContribution || (this.isTinyVersion() && isDisabled)) return
-
-    const choiceButtonAddPadding = this.isTinyVersion()
-      ? styles.choiceButton.addPadding.tinyVersion
-      : styles.choiceButton.addPadding
-
-    return (
-      <Fragment>
-        {this.isSOrLessVersion() && (
-          <Grid style={choiceButtonAddPadding}>
-            <GridCol>
-              <div style={styles.myContribution}>
-                {this.renderIconBadge()}
-                <div style={styles.myContribution.text}>
-                  <Text color="font1" size="tiny" weight="regular">
-                    {myContribution}
-                    <br />
-                    <Text
-                      tag="a"
-                      href={manageContributionLink}
-                      color="primary1"
-                      weight="regular"
-                      decoration="none"
-                    >
-                      {manageContribution}
-                    </Text>
-                  </Text>
-                </div>
-              </div>
-            </GridCol>
-          </Grid>
-        )}
-
-        {!this.isSOrLessVersion() && (
-          <div style={styles.myContribution}>
-            {this.renderIconBadge()}
-            <div style={styles.myContribution.text}>
-              <Text color="font1" size="tiny" weight="regular">
-                {myContribution}
-                <br />
-                <Text
-                  tag="a"
-                  href={manageContributionLink}
-                  color="primary1"
-                  weight="regular"
-                  decoration="none"
-                >
-                  {manageContribution}
-                </Text>
-              </Text>
-            </div>
-          </div>
-        )}
-      </Fragment>
-    )
-  }
+  renderMyContribution() {}
 
   renderImage() {
     const { isDisabled } = this.props

--- a/assets/javascripts/kitten/components/cards/reward-card.js
+++ b/assets/javascripts/kitten/components/cards/reward-card.js
@@ -7,10 +7,7 @@ import {
   Grid as GridBase,
   GridCol as GridColBase,
 } from 'kitten/components/grid/grid'
-import { Button as ButtonBase } from 'kitten/components/buttons/button'
 import { StarIcon } from 'kitten/components/icons/star-icon'
-import { Text as TextBase } from 'kitten/components/typography/text'
-import { Paragraph as ParagraphBase } from 'kitten/components/typography/paragraph'
 import { IconBadge as IconBadgeBase } from 'kitten/components/notifications/icon-badge'
 import { CheckedIcon } from 'kitten/components/icons/checked-icon'
 import COLORS from 'kitten/constants/colors-config'
@@ -25,9 +22,6 @@ import {
 
 const Grid = Radium(GridBase)
 const GridCol = Radium(GridColBase)
-const Button = Radium(ButtonBase)
-const Text = Radium(TextBase)
-const Paragraph = Radium(ParagraphBase)
 const IconBadge = Radium(IconBadgeBase)
 
 class RewardCardComponent extends Component {
@@ -52,6 +46,8 @@ class RewardCardComponent extends Component {
     starLabel: PropTypes.string,
 
     version: PropTypes.oneOf(['default', 'tiny']),
+    viewportIsMobile: PropTypes.bool,
+    viewportIsSOrLess: PropTypes.bool,
 
     // Deprecated props
     titleDescription: deprecated(
@@ -79,7 +75,6 @@ class RewardCardComponent extends Component {
   isSOrLessVersion = () => this.isTinyVersion() || this.props.viewportIsSOrLess
 
   render() {
-    // We need to destructure the props to prevent them to hydrate children components.
     const {
       isDisabled,
       viewportIsMobile,
@@ -114,11 +109,11 @@ class RewardCardComponent extends Component {
       ...others
     } = this.props
 
-    const styleCard = [others.style, styles.card]
+    const cardStyles = [others.style, styles.card]
 
-    const cardAddPadding = this.isTinyVersion()
-      ? styles.card.addPadding.tinyVersion
-      : styles.card.addPadding
+    const cardPaddings = this.isTinyVersion()
+      ? styles.card.paddings.tinyVersion
+      : styles.card.paddings
 
     const cardImage = this.isTinyVersion()
       ? styles.card.image.tinyVersion
@@ -139,12 +134,12 @@ class RewardCardComponent extends Component {
         }
 
     return (
-      <StyleRoot {...others} style={styleCard}>
+      <StyleRoot {...others} style={cardStyles}>
         <Marger
           bottom={this.isSOrLessVersion() ? 0 : 4}
           top={this.isSOrLessVersion() ? 3 : 4}
         >
-          <Grid style={cardAddPadding}>
+          <Grid style={cardPaddings}>
             <GridCol {...leftColumnProps}>
               <RewardCardContent
                 {...this.props}
@@ -199,15 +194,12 @@ class RewardCardComponent extends Component {
                 manageContributionLinkHref || manageContributionLink
               }
               isTinyVersion={this.isTinyVersion()}
-              withTopMargin={!imageProps.src || !this.isTinyVersion()}
             />
           )}
         </Marger>
       </StyleRoot>
     )
   }
-
-  renderButton() {}
 
   renderIconBadge() {
     return (
@@ -216,8 +208,6 @@ class RewardCardComponent extends Component {
       </IconBadge>
     )
   }
-
-  renderMyContribution() {}
 
   renderImage() {
     const { isDisabled } = this.props
@@ -249,7 +239,7 @@ export const styles = {
     borderStyle: 'solid',
     borderColor: COLORS.line1,
 
-    addPadding: {
+    paddings: {
       paddingLeft: 20,
       paddingRight: 20,
 
@@ -306,7 +296,7 @@ export const styles = {
     paddingLeft: 20,
     paddingRight: 20,
 
-    addPadding: {
+    paddings: {
       [`@media (min-width: ${ScreenConfig['S'].min}px)`]: {
         paddingLeft: 30,
         paddingRight: 30,

--- a/assets/javascripts/kitten/components/cards/reward-card.js
+++ b/assets/javascripts/kitten/components/cards/reward-card.js
@@ -115,7 +115,7 @@ class RewardCardComponent extends Component {
       ? styles.card.paddings.tinyVersion
       : styles.card.paddings
 
-    const cardImage = this.isTinyVersion()
+    const cardImageStyles = this.isTinyVersion()
       ? styles.card.image.tinyVersion
       : styles.card.image
 
@@ -173,7 +173,7 @@ class RewardCardComponent extends Component {
             </GridCol>
 
             {imageProps.src && (
-              <GridCol {...rightColumnProps} style={cardImage}>
+              <GridCol {...rightColumnProps} style={cardImageStyles}>
                 <Marger bottom={!myContribution ? 2 : null}>
                   {this.renderImage()}
                 </Marger>

--- a/assets/javascripts/kitten/components/cards/reward-card.js
+++ b/assets/javascripts/kitten/components/cards/reward-card.js
@@ -1,6 +1,7 @@
 import React, { Component, Fragment } from 'react'
 import Radium, { StyleRoot } from 'radium'
 import PropTypes from 'prop-types'
+import deprecated from 'prop-types-extra/lib/deprecated'
 import { Marger } from 'kitten/components/layout/marger'
 import {
   Grid as GridBase,
@@ -17,6 +18,10 @@ import { ScreenConfig } from 'kitten/constants/screen-config'
 import { mediaQueries } from 'kitten/hoc/media-queries'
 import { RewardCardContent } from 'kitten/components/cards/reward-card/content'
 import { RewardCardInfos } from 'kitten/components/cards/reward-card/infos'
+import {
+  RewardCardAction,
+  RewardCardActionOnMOrMore,
+} from 'kitten/components/cards/reward-card/action'
 
 const Grid = Radium(GridBase)
 const GridCol = Radium(GridColBase)
@@ -27,15 +32,16 @@ const IconBadge = Radium(IconBadgeBase)
 
 class RewardCardComponent extends Component {
   static propTypes = {
-    titleDescription: deprecated(
-      PropTypes.string,
-      'Use `subtitle` prop instead',
-    ),
-    textDescription: deprecated(
-      PropTypes.string,
-      'Use `description` prop instead',
-    ),
-    textTag: deprecated(PropTypes.string, 'Use `subtitleTag` prop instead'),
+    titleAmount: PropTypes.string.isRequired,
+    titleTag: PropTypes.string,
+    subtitle: PropTypes.string,
+    subtitleTag: PropTypes.string,
+    description: PropTypes.string,
+
+    manageContributionDescription: PropTypes.string,
+    manageContributionLinkLabel: PropTypes.string,
+    manageContributionLinkHref: PropTypes.string,
+
     button: PropTypes.string,
     buttonOnMouseEnter: PropTypes.func,
     buttonOnMouseLeave: PropTypes.func,
@@ -46,27 +52,25 @@ class RewardCardComponent extends Component {
     starLabel: PropTypes.string,
 
     version: PropTypes.oneOf(['default', 'tiny']),
-  }
 
-  static defaultProps = {
-    imageProps: {
-      src: '',
-      alt: '',
-    },
-    button: '',
-    buttonOnMouseEnter: () => {},
-    buttonOnMouseLeave: () => {},
-    buttonOnClick: () => {},
-
-    myContribution: '',
-    manageContribution: '',
-    manageContributionLink: '',
-
-    isDisabled: false,
-    starred: false,
-    starLabel: '',
-
-    version: 'default',
+    // Deprecated props
+    titleDescription: deprecated(
+      PropTypes.string,
+      'Use `subtitle` prop instead',
+    ),
+    textDescription: deprecated(
+      PropTypes.string,
+      'Use `description` prop instead',
+    ),
+    textTag: deprecated(PropTypes.string, 'Use `subtitleTag` prop instead'),
+    myContribution: deprecated(
+      PropTypes.string,
+      'Use `manageContributionDescription` prop instead',
+    ),
+    manageContribution: deprecated(
+      PropTypes.string,
+      'Use `manageContributionLinkLabel` prop instead',
+    ),
   }
 
   isTinyVersion = () =>
@@ -156,7 +160,21 @@ class RewardCardComponent extends Component {
                 viewportIsTabletOrLess={viewportIsTabletOrLess}
               />
 
-              {!this.isSOrLessVersion() && this.renderChoiceButton()}
+              {!this.isSOrLessVersion() && (
+                <RewardCardActionOnMOrMore
+                  {...this.props}
+                  manageContributionDescription={
+                    manageContributionDescription || myContribution
+                  }
+                  manageContributionLinkLabel={
+                    manageContributionLinkLabel || manageContribution
+                  }
+                  manageContributionLinkHref={
+                    manageContributionLinkHref || manageContributionLink
+                  }
+                  isTinyVersion={this.isTinyVersion()}
+                />
+              )}
             </GridCol>
 
             {imageProps.src && (
@@ -168,48 +186,28 @@ class RewardCardComponent extends Component {
             )}
           </Grid>
 
-          {this.isSOrLessVersion() && this.renderChoiceButton()}
+          {this.isSOrLessVersion() && (
+            <RewardCardAction
+              {...this.props}
+              manageContributionDescription={
+                manageContributionDescription || myContribution
+              }
+              manageContributionLinkLabel={
+                manageContributionLinkLabel || manageContribution
+              }
+              manageContributionLinkHref={
+                manageContributionLinkHref || manageContributionLink
+              }
+              isTinyVersion={this.isTinyVersion()}
+              withTopMargin={!imageProps.src || !this.isTinyVersion()}
+            />
+          )}
         </Marger>
       </StyleRoot>
     )
   }
 
-  renderChoiceButton() {
-    const { myContribution, button } = this.props
-  }
-
-  renderButton() {
-    const {
-      button,
-      buttonOnMouseEnter,
-      buttonOnMouseLeave,
-      buttonOnClick,
-      myContribution,
-      isDisabled,
-    } = this.props
-
-    const buttonStyles = this.isTinyVersion()
-      ? styles.button.tinyVersion
-      : styles.button
-
-    if (!button) return
-
-    return (
-      <Button
-        size="big"
-        modifier="helium"
-        type="button"
-        aria-labelledby={button}
-        style={buttonStyles}
-        onMouseEnter={buttonOnMouseEnter}
-        onMouseLeave={buttonOnMouseLeave}
-        onClick={buttonOnClick}
-        disabled={isDisabled}
-      >
-        {button}
-      </Button>
-    )
-  }
+  renderButton() {}
 
   renderIconBadge() {
     return (

--- a/assets/javascripts/kitten/components/cards/reward-card.js
+++ b/assets/javascripts/kitten/components/cards/reward-card.js
@@ -76,6 +76,8 @@ class RewardCardComponent extends Component {
   isSOrLessVersion = () => this.isTinyVersion() || this.props.viewportIsSOrLess
 
   render() {
+    // Part of destructuration is needed to handle retro-compatibility with
+    // deprecated props.
     const {
       viewportIsTabletOrLess,
       titleDescription,
@@ -86,12 +88,18 @@ class RewardCardComponent extends Component {
       subtitle,
       subtitleTag,
       button,
+      buttonLabel,
       myContribution,
       manageContribution,
       manageContributionLink,
+      manageContributionDescription,
+      manageContributionLinkLabel,
+      manageContributionLinkHref,
       imageProps,
       ...others
     } = this.props
+
+    const shouldDisplayImage = imageProps && imageProps.src
 
     const cardStyles = [others.style, styles.card]
 
@@ -106,7 +114,7 @@ class RewardCardComponent extends Component {
     const leftColumnProps = this.isTinyVersion()
       ? null
       : {
-          'col-l': !imageProps.src ? 10 : 7,
+          'col-l': shouldDisplayImage ? 7 : 10,
           'col-s': 7,
         }
 
@@ -153,11 +161,12 @@ class RewardCardComponent extends Component {
                   }
                   buttonLabel={buttonLabel || button}
                   isTinyVersion={this.isTinyVersion()}
+                  isSOrLessVersion={this.isSOrLessVersion()}
                 />
               )}
             </GridCol>
 
-            {imageProps.src && (
+            {shouldDisplayImage && (
               <GridCol {...rightColumnProps} style={cardImageStyles}>
                 <Marger bottom={!myContribution ? 2 : null}>
                   {this.renderImage()}
@@ -180,6 +189,8 @@ class RewardCardComponent extends Component {
               }
               buttonLabel={buttonLabel || button}
               isTinyVersion={this.isTinyVersion()}
+              isSOrLessVersion={this.isSOrLessVersion()}
+              topMargin={shouldDisplayImage || this.isTinyVersion() ? 2 : 0}
             />
           )}
         </Marger>

--- a/assets/javascripts/kitten/components/cards/reward-card.js
+++ b/assets/javascripts/kitten/components/cards/reward-card.js
@@ -36,7 +36,7 @@ class RewardCardComponent extends Component {
     manageContributionLinkLabel: PropTypes.string,
     manageContributionLinkHref: PropTypes.string,
 
-    button: PropTypes.string,
+    buttonLabel: PropTypes.string,
     buttonOnMouseEnter: PropTypes.func,
     buttonOnMouseLeave: PropTypes.func,
     buttonOnClick: PropTypes.func,
@@ -67,6 +67,7 @@ class RewardCardComponent extends Component {
       PropTypes.string,
       'Use `manageContributionLinkLabel` prop instead',
     ),
+    button: deprecated(PropTypes.string, 'Use `buttonLabel` prop instead'),
   }
 
   isTinyVersion = () =>
@@ -76,36 +77,19 @@ class RewardCardComponent extends Component {
 
   render() {
     const {
-      isDisabled,
-      viewportIsMobile,
-      viewportIsSOrLess,
       viewportIsTabletOrLess,
-      titleAmount,
       titleDescription,
       textDescription,
+      titleTag,
+      textTag,
       description,
       subtitle,
       subtitleTag,
-      titleContributors,
-      titleDelivery,
-      titleAvailability,
-      valueContributors,
-      valueDelivery,
-      valueAvailability,
       button,
-      buttonOnMouseEnter,
-      buttonOnMouseLeave,
-      buttonOnClick,
       myContribution,
       manageContribution,
       manageContributionLink,
       imageProps,
-      titleTag,
-      textTag,
-      render,
-      starred,
-      starLabel,
-      version,
       ...others
     } = this.props
 
@@ -167,6 +151,7 @@ class RewardCardComponent extends Component {
                   manageContributionLinkHref={
                     manageContributionLinkHref || manageContributionLink
                   }
+                  buttonLabel={buttonLabel || button}
                   isTinyVersion={this.isTinyVersion()}
                 />
               )}
@@ -193,6 +178,7 @@ class RewardCardComponent extends Component {
               manageContributionLinkHref={
                 manageContributionLinkHref || manageContributionLink
               }
+              buttonLabel={buttonLabel || button}
               isTinyVersion={this.isTinyVersion()}
             />
           )}

--- a/assets/javascripts/kitten/components/cards/reward-card.js
+++ b/assets/javascripts/kitten/components/cards/reward-card.js
@@ -8,33 +8,25 @@ import {
 } from 'kitten/components/grid/grid'
 import { Button as ButtonBase } from 'kitten/components/buttons/button'
 import { StarIcon } from 'kitten/components/icons/star-icon'
-import { Title as TitleBase } from 'kitten/components/typography/title'
 import { Text as TextBase } from 'kitten/components/typography/text'
 import { Paragraph as ParagraphBase } from 'kitten/components/typography/paragraph'
 import { IconBadge as IconBadgeBase } from 'kitten/components/notifications/icon-badge'
 import { CheckedIcon } from 'kitten/components/icons/checked-icon'
-import { HorizontalStroke as HorizontalStrokeBase } from 'kitten/components/layout/horizontal-stroke'
 import COLORS from 'kitten/constants/colors-config'
 import { ScreenConfig } from 'kitten/constants/screen-config'
 import { mediaQueries } from 'kitten/hoc/media-queries'
+import { RewardCardContent } from 'kitten/components/cards/reward-card/content'
+import { RewardCardInfos } from 'kitten/components/cards/reward-card/infos'
 
 const Grid = Radium(GridBase)
 const GridCol = Radium(GridColBase)
 const Button = Radium(ButtonBase)
-const Title = Radium(TitleBase)
 const Text = Radium(TextBase)
 const Paragraph = Radium(ParagraphBase)
 const IconBadge = Radium(IconBadgeBase)
-const HorizontalStroke = Radium(HorizontalStrokeBase)
 
 class RewardCardComponent extends Component {
   static propTypes = {
-    titleAmount: PropTypes.string.isRequired,
-    titleTag: PropTypes.string,
-    titleDescription: PropTypes.string,
-    textDescription: PropTypes.string.isRequired,
-    textTag: PropTypes.string,
-
     button: PropTypes.string,
     buttonOnMouseEnter: PropTypes.func,
     buttonOnMouseLeave: PropTypes.func,
@@ -52,9 +44,6 @@ class RewardCardComponent extends Component {
   }
 
   static defaultProps = {
-    titleDescription: '',
-    titleTag: 'h1',
-    textTag: 'p',
     imageProps: {
       src: '',
       alt: '',
@@ -71,7 +60,6 @@ class RewardCardComponent extends Component {
     isDisabled: false,
     starred: false,
     starLabel: '',
-    render: () => {},
 
     version: 'default',
   }
@@ -145,7 +133,20 @@ class RewardCardComponent extends Component {
           top={this.isSOrLessVersion() ? 3 : 4}
         >
           <Grid style={cardAddPadding}>
-            <GridCol {...leftColumnProps}>{this.renderDescription()}</GridCol>
+            <GridCol {...leftColumnProps}>
+              <RewardCardContent
+                {...this.props}
+                isTinyVersion={this.isTinyVersion()}
+              />
+
+              <RewardCardInfos
+                {...this.props}
+                isTinyVersion={this.isTinyVersion()}
+                viewportIsTabletOrLess={viewportIsTabletOrLess}
+              />
+
+              {!this.isSOrLessVersion() && this.renderChoiceButton()}
+            </GridCol>
 
             {imageProps.src && (
               <GridCol {...rightColumnProps} style={cardImage}>
@@ -159,144 +160,6 @@ class RewardCardComponent extends Component {
           {this.isSOrLessVersion() && this.renderChoiceButton()}
         </Marger>
       </StyleRoot>
-    )
-  }
-
-  renderDescription() {
-    const {
-      titleAmount,
-      titleDescription,
-      textDescription,
-      titleTag,
-      textTag,
-      starred,
-      starLabel,
-      isDisabled,
-    } = this.props
-
-    const styleDescription = [isDisabled && styles.disabled]
-
-    return (
-      <Fragment>
-        <div style={styleDescription} disabled={isDisabled}>
-          {starred && (
-            <Marger bottom="2">
-              <Button
-                icon
-                readonly
-                tag="span"
-                size="tiny"
-                modifier="lithium"
-                style={{ borderRadius: 5 }}
-              >
-                <StarIcon className="k-Button__icon is-readonly" />
-                {starLabel}
-              </Button>
-            </Marger>
-          )}
-          <Marger top={starred ? 2 : 0} bottom="2">
-            <Title
-              modifier={this.isTinyVersion() ? 'quaternary' : 'tertiary'}
-              italic
-              margin={false}
-              tag={titleTag}
-              style={styles.textColor}
-            >
-              {titleAmount}
-            </Title>
-          </Marger>
-          <Marger top="2" bottom="3">
-            <HorizontalStroke size="big" />
-          </Marger>
-          {titleDescription && (
-            <Marger top="3" bottom="1">
-              <Text
-                color="font1"
-                size={this.isTinyVersion() ? 'big' : 'huge'}
-                tag={textTag}
-                weight="bold"
-                style={styles.textMargin}
-              >
-                {titleDescription}
-              </Text>
-            </Marger>
-          )}
-          <Marger top={!titleDescription ? 3 : 1}>
-            <Paragraph
-              style={styles.textColor}
-              modifier={this.isTinyVersion() ? 'quaternary' : 'tertiary'}
-              margin={false}
-            >
-              {textDescription}
-            </Paragraph>
-          </Marger>
-        </div>
-
-        {!!this.props.render && this.props.render()}
-        {this.renderInfos()}
-        {!this.isSOrLessVersion() && this.renderChoiceButton()}
-      </Fragment>
-    )
-  }
-
-  renderInfos() {
-    const {
-      titleContributors,
-      titleDelivery,
-      titleAvailability,
-      valueContributors,
-      valueDelivery,
-      valueAvailability,
-      isDisabled,
-    } = this.props
-
-    const styleInfos = [isDisabled && styles.disabled]
-
-    if (!valueContributors && !valueDelivery && !valueAvailability) return
-
-    return (
-      <div style={styleInfos} disabled={isDisabled}>
-        <Marger top="2" bottom="3">
-          {this.renderInfo(titleContributors, valueContributors)}
-          {this.renderInfo(titleDelivery, valueDelivery)}
-          {this.renderInfo(titleAvailability, valueAvailability)}
-        </Marger>
-      </div>
-    )
-  }
-
-  renderInfo(title, value) {
-    const { viewportIsTabletOrLess } = this.props
-
-    if (!title) return
-
-    const infosLists = this.isTinyVersion()
-      ? styles.infos.lists.tinyVersion
-      : styles.infos.lists
-
-    return (
-      <Fragment>
-        {(viewportIsTabletOrLess || this.isTinyVersion()) && (
-          <div>
-            <Text color="font1" weight="regular" style={infosLists}>
-              {title}{' '}
-              <Text color="font1" weight="light">
-                {value}
-              </Text>
-            </Text>
-          </div>
-        )}
-
-        {!viewportIsTabletOrLess &&
-          !this.isTinyVersion() && (
-            <Text color="font1" weight="regular" style={infosLists}>
-              {title}{' '}
-              <Text color="font1" weight="light">
-                {value}
-              </Text>
-            </Text>
-          )}
-      </Fragment>
     )
   }
 
@@ -458,7 +321,7 @@ class RewardCardComponent extends Component {
   }
 }
 
-const styles = {
+export const styles = {
   disabled: {
     filter: 'grayscale(1) opacity(.4)',
     cursor: 'not-allowed',

--- a/assets/javascripts/kitten/components/cards/reward-card/action.js
+++ b/assets/javascripts/kitten/components/cards/reward-card/action.js
@@ -95,9 +95,9 @@ const commonPropTypes = {
   buttonOnMouseEnter: PropTypes.func,
   buttonOnMouseLeave: PropTypes.func,
   buttonOnClick: PropTypes.func,
-  isDisabled: PropTypes.bool.required,
-  isTinyVersion: PropTypes.bool.required,
-  isSOrLessVersion: PropTypes.bool.required,
+  isDisabled: PropTypes.bool,
+  isTinyVersion: PropTypes.bool.isRequired,
+  isSOrLessVersion: PropTypes.bool.isRequired,
 }
 
 const commonDefaultProps = {
@@ -108,6 +108,7 @@ const commonDefaultProps = {
   buttonOnMouseEnter: () => {},
   buttonOnMouseLeave: () => {},
   buttonOnClick: () => {},
+  isDisabled: false,
   topMargin: 0,
 }
 

--- a/assets/javascripts/kitten/components/cards/reward-card/action.js
+++ b/assets/javascripts/kitten/components/cards/reward-card/action.js
@@ -1,0 +1,116 @@
+import React, { Fragment } from 'react'
+import PropTypes from 'prop-types'
+import { Marger } from 'kitten/components/layout/marger'
+import { ManageContribution } from 'kitten/components/cards/reward-card/manage-contribution'
+import { RewardCardButton } from 'kitten/components/cards/reward-card/button'
+
+export const RewardCardAction = ({
+  manageContributionDescription,
+  manageContributionLinkLabel,
+  manageContributionLinkHref,
+  buttonLabel,
+  buttonOnMouseEnter,
+  buttonOnMouseLeave,
+  buttonOnClick,
+  isDisabled,
+  isTinyVersion,
+  withTopMargin,
+}) => {
+  if (!button && !manageContributionDescription) return
+
+  return (
+    <Fragment>
+      {manageContributionDescription && (
+        <Marger
+          top={withTopMargin ? 0 : 2}
+          bottom={!manageContributionDescription ? 0 : 2}
+        >
+          <ManageContribution
+            description={manageContributionDescription}
+            linkLabel={manageContributionLinkLabel}
+            linkHref={manageContributionLinkHref}
+            isDisabled={isDisabled}
+            isTinyVersion={isTinyVersion}
+          />
+        </Marger>
+      )}
+      <RewardCardButton
+        label={buttonLabel}
+        onMouseEnter={buttonOnMouseEnter}
+        onMouseLeave={buttonOnMouseLeave}
+        onClick={buttonOnClick}
+        isDisabled={isDisabled}
+        isTinyVersion={isTinyVersion}
+      />
+    </Fragment>
+  )
+}
+
+export const RewardCardActionOnMOrMore = ({
+  manageContributionDescription,
+  manageContributionLinkLabel,
+  manageContributionLinkHref,
+  isDisabled,
+  isTinyVersion,
+  button,
+}) => {
+  if (!button && !manageContributionDescription) return
+
+  return (
+    <Fragment>
+      <Marger top="3">
+        <RewardCardButton
+          label={buttonLabel}
+          onMouseEnter={buttonOnMouseEnter}
+          onMouseLeave={buttonOnMouseLeave}
+          onClick={buttonOnClick}
+          isDisabled={isDisabled}
+          isTinyVersion={isTinyVersion}
+        />
+        {manageContributionDescription && (
+          <Marger top={!manageContributionDescription ? 0 : 2}>
+            <ManageContribution
+              description={manageContributionDescription}
+              linkLabel={manageContributionLinkLabel}
+              linkHref={manageContributionLinkHref}
+              isDisabled={isDisabled}
+              isTinyVersion={isTinyVersion}
+            />
+          </Marger>
+        )}
+      </Marger>
+    </Fragment>
+  )
+}
+
+const commonPropTypes = {
+  manageContributionDescription: PropTypes.string,
+  manageContributionLinkLabel: PropTypes.string,
+  manageContributionLinkHref: PropTypes.string,
+  buttonLabel: PropTypes.string,
+  buttonOnMouseEnter: PropTypes.func,
+  buttonOnMouseLeave: PropTypes.func,
+  buttonOnClick: PropTypes.func,
+  isDisabled: PropTypes.bool.required,
+  isTinyVersion: PropTypes.bool.required,
+}
+
+const commonDefaultProps = {
+  manageContributionDescription: '',
+  manageContributionLinkLabel: '',
+  manageContributionLinkHref: '',
+  buttonLabel: '',
+  buttonOnMouseEnter: () => {},
+  buttonOnMouseLeave: () => {},
+  buttonOnClick: () => {},
+  withTopMargin: false,
+}
+
+RewardCardAction.propTypes = {
+  ...commonPropTypes,
+  withTopMargin: PropTypes.bool,
+}
+
+RewardCardAction.defaultProps = { ...commonDefaultProps }
+RewardCardActionOnMOrMore.propTypes = { ...commonPropTypes }
+RewardCardActionOnMOrMore.defaultProps = { ...commonDefaultProps }

--- a/assets/javascripts/kitten/components/cards/reward-card/action.js
+++ b/assets/javascripts/kitten/components/cards/reward-card/action.js
@@ -14,23 +14,22 @@ export const RewardCardAction = ({
   buttonOnClick,
   isDisabled,
   isTinyVersion,
-  withTopMargin,
+  isSOrLessVersion,
+  topMargin,
 }) => {
-  if (!button && !manageContributionDescription) return
+  if (!buttonLabel && !manageContributionDescription) return
 
   return (
     <Fragment>
       {manageContributionDescription && (
-        <Marger
-          top={withTopMargin ? 0 : 2}
-          bottom={!manageContributionDescription ? 0 : 2}
-        >
+        <Marger top={topMargin} bottom={!manageContributionDescription ? 0 : 2}>
           <ManageContribution
             description={manageContributionDescription}
             linkLabel={manageContributionLinkLabel}
             linkHref={manageContributionLinkHref}
             isDisabled={isDisabled}
             isTinyVersion={isTinyVersion}
+            isSOrLessVersion={isSOrLessVersion}
           />
         </Marger>
       )}
@@ -50,11 +49,15 @@ export const RewardCardActionOnMOrMore = ({
   manageContributionDescription,
   manageContributionLinkLabel,
   manageContributionLinkHref,
+  buttonLabel,
+  buttonOnMouseEnter,
+  buttonOnMouseLeave,
+  buttonOnClick,
   isDisabled,
   isTinyVersion,
-  button,
+  isSOrLessVersion,
 }) => {
-  if (!button && !manageContributionDescription) return
+  if (!buttonLabel && !manageContributionDescription) return
 
   return (
     <Fragment>
@@ -75,6 +78,7 @@ export const RewardCardActionOnMOrMore = ({
               linkHref={manageContributionLinkHref}
               isDisabled={isDisabled}
               isTinyVersion={isTinyVersion}
+              isSOrLessVersion={isSOrLessVersion}
             />
           </Marger>
         )}
@@ -93,6 +97,7 @@ const commonPropTypes = {
   buttonOnClick: PropTypes.func,
   isDisabled: PropTypes.bool.required,
   isTinyVersion: PropTypes.bool.required,
+  isSOrLessVersion: PropTypes.bool.required,
 }
 
 const commonDefaultProps = {
@@ -103,12 +108,12 @@ const commonDefaultProps = {
   buttonOnMouseEnter: () => {},
   buttonOnMouseLeave: () => {},
   buttonOnClick: () => {},
-  withTopMargin: false,
+  topMargin: 0,
 }
 
 RewardCardAction.propTypes = {
   ...commonPropTypes,
-  withTopMargin: PropTypes.bool,
+  topMargin: PropTypes.number,
 }
 
 RewardCardAction.defaultProps = { ...commonDefaultProps }

--- a/assets/javascripts/kitten/components/cards/reward-card/button.js
+++ b/assets/javascripts/kitten/components/cards/reward-card/button.js
@@ -40,8 +40,8 @@ RewardCardButton.propTypes = {
   onMouseEnter: PropTypes.func,
   onMouseLeave: PropTypes.func,
   onClick: PropTypes.func,
-  isDisabled: PropTypes.bool.required,
-  isTinyVersion: PropTypes.bool.required,
+  isDisabled: PropTypes.bool,
+  isTinyVersion: PropTypes.bool.isRequired,
 }
 
 RewardCardButton.defaultProps = {
@@ -49,4 +49,5 @@ RewardCardButton.defaultProps = {
   onMouseEnter: () => {},
   onMouseLeave: () => {},
   onClick: () => {},
+  disabled: false,
 }

--- a/assets/javascripts/kitten/components/cards/reward-card/button.js
+++ b/assets/javascripts/kitten/components/cards/reward-card/button.js
@@ -14,9 +14,9 @@ export const RewardCardButton = ({
   isDisabled,
   isTinyVersion,
 }) => {
-  const buttonStyles = isTinyVersion ? styles.button.tinyVersion : styles.button
+  if (!label) return null
 
-  if (!button) return
+  const buttonStyles = isTinyVersion ? styles.button.tinyVersion : styles.button
 
   return (
     <Button

--- a/assets/javascripts/kitten/components/cards/reward-card/button.js
+++ b/assets/javascripts/kitten/components/cards/reward-card/button.js
@@ -1,0 +1,52 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Radium from 'radium'
+import { Button as ButtonBase } from 'kitten/components/buttons/button'
+import { styles } from 'kitten/components/cards/reward-card'
+
+const Button = Radium(ButtonBase)
+
+export const RewardCardButton = ({
+  label,
+  onMouseEnter,
+  onMouseLeave,
+  onClick,
+  isDisabled,
+  isTinyVersion,
+}) => {
+  const buttonStyles = isTinyVersion ? styles.button.tinyVersion : styles.button
+
+  if (!button) return
+
+  return (
+    <Button
+      size="big"
+      modifier="helium"
+      type="button"
+      aria-labelledby={label}
+      style={buttonStyles}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      onClick={onClick}
+      disabled={isDisabled}
+    >
+      {label}
+    </Button>
+  )
+}
+
+RewardCardButton.propTypes = {
+  label: PropTypes.string,
+  onMouseEnter: PropTypes.func,
+  onMouseLeave: PropTypes.func,
+  onClick: PropTypes.func,
+  isDisabled: PropTypes.bool.required,
+  isTinyVersion: PropTypes.bool.required,
+}
+
+RewardCardButton.defaultProps = {
+  label: '',
+  onMouseEnter: () => {},
+  onMouseLeave: () => {},
+  onClick: () => {},
+}

--- a/assets/javascripts/kitten/components/cards/reward-card/checked-icon.js
+++ b/assets/javascripts/kitten/components/cards/reward-card/checked-icon.js
@@ -1,0 +1,13 @@
+import React from 'react'
+import Radium from 'radium'
+import { IconBadge as IconBadgeBase } from 'kitten/components/notifications/icon-badge'
+import { CheckedIcon } from 'kitten/components/icons/checked-icon'
+import { styles } from 'kitten/components/cards/reward-card'
+
+const IconBadge = Radium(IconBadgeBase)
+
+export const RewardCardCheckedIcon = () => (
+  <IconBadge valid style={styles.iconBadge}>
+    <CheckedIcon className="k-IconBadge__svg" />
+  </IconBadge>
+)

--- a/assets/javascripts/kitten/components/cards/reward-card/content.js
+++ b/assets/javascripts/kitten/components/cards/reward-card/content.js
@@ -1,7 +1,6 @@
 import React, { Fragment } from 'react'
 import PropTypes from 'prop-types'
 import { styles } from 'kitten/components/cards/reward-card'
-import deprecated from 'prop-types-extra/lib/deprecated'
 import { Marger } from 'kitten/components/layout/marger'
 import { Title } from 'kitten/components/typography/title'
 import { Button } from 'kitten/components/buttons/button'
@@ -86,11 +85,12 @@ RewardCardContent.propTypes = {
   titleTag: PropTypes.string,
   subtitle: PropTypes.string,
   subtitleTag: PropTypes.string,
-  description: PropTypes.string.isRequired,
+  description: PropTypes.string,
 }
 
 RewardCardContent.defaultProps = {
   titleTag: 'h1',
   subtitle: '',
   subtitleTag: 'p',
+  description: '',
 }

--- a/assets/javascripts/kitten/components/cards/reward-card/content.js
+++ b/assets/javascripts/kitten/components/cards/reward-card/content.js
@@ -1,0 +1,112 @@
+import React, { Fragment } from 'react'
+import PropTypes from 'prop-types'
+import { styles } from 'kitten/components/cards/reward-card'
+import deprecated from 'prop-types-extra/lib/deprecated'
+import { Marger } from 'kitten/components/layout/marger'
+import { Title } from 'kitten/components/typography/title'
+import { Button } from 'kitten/components/buttons/button'
+import { HorizontalStroke } from 'kitten/components/layout/horizontal-stroke'
+import { Paragraph } from 'kitten/components/typography/paragraph'
+import { Text } from 'kitten/components/typography/text'
+
+export const RewardCardContent = ({
+  titleAmount,
+  titleTag,
+  subtitle,
+  subtitleTag,
+  description,
+  starred,
+  starLabel,
+  isDisabled,
+  isTinyVersion,
+  titleDescription,
+  textDescription,
+  textTag,
+}) => {
+  const descriptionStyle = [isDisabled && styles.disabled]
+  const subtitleText = subtitle || titleDescription
+  const subtitleTagname = subtitleTag || textTag
+  const descriptionText = description || textDescription
+
+  return (
+    <Fragment>
+      <div style={descriptionStyle} disabled={isDisabled}>
+        {starred && (
+          <Marger bottom="2">
+            <Button
+              icon
+              readonly
+              tag="span"
+              size="tiny"
+              modifier="lithium"
+              style={{ borderRadius: 5 }}
+            >
+              <StarIcon className="k-Button__icon is-readonly" />
+              {starLabel}
+            </Button>
+          </Marger>
+        )}
+        <Marger top={starred ? 2 : 0} bottom="2">
+          <Title
+            modifier={isTinyVersion ? 'quaternary' : 'tertiary'}
+            italic
+            margin={false}
+            tag={titleTag}
+            style={styles.textColor}
+          >
+            {titleAmount}
+          </Title>
+        </Marger>
+        <Marger top="2" bottom="3">
+          <HorizontalStroke size="big" />
+        </Marger>
+        {subtitleText && (
+          <Marger top="3" bottom="1">
+            <Text
+              color="font1"
+              size={isTinyVersion ? 'big' : 'huge'}
+              tag={subtitleTagname}
+              weight="bold"
+              style={styles.textMargin}
+            >
+              {subtitleText}
+            </Text>
+          </Marger>
+        )}
+        <Marger top={!subtitleText ? 3 : 1}>
+          <Paragraph
+            style={styles.textColor}
+            modifier={isTinyVersion ? 'quaternary' : 'tertiary'}
+            margin={false}
+          >
+            {descriptionText}
+          </Paragraph>
+        </Marger>
+      </div>
+    </Fragment>
+  )
+}
+
+RewardCardContent.propTypes = {
+  titleAmount: PropTypes.string.isRequired,
+  titleTag: PropTypes.string,
+  subtitle: PropTypes.string,
+  subtitleTag: PropTypes.string,
+  description: PropTypes.string.isRequired,
+
+  titleDescription: deprecated(PropTypes.string, 'Use `subtitle` prop instead'),
+  textDescription: deprecated(
+    PropTypes.string,
+    'Use `description` prop instead',
+  ),
+  textTag: deprecated(PropTypes.string, 'Use `subtitleTag` prop instead'),
+}
+
+RewardCardContent.defaultProps = {
+  titleTag: 'h1',
+  subtitle: '',
+  subtitleTag: 'p',
+
+  titleDescription: '',
+  textTag: 'p',
+}

--- a/assets/javascripts/kitten/components/cards/reward-card/content.js
+++ b/assets/javascripts/kitten/components/cards/reward-card/content.js
@@ -53,26 +53,26 @@ export const RewardCardContent = ({
         <Marger top="2" bottom="3">
           <HorizontalStroke size="big" />
         </Marger>
-        {subtitleText && (
+        {subtitle && (
           <Marger top="3" bottom="1">
             <Text
               color="font1"
               size={isTinyVersion ? 'big' : 'huge'}
-              tag={subtitleTagname}
+              tag={subtitleTag}
               weight="bold"
               style={styles.textMargin}
             >
-              {subtitleText}
+              {subtitle}
             </Text>
           </Marger>
         )}
-        <Marger top={!subtitleText ? 3 : 1}>
+        <Marger top={!subtitle ? 3 : 1}>
           <Paragraph
             style={styles.textColor}
             modifier={isTinyVersion ? 'quaternary' : 'tertiary'}
             margin={false}
           >
-            {descriptionText}
+            {description}
           </Paragraph>
         </Marger>
       </div>

--- a/assets/javascripts/kitten/components/cards/reward-card/content.js
+++ b/assets/javascripts/kitten/components/cards/reward-card/content.js
@@ -19,14 +19,8 @@ export const RewardCardContent = ({
   starLabel,
   isDisabled,
   isTinyVersion,
-  titleDescription,
-  textDescription,
-  textTag,
 }) => {
   const descriptionStyle = [isDisabled && styles.disabled]
-  const subtitleText = subtitle || titleDescription
-  const subtitleTagname = subtitleTag || textTag
-  const descriptionText = description || textDescription
 
   return (
     <Fragment>
@@ -93,20 +87,10 @@ RewardCardContent.propTypes = {
   subtitle: PropTypes.string,
   subtitleTag: PropTypes.string,
   description: PropTypes.string.isRequired,
-
-  titleDescription: deprecated(PropTypes.string, 'Use `subtitle` prop instead'),
-  textDescription: deprecated(
-    PropTypes.string,
-    'Use `description` prop instead',
-  ),
-  textTag: deprecated(PropTypes.string, 'Use `subtitleTag` prop instead'),
 }
 
 RewardCardContent.defaultProps = {
   titleTag: 'h1',
   subtitle: '',
   subtitleTag: 'p',
-
-  titleDescription: '',
-  textTag: 'p',
 }

--- a/assets/javascripts/kitten/components/cards/reward-card/info.js
+++ b/assets/javascripts/kitten/components/cards/reward-card/info.js
@@ -39,8 +39,8 @@ export const Info = ({
 Info.propTypes = {
   label: PropTypes.string,
   value: PropTypes.string,
-  viewportIsTabletOrLess: PropTypes.bool.required,
-  isTinyVersion: PropTypes.bool.required,
+  viewportIsTabletOrLess: PropTypes.bool.isRequired,
+  isTinyVersion: PropTypes.bool.isRequired,
 }
 
 Info.defaultProps = {

--- a/assets/javascripts/kitten/components/cards/reward-card/info.js
+++ b/assets/javascripts/kitten/components/cards/reward-card/info.js
@@ -12,7 +12,7 @@ export const Info = ({
   viewportIsTabletOrLess,
   isTinyVersion,
 }) => {
-  if (!label) return
+  if (!label) return null
 
   const infosLists = isTinyVersion
     ? styles.infos.lists.tinyVersion
@@ -31,7 +31,7 @@ export const Info = ({
     <Fragment>
       {(viewportIsTabletOrLess || isTinyVersion) && <div>{InfoBase}</div>}
 
-      {!viewportIsTabletOrLess && !this.isTinyVersion() && InfoBase}
+      {!viewportIsTabletOrLess && !isTinyVersion && InfoBase}
     </Fragment>
   )
 }

--- a/assets/javascripts/kitten/components/cards/reward-card/info.js
+++ b/assets/javascripts/kitten/components/cards/reward-card/info.js
@@ -1,0 +1,49 @@
+import React, { Fragment } from 'react'
+import Radium from 'radium'
+import PropTypes from 'prop-types'
+import { Text as TextBase } from 'kitten/components/typography/text'
+import { styles } from 'kitten/components/cards/reward-card'
+
+const Text = Radium(TextBase)
+
+export const Info = ({
+  label,
+  value,
+  viewportIsTabletOrLess,
+  isTinyVersion,
+}) => {
+  if (!label) return
+
+  const infosLists = isTinyVersion
+    ? styles.infos.lists.tinyVersion
+    : styles.infos.lists
+
+  const InfoBase = (
+    <Text color="font1" weight="regular" style={infosLists}>
+      {`${label} `}
+      <Text color="font1" weight="light">
+        {value}
+      </Text>
+    </Text>
+  )
+
+  return (
+    <Fragment>
+      {(viewportIsTabletOrLess || isTinyVersion) && <div>{InfoBase}</div>}
+
+      {!viewportIsTabletOrLess && !this.isTinyVersion() && InfoBase}
+    </Fragment>
+  )
+}
+
+Info.propTypes = {
+  label: PropTypes.string,
+  value: PropTypes.string,
+  viewportIsTabletOrLess: PropTypes.bool.required,
+  isTinyVersion: PropTypes.bool.required,
+}
+
+Info.defaultProps = {
+  label: null,
+  value: null,
+}

--- a/assets/javascripts/kitten/components/cards/reward-card/infos.js
+++ b/assets/javascripts/kitten/components/cards/reward-card/infos.js
@@ -1,0 +1,44 @@
+import React, { Fragment } from 'react'
+import PropTypes from 'prop-types'
+import { styles } from 'kitten/components/cards/reward-card'
+import { Info } from 'kitten/components/cards/reward-card/info'
+import { Marger } from 'kitten/components/layout/marger'
+
+export const RewardCardInfos = ({
+  infos,
+  isDisabled,
+  viewportIsTabletOrLess,
+  isTinyVersion,
+}) => {
+  const styleInfos = [isDisabled && styles.disabled]
+
+  if (infos.length === 0) return null
+
+  return (
+    <div style={styleInfos} disabled={isDisabled}>
+      <Marger top="2" bottom="3">
+        {infos &&
+          infos.map(info => (
+            <Info
+              key={info.label}
+              label={info.label}
+              value={info.value}
+              viewportIsTabletOrLess={viewportIsTabletOrLess}
+              isTinyVersion={isTinyVersion}
+            />
+          ))}
+      </Marger>
+    </div>
+  )
+}
+
+RewardCardInfos.propTypes = {
+  infos: PropTypes.array,
+  isDisabled: PropTypes.bool.required,
+  viewportIsTabletOrLess: PropTypes.bool.required,
+  isTinyVersion: PropTypes.bool.required,
+}
+
+RewardCardInfos.defaultProps = {
+  infos: [],
+}

--- a/assets/javascripts/kitten/components/cards/reward-card/infos.js
+++ b/assets/javascripts/kitten/components/cards/reward-card/infos.js
@@ -34,11 +34,12 @@ export const RewardCardInfos = ({
 
 RewardCardInfos.propTypes = {
   infos: PropTypes.array,
-  isDisabled: PropTypes.bool.required,
-  viewportIsTabletOrLess: PropTypes.bool.required,
-  isTinyVersion: PropTypes.bool.required,
+  isDisabled: PropTypes.bool,
+  viewportIsTabletOrLess: PropTypes.bool.isRequired,
+  isTinyVersion: PropTypes.bool.isRequired,
 }
 
 RewardCardInfos.defaultProps = {
   infos: [],
+  isDisabled: false,
 }

--- a/assets/javascripts/kitten/components/cards/reward-card/manage-contribution.js
+++ b/assets/javascripts/kitten/components/cards/reward-card/manage-contribution.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import Radium from 'radium'
 import { Grid as GridBase, GridCol } from 'kitten/components/grid/grid'
 import { Text } from 'kitten/components/typography/text'
+import { RewardCardCheckedIcon } from 'kitten/components/cards/reward-card/checked-icon'
 import { styles } from 'kitten/components/cards/reward-card'
 
 const Grid = Radium(GridBase)
@@ -27,7 +28,7 @@ export const ManageContribution = ({
         <Grid style={choiceButtonPaddings}>
           <GridCol>
             <div style={styles.myContribution}>
-              {this.renderIconBadge()}
+              <RewardCardCheckedIcon />
               <div style={styles.myContribution.text}>
                 <Text color="font1" size="tiny" weight="regular">
                   {description}
@@ -50,7 +51,7 @@ export const ManageContribution = ({
 
       {!isSOrLessVersion && (
         <div style={styles.myContribution}>
-          {this.renderIconBadge()}
+          <RewardCardCheckedIcon />
           <div style={styles.myContribution.text}>
             <Text color="font1" size="tiny" weight="regular">
               {description}

--- a/assets/javascripts/kitten/components/cards/reward-card/manage-contribution.js
+++ b/assets/javascripts/kitten/components/cards/reward-card/manage-contribution.js
@@ -15,14 +15,14 @@ export const ManageContribution = ({
 }) => {
   if (!description || (isTinyVersion && isDisabled)) return
 
-  const choiceButtonAddPadding = isTinyVersion
-    ? styles.choiceButton.addPadding.tinyVersion
-    : styles.choiceButton.addPadding
+  const choiceButtonPaddings = isTinyVersion
+    ? styles.choiceButton.paddings.tinyVersion
+    : styles.choiceButton.paddings
 
   return (
     <Fragment>
       {this.isSOrLessVersion() && (
-        <Grid style={choiceButtonAddPadding}>
+        <Grid style={choiceButtonPaddings}>
           <GridCol>
             <div style={styles.myContribution}>
               {this.renderIconBadge()}

--- a/assets/javascripts/kitten/components/cards/reward-card/manage-contribution.js
+++ b/assets/javascripts/kitten/components/cards/reward-card/manage-contribution.js
@@ -1,0 +1,84 @@
+import React, { Fragment } from 'react'
+import PropTypes from 'prop-types'
+import Radium from 'radium'
+import { Grid as GridBase, GridCol } from 'kitten/components/grid/grid'
+import { Text } from 'kitten/components/typography/text'
+
+const Grid = Radium(GridBase)
+
+export const ManageContribution = ({
+  description,
+  linkLabel,
+  linkHref,
+  isDisabled,
+  isTinyVersion,
+}) => {
+  if (!description || (isTinyVersion && isDisabled)) return
+
+  const choiceButtonAddPadding = isTinyVersion
+    ? styles.choiceButton.addPadding.tinyVersion
+    : styles.choiceButton.addPadding
+
+  return (
+    <Fragment>
+      {this.isSOrLessVersion() && (
+        <Grid style={choiceButtonAddPadding}>
+          <GridCol>
+            <div style={styles.myContribution}>
+              {this.renderIconBadge()}
+              <div style={styles.myContribution.text}>
+                <Text color="font1" size="tiny" weight="regular">
+                  {description}
+                  <br />
+                  <Text
+                    tag="a"
+                    href={linkHref}
+                    color="primary1"
+                    weight="regular"
+                    decoration="none"
+                  >
+                    {linkLabel}
+                  </Text>
+                </Text>
+              </div>
+            </div>
+          </GridCol>
+        </Grid>
+      )}
+
+      {!this.isSOrLessVersion() && (
+        <div style={styles.myContribution}>
+          {this.renderIconBadge()}
+          <div style={styles.myContribution.text}>
+            <Text color="font1" size="tiny" weight="regular">
+              {description}
+              <br />
+              <Text
+                tag="a"
+                href={linkHref}
+                color="primary1"
+                weight="regular"
+                decoration="none"
+              >
+                {linkLabel}
+              </Text>
+            </Text>
+          </div>
+        </div>
+      )}
+    </Fragment>
+  )
+}
+
+ManageContribution.propTypes = {
+  description: PropTypes.string,
+  linkLabel: PropTypes.string,
+  linkHref: PropTypes.string,
+  isDisabled: PropTypes.bool.required,
+}
+
+ManageContribution.defaultProps = {
+  description: '',
+  linkLabel: '',
+  linkHref: '',
+}

--- a/assets/javascripts/kitten/components/cards/reward-card/manage-contribution.js
+++ b/assets/javascripts/kitten/components/cards/reward-card/manage-contribution.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import Radium from 'radium'
 import { Grid as GridBase, GridCol } from 'kitten/components/grid/grid'
 import { Text } from 'kitten/components/typography/text'
+import { styles } from 'kitten/components/cards/reward-card'
 
 const Grid = Radium(GridBase)
 
@@ -12,6 +13,7 @@ export const ManageContribution = ({
   linkHref,
   isDisabled,
   isTinyVersion,
+  isSOrLessVersion,
 }) => {
   if (!description || (isTinyVersion && isDisabled)) return
 
@@ -21,7 +23,7 @@ export const ManageContribution = ({
 
   return (
     <Fragment>
-      {this.isSOrLessVersion() && (
+      {isSOrLessVersion && (
         <Grid style={choiceButtonPaddings}>
           <GridCol>
             <div style={styles.myContribution}>
@@ -46,7 +48,7 @@ export const ManageContribution = ({
         </Grid>
       )}
 
-      {!this.isSOrLessVersion() && (
+      {!isSOrLessVersion && (
         <div style={styles.myContribution}>
           {this.renderIconBadge()}
           <div style={styles.myContribution.text}>
@@ -75,6 +77,8 @@ ManageContribution.propTypes = {
   linkLabel: PropTypes.string,
   linkHref: PropTypes.string,
   isDisabled: PropTypes.bool.required,
+  isTinyVersion: PropTypes.bool.required,
+  isSOrLessVersion: PropTypes.bool.required,
 }
 
 ManageContribution.defaultProps = {

--- a/assets/javascripts/kitten/components/cards/reward-card/manage-contribution.js
+++ b/assets/javascripts/kitten/components/cards/reward-card/manage-contribution.js
@@ -77,13 +77,14 @@ ManageContribution.propTypes = {
   description: PropTypes.string,
   linkLabel: PropTypes.string,
   linkHref: PropTypes.string,
-  isDisabled: PropTypes.bool.required,
-  isTinyVersion: PropTypes.bool.required,
-  isSOrLessVersion: PropTypes.bool.required,
+  isDisabled: PropTypes.bool,
+  isTinyVersion: PropTypes.bool.isRequired,
+  isSOrLessVersion: PropTypes.bool.isRequired,
 }
 
 ManageContribution.defaultProps = {
   description: '',
   linkLabel: '',
   linkHref: '',
+  isDisabled: false,
 }


### PR DESCRIPTION
Le composant `RewardCard` gère énormément de cas et est compliqué à lire. Dans cette PR : 
- je l'ai donc splitté en plusieurs composants
- j'ai renommé des props pour qu'elles soient plus explicites
- j'ai retiré des ternaires trop lourdes à lire
- j'ai géré la retro-compatibilité avec les anciennes props

J'ai choisi de mettre des PropTypes partout car on est sur un composant Kitten (et également parce que ça me permettait de cleaner plus facilement).