### PR TITLE
[ProjectPage] Update RewardCard box-sizing

### DIFF
--- a/assets/javascripts/kitten/components/cards/reward-card.js
+++ b/assets/javascripts/kitten/components/cards/reward-card.js
@@ -228,6 +228,7 @@ const style = {
     borderColor: COLORS.line1,
     width: '100%',
     padding: `${pxToRem(15)} 0`,
+    boxSizing: 'border-box',
   },
   image: {
     width: '100%',


### PR DESCRIPTION
## Ajoute la règle de box-sizing sur `RewardCard`

Pour permettre à la RewardCard de rentrer correctement dans nos grids, cette PR ajoute la règle suivante sur la `RewardCard` : 
```css
box-sizing: 'border-box';
```

Avant : 

<img width="383" alt="avant" src="https://user-images.githubusercontent.com/548778/48842780-74c86400-ed95-11e8-82b9-6d0e987b74e6.png">

Après : 

<img width="362" alt="apres" src="https://user-images.githubusercontent.com/548778/48842785-78f48180-ed95-11e8-9535-9752eb2a75d7.png">

