### PR TITLE
[Storybook] Update release task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -68,6 +68,9 @@ task kitten_release: [:sassdoc, :build] do
   sh 'bin/install'
   sh 'npm publish'
 
+  # Deploy storybook
+  sh 'yarn deploy-storybook'
+
   # Move the styleguide branch to the latest version
   sh 'git checkout styleguide'
   sh 'git merge --ff-only master'


### PR DESCRIPTION
Cette PR ajoute le déploiement de Storybook dans la tâche de release de Kitten. 

On pourrait à terme voir si on peut brancher le déploiement de Storybook sur le CI pour l'avoir à jour à chaque fois que `master` est mis à jour. Cela nécessite quelques recherches sur les droits d'écriture. En attendant, l'avoir dans la release est déjà un premier pas.