### PR TITLE
[ProjectPage] Update ExpandBoard button styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Fix `ExpandBoard.Button` arrow styles.
+
 ## [23.13.0] - 2018-11-21
 
 Features:

--- a/assets/javascripts/kitten/components/expandable/__snapshots__/expand-board.test.js.snap
+++ b/assets/javascripts/kitten/components/expandable/__snapshots__/expand-board.test.js.snap
@@ -17,36 +17,40 @@ exports[`<ExpandBoard /> with <ExpandBoard.Button> and <ExpandBoard.Content> by 
         "alignItems": "center",
         "display": "flex",
         "justifyContent": "center",
-        "lineHeight": "1.3em",
-        "paddingBottom": "0.1875rem",
-        "paddingTop": "0.1875rem",
+        "lineHeight": "1.3rem",
+        "padding": "1.375rem 1.875rem",
         "width": "100%",
       }
     }
     tabIndex={null}
     type="button"
   >
-    Alice
-    <svg
-      className="k-ArrowIcon k-ArrowIcon--bottom k-Button__icon"
+    <div
       data-radium={true}
-      fill="#fff"
-      style={
-        Object {
-          "height": "0.375rem",
-          "width": "0.375rem",
-        }
-      }
-      viewBox="0 0 6 6"
-      xmlns="http://www.w3.org/2000/svg"
     >
-      <title>
-        Arrow
-      </title>
-      <path
-        d="M6 0H0v6h2V2h4z"
-      />
-    </svg>
+      Alice
+      <svg
+        className=""
+        data-radium={true}
+        fill="#fff"
+        height="5.64"
+        style={
+          Object {
+            "height": "0.75rem",
+            "marginLeft": "0.625rem",
+            "transform": "rotate(180deg)",
+            "width": "0.5rem",
+          }
+        }
+        viewBox="0 0 8.48 5.64"
+        width="8.48"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M0 4.24 L4.24,0 L8.48,4.24 L7.08,5.64 L4.24,2.77 L1.4,5.6 z"
+        />
+      </svg>
+    </div>
   </button>
 </div>
 `;
@@ -68,36 +72,40 @@ exports[`<ExpandBoard /> with <ExpandBoard.Button> and <ExpandBoard.Content> dis
         "alignItems": "center",
         "display": "flex",
         "justifyContent": "center",
-        "lineHeight": "1.3em",
-        "paddingBottom": "0.1875rem",
-        "paddingTop": "0.1875rem",
+        "lineHeight": "1.3rem",
+        "padding": "1.375rem 1.875rem",
         "width": "100%",
       }
     }
     tabIndex={null}
     type="button"
   >
-    Alice
-    <svg
-      className="k-ArrowIcon k-ArrowIcon--bottom k-Button__icon"
+    <div
       data-radium={true}
-      fill="#fff"
-      style={
-        Object {
-          "height": "0.375rem",
-          "width": "0.375rem",
-        }
-      }
-      viewBox="0 0 6 6"
-      xmlns="http://www.w3.org/2000/svg"
     >
-      <title>
-        Arrow
-      </title>
-      <path
-        d="M6 0H0v6h2V2h4z"
-      />
-    </svg>
+      Alice
+      <svg
+        className=""
+        data-radium={true}
+        fill="#fff"
+        height="5.64"
+        style={
+          Object {
+            "height": "0.75rem",
+            "marginLeft": "0.625rem",
+            "transform": "rotate(180deg)",
+            "width": "0.5rem",
+          }
+        }
+        viewBox="0 0 8.48 5.64"
+        width="8.48"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M0 4.24 L4.24,0 L8.48,4.24 L7.08,5.64 L4.24,2.77 L1.4,5.6 z"
+        />
+      </svg>
+    </div>
   </button>
 </div>
 `;

--- a/assets/javascripts/kitten/components/expandable/expand-board.js
+++ b/assets/javascripts/kitten/components/expandable/expand-board.js
@@ -56,13 +56,15 @@ class ExpandBoardButton extends Component {
         onClick={onClick}
         type="button"
       >
-        {expanded ? defaultExpandChildren : children}
-        <ArrowIcon
-          direction={expanded ? 'top' : 'bottom'}
-          className="k-Button__icon"
-          fill={COLORS.background1}
-          style={style.arrow}
-        />
+        <div>
+          {expanded ? defaultExpandChildren : children}
+          <ArrowIcon
+            version="solid"
+            direction={expanded ? 'top' : 'bottom'}
+            fill={COLORS.background1}
+            style={style.arrow}
+          />
+        </div>
       </Button>
     )
   }
@@ -168,20 +170,17 @@ const styles = {
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'center',
-      lineHeight: '1.3em',
-      // As the arrow takes a huge space because of its rotation, we cannot
-      // apply the same paddings as on the basic big button. These values ajust
-      // the paddings so it fits the same as the basic big button.
-      paddingTop: pxToRem(3),
-      paddingBottom: pxToRem(3),
+      lineHeight: '1.3rem',
+      padding: `${pxToRem(22)} ${pxToRem(30)}`,
     },
     expanded: {
       backgroundColor: COLORS.font1,
       borderColor: COLORS.font1,
     },
     arrow: {
-      width: '0.375rem',
-      height: '0.375rem',
+      width: pxToRem(8),
+      height: '0.75rem', // half of button base line-height
+      marginLeft: pxToRem(10),
     },
   },
 }


### PR DESCRIPTION
Related to https://github.com/KissKissBankBank/kisskissbankbank/issues/5317.

Cette PR fixe : 
- **la distance entre le texte du bouton et la flèche**  

Avant : 
<img width="366" alt="screenshot 2018-11-21 at 15 16 52" src="https://user-images.githubusercontent.com/548778/48846896-84997580-eda0-11e8-94e0-ec122d6a6ec0.png">

Après : 
<img width="371" alt="screenshot 2018-11-21 at 15 16 58" src="https://user-images.githubusercontent.com/548778/48846899-882cfc80-eda0-11e8-8d7c-f004ae1e46e5.png">

- **le fait que la flèche rétrécisse lorsque l'espace disponible diminue**

Avant : 
<img width="153" alt="screenshot 2018-11-21 at 15 19 16" src="https://user-images.githubusercontent.com/548778/48847022-db06b400-eda0-11e8-8075-f611bff92b19.png">

Après : 
<img width="153" alt="screenshot 2018-11-21 at 15 19 22" src="https://user-images.githubusercontent.com/548778/48847036-e2c65880-eda0-11e8-9060-d2e01ee09f3f.png">
