### PR TITLE
 [ProjectPage] Deprecate viewportIsMobile and viewportIsTabletOrLess on mediaQueries HOC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [unreleased]
 
 - Feature: Add animation on `List.ButtonItem` hover.
-- Feature: Add new viewport range to MediaQueries HOC.
+- Feature: Add new viewport range to mediaQueries HOC.
+- Feature: Deprecated `viewportIsMobile` and `viewportIsTabletOrLess` on
+  mediaQueries HOC. Please use `viewportIsXS` and `viewportIsMOrLess` instead
+  now.
 
 ## [23.12.0] - 2018-11-15
 

--- a/assets/javascripts/kitten/hoc/media-queries.js
+++ b/assets/javascripts/kitten/hoc/media-queries.js
@@ -14,7 +14,7 @@ const viewPortTable = {
   viewportIsMobile: SCREEN_SIZE_XS,
   viewportIsTabletOrLess: SCREEN_SIZE_M,
 
-  viewportIsXSOrLess: SCREEN_SIZE_XS,
+  viewportIsXS: SCREEN_SIZE_XS,
   viewportIsSOrLess: SCREEN_SIZE_S,
   viewportIsMOrLess: SCREEN_SIZE_M,
   viewportIsLOrLess: SCREEN_SIZE_L,
@@ -52,7 +52,7 @@ export const mediaQueries = (WrappedComponent, hocProps = {}) =>
 
     warnIfHocPropIsDeprecated(prop) {
       const deprecatedPropsToNewProps = {
-        viewportIsMobile: 'viewportIsXSOrLess',
+        viewportIsMobile: 'viewportIsXS',
         viewportIsTabletOrLess: 'viewportIsMOrLess',
       }
 

--- a/assets/javascripts/kitten/hoc/media-queries.js
+++ b/assets/javascripts/kitten/hoc/media-queries.js
@@ -12,8 +12,11 @@ import {
 
 const viewPortTable = {
   viewportIsMobile: SCREEN_SIZE_XS,
-  viewportIsSOrLess: SCREEN_SIZE_S,
   viewportIsTabletOrLess: SCREEN_SIZE_M,
+
+  viewportIsXSOrLess: SCREEN_SIZE_XS,
+  viewportIsSOrLess: SCREEN_SIZE_S,
+  viewportIsMOrLess: SCREEN_SIZE_M,
   viewportIsLOrLess: SCREEN_SIZE_L,
 }
 
@@ -47,12 +50,28 @@ export const mediaQueries = (WrappedComponent, hocProps = {}) =>
       )
     }
 
+    warnIfHocPropIsDeprecated(prop) {
+      const deprecatedPropsToNewProps = {
+        viewportIsMobile: 'viewportIsXSOrLess',
+        viewportIsTabletOrLess: 'viewportIsMOrLess',
+      }
+
+      if (Object.keys(deprecatedPropsToNewProps).includes(prop)) {
+        console.warn(
+          `${prop} is deprecated. Please use ${
+            deprecatedPropsToNewProps[prop]
+          } instead now.`,
+        )
+      }
+    }
+
     componentDidMount() {
       for (let prop in hocProps) {
         const propValue = hocProps[prop]
         if (this.isInvalidProp(prop)) {
           break
         }
+        this.warnIfHocPropIsDeprecated(prop)
         this.viewports[prop] =
           typeof propValue === 'boolean'
             ? createMatchMediaMax(viewPortTable[prop])

--- a/assets/javascripts/kitten/hoc/media-queries.test.js
+++ b/assets/javascripts/kitten/hoc/media-queries.test.js
@@ -7,7 +7,7 @@ class SimpleComponent extends Component {
     const {
       viewportIsMobile,
       viewportIsTabletOrLess,
-      viewportIsXSOrLess,
+      viewportIsXS,
       viewportIsSOrLess,
       viewportIsMOrLess,
       viewportIsLOrLess,
@@ -47,7 +47,7 @@ describe('mediaQueries()', () => {
   describe('by default', () => {
     beforeEach(() => {
       SimpleComponentWithMediaQueries = mediaQueries(SimpleComponent, {
-        viewportIsXSOrLess: true,
+        viewportIsXS: true,
         viewportIsSOrLess: true,
         viewportIsMOrLess: true,
         viewportIsLOrLess: true,
@@ -65,7 +65,7 @@ describe('mediaQueries()', () => {
     it('pushes media queries props to wrapped component', () => {
       const wrappedComponent = component.find(SimpleComponent).first()
 
-      expect(wrappedComponent.prop('viewportIsXSOrLess')).toBeFalsy()
+      expect(wrappedComponent.prop('viewportIsXS')).toBeFalsy()
       expect(wrappedComponent.prop('viewportIsSOrLess')).toBeFalsy()
       expect(wrappedComponent.prop('viewportIsMOrLess')).toBeFalsy()
       expect(wrappedComponent.prop('viewportIsLOrLess')).toBeFalsy()
@@ -93,7 +93,7 @@ describe('mediaQueries()', () => {
     it('pushes media queries props to wrapped component', () => {
       const wrappedComponent = component.find(SimpleComponent).first()
 
-      expect(wrappedComponent.prop('viewportIsXSOrLess')).toBeFalsy()
+      expect(wrappedComponent.prop('viewportIsXS')).toBeFalsy()
       expect(wrappedComponent.prop('viewportIsSOrLess')).toBeFalsy()
       expect(wrappedComponent.prop('viewportIsMOrLess')).toBeTruthy()
       expect(wrappedComponent.prop('viewportIsLOrLess')).toBeFalsy()
@@ -112,7 +112,7 @@ describe('mediaQueries()', () => {
     it('pushes media queries props to wrapped component', () => {
       const wrappedComponent = component.find(SimpleComponent).first()
 
-      expect(wrappedComponent.prop('viewportIsXSOrLess')).toBeFalsy()
+      expect(wrappedComponent.prop('viewportIsXS')).toBeFalsy()
       expect(wrappedComponent.prop('viewportIsSOrLess')).toBeTruthy()
       expect(wrappedComponent.prop('viewportIsMOrLess')).toBeFalsy()
       expect(wrappedComponent.prop('viewportIsLOrLess')).toBeFalsy()
@@ -132,7 +132,7 @@ describe('mediaQueries()', () => {
       const wrappedComponent = component.find(SimpleComponent).first()
 
       expect(wrappedComponent.prop('myCustomMediaQuery')).toBeDefined()
-      expect(wrappedComponent.prop('viewportIsXSOrLess')).toBeFalsy()
+      expect(wrappedComponent.prop('viewportIsXS')).toBeFalsy()
       expect(wrappedComponent.prop('viewportIsSOrLess')).toBeFalsy()
       expect(wrappedComponent.prop('viewportIsMOrLess')).toBeFalsy()
       expect(wrappedComponent.prop('viewportIsLOrLess')).toBeFalsy()

--- a/assets/javascripts/kitten/hoc/media-queries.test.js
+++ b/assets/javascripts/kitten/hoc/media-queries.test.js
@@ -1,15 +1,22 @@
-import React from 'react'
+import React, { Component } from 'react'
 import renderer from 'react-test-renderer'
 import { mediaQueries } from 'kitten/hoc/media-queries'
 
-const SimpleComponent = ({
-  viewportIsMobile,
-  viewportIsTabletOrLess,
-  viewportIsSOrLess,
-  myCustomMediaQuery,
-  ...props
-}) => {
-  return <div title="Test me!" {...props} />
+class SimpleComponent extends Component {
+  render() {
+    const {
+      viewportIsMobile,
+      viewportIsTabletOrLess,
+      viewportIsXSOrLess,
+      viewportIsSOrLess,
+      viewportIsMOrLess,
+      viewportIsLOrLess,
+      myCustomMediaQuery,
+      ...props
+    } = this.props
+
+    return <div title="Test me!" {...props} />
+  }
 }
 
 const mockAddListener = jest.fn()
@@ -40,9 +47,10 @@ describe('mediaQueries()', () => {
   describe('by default', () => {
     beforeEach(() => {
       SimpleComponentWithMediaQueries = mediaQueries(SimpleComponent, {
-        viewportIsMobile: true,
-        viewportIsTabletOrLess: true,
+        viewportIsXSOrLess: true,
         viewportIsSOrLess: true,
+        viewportIsMOrLess: true,
+        viewportIsLOrLess: true,
       })
       component = mount(<SimpleComponentWithMediaQueries />)
       componentSnapshot = renderer
@@ -57,9 +65,10 @@ describe('mediaQueries()', () => {
     it('pushes media queries props to wrapped component', () => {
       const wrappedComponent = component.find(SimpleComponent).first()
 
-      expect(wrappedComponent.prop('viewportIsMobile')).toBeFalsy()
-      expect(wrappedComponent.prop('viewportIsTabletOrLess')).toBeFalsy()
+      expect(wrappedComponent.prop('viewportIsXSOrLess')).toBeFalsy()
       expect(wrappedComponent.prop('viewportIsSOrLess')).toBeFalsy()
+      expect(wrappedComponent.prop('viewportIsMOrLess')).toBeFalsy()
+      expect(wrappedComponent.prop('viewportIsLOrLess')).toBeFalsy()
     })
 
     it('attaches listeners', () => {
@@ -72,11 +81,11 @@ describe('mediaQueries()', () => {
     })
   })
 
-  describe('with tablet or less version', () => {
+  describe('with M or less version', () => {
     beforeEach(() => {
       window.matchMedia = createMockMediaMatcher(true)
       SimpleComponentWithMediaQueries = mediaQueries(SimpleComponent, {
-        viewportIsTabletOrLess: true,
+        viewportIsMOrLess: true,
       })
       component = mount(<SimpleComponentWithMediaQueries />)
     })
@@ -84,9 +93,10 @@ describe('mediaQueries()', () => {
     it('pushes media queries props to wrapped component', () => {
       const wrappedComponent = component.find(SimpleComponent).first()
 
-      expect(wrappedComponent.prop('viewportIsMobile')).toBeFalsy()
-      expect(wrappedComponent.prop('viewportIsTabletOrLess')).toBeTruthy()
+      expect(wrappedComponent.prop('viewportIsXSOrLess')).toBeFalsy()
       expect(wrappedComponent.prop('viewportIsSOrLess')).toBeFalsy()
+      expect(wrappedComponent.prop('viewportIsMOrLess')).toBeTruthy()
+      expect(wrappedComponent.prop('viewportIsLOrLess')).toBeFalsy()
     })
   })
 
@@ -102,9 +112,10 @@ describe('mediaQueries()', () => {
     it('pushes media queries props to wrapped component', () => {
       const wrappedComponent = component.find(SimpleComponent).first()
 
-      expect(wrappedComponent.prop('viewportIsMobile')).toBeFalsy()
-      expect(wrappedComponent.prop('viewportIsTabletOrLess')).toBeFalsy()
+      expect(wrappedComponent.prop('viewportIsXSOrLess')).toBeFalsy()
       expect(wrappedComponent.prop('viewportIsSOrLess')).toBeTruthy()
+      expect(wrappedComponent.prop('viewportIsMOrLess')).toBeFalsy()
+      expect(wrappedComponent.prop('viewportIsLOrLess')).toBeFalsy()
     })
   })
 
@@ -121,9 +132,28 @@ describe('mediaQueries()', () => {
       const wrappedComponent = component.find(SimpleComponent).first()
 
       expect(wrappedComponent.prop('myCustomMediaQuery')).toBeDefined()
-      expect(wrappedComponent.prop('viewportIsMobile')).toBeFalsy()
-      expect(wrappedComponent.prop('viewportIsTabletOrLess')).toBeFalsy()
+      expect(wrappedComponent.prop('viewportIsXSOrLess')).toBeFalsy()
       expect(wrappedComponent.prop('viewportIsSOrLess')).toBeFalsy()
+      expect(wrappedComponent.prop('viewportIsMOrLess')).toBeFalsy()
+      expect(wrappedComponent.prop('viewportIsLOrLess')).toBeFalsy()
+    })
+  })
+
+  describe('with deprecated versions', () => {
+    beforeEach(() => {
+      window.matchMedia = createMockMediaMatcher(true)
+      SimpleComponentWithMediaQueries = mediaQueries(SimpleComponent, {
+        viewportIsTabletOrLess: true,
+        viewportIsMobile: true,
+      })
+      component = mount(<SimpleComponentWithMediaQueries />)
+    })
+
+    it('pushes media queries props to wrapped component', () => {
+      const wrappedComponent = component.find(SimpleComponent).first()
+
+      expect(wrappedComponent.prop('viewportIsTabletOrLess')).toBeTruthy()
+      expect(wrappedComponent.prop('viewportIsMobile')).toBeTruthy()
     })
   })
 })


### PR DESCRIPTION
Les props `viewportIsMobile` et `viewportIsTabletOrLess` ne sont pas très précises et ne correspondent pas au tableau présenté dans `kitten/constants/screen-config`. 

Cette PR se propose de déprécier ces props de HOC. Ce serait bien, à terme, de les remplacer sur les plateformes.