### PR TITLE
[RewardCard] Enable props to spread on root tag

### DIFF
--- a/assets/javascripts/kitten/components/cards/reward-card.js
+++ b/assets/javascripts/kitten/components/cards/reward-card.js
@@ -205,12 +205,16 @@ export class RewardCard extends Component {
   }
 
   render() {
-    const { children } = this.props
+    const { children, ...others } = this.props
 
     return (
       <Fragment>
         <LegacyRewardCardContainer {...this.props} />
-        {children && <div style={style.card}>{children}</div>}
+        {children && (
+          <div {...others} style={style.card}>
+            {children}
+          </div>
+        )}
       </Fragment>
     )
   }


### PR DESCRIPTION
Cette PR permet de pouvoir passer des attributs de DOM à la balise racine du composant `RewardCard`. Entre-autre, cela permet sur KissKiss de pouvoir passer l'attribut `data-test-id`.

De manière générale, j'ai l'impression qu'on devrait pouvoir autoriser le spread operator sur les props restantes après assignation des props spécifiques sur les composants dont la "balise parent" est un élément de DOM (et non un composant React).

Je ne mets pas le `CHANGELOG` à jour car cela correspond toujours à la modification de l'intégration de la `RewardCard` mentionnée dans #1374.