### PR TITLE
Fix color values for disabled location input

### DIFF
--- a/assets/stylesheets/kitten/components/form/_location-input.scss
+++ b/assets/stylesheets/kitten/components/form/_location-input.scss
@@ -41,8 +41,8 @@
   $border-color-focus: map-get($k-colors, 'line-2');
 
   // Disabled
-  $color-disabled: map-get($k-colors, 'background-1');
-  $border-color-disabled: map-get($k-colors, 'background-1');
+  $color-disabled: map-get($k-colors, 'font-2');
+  $border-color-disabled: map-get($k-colors, 'line-1');
   $background-color-disabled: map-get($k-colors, 'line-1');
 
   // Placeholder


### PR DESCRIPTION
La couleur du disabled location input était incorrecte. 

Avant
<img width="523" alt="capture d ecran 2018-11-28 a 16 17 44" src="https://user-images.githubusercontent.com/25149138/49161478-31d43680-f329-11e8-9a67-11f297be99d4.png">

Après
<img width="512" alt="capture d ecran 2018-11-28 a 16 19 58" src="https://user-images.githubusercontent.com/25149138/49161606-7a8bef80-f329-11e8-80ac-4ea79da8d0f3.png">

