### PR TITLE
[Performance] Use media-query for default value on `Marger`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Use media-query for default value on `Marger` component when prop `top`
+  or `bottom` is an object.
+
 ## [23.16.0] - 2018-11-30
 
 Feature:

--- a/assets/javascripts/kitten/components/layout/marger.js
+++ b/assets/javascripts/kitten/components/layout/marger.js
@@ -96,14 +96,23 @@ export class MargerBase extends Component {
   hasXxsProp = propName => this.props[propName] && this.props[propName].fromXxs
 
   defaultProp = propName => {
+    const mediaQueryRule = `@media (min-width: 0)`
     const cssRule = `margin${upcaseFirst(propName)}`
 
     if (this.hasDefaultProp(propName)) {
-      return { [cssRule]: this.marginSize(this.props[propName].default) }
+      return {
+        [mediaQueryRule]: {
+          [cssRule]: this.marginSize(this.props[propName].default),
+        },
+      }
     }
 
     if (this.hasXxsProp(propName)) {
-      return { [cssRule]: this.marginSize(this.props[propName].fromXxs) }
+      return {
+        [mediaQueryRule]: {
+          [cssRule]: this.marginSize(this.props[propName].fromXxs),
+        },
+      }
     }
   }
 

--- a/assets/javascripts/kitten/components/layout/marger.test.js
+++ b/assets/javascripts/kitten/components/layout/marger.test.js
@@ -68,7 +68,7 @@ describe('<Marger />', () => {
         const styles = cleanStyles(marger.props().style)
 
         expect(styles).toEqual([
-          { marginTop: '2.5rem' },
+          { '@media (min-width: 0)': { marginTop: '2.5rem' } },
           { '@media (min-width: 480px)': { marginTop: '7.5rem' } },
           { '@media (min-width: 768px)': { marginTop: '1.25rem' } },
         ])
@@ -87,7 +87,9 @@ describe('<Marger />', () => {
           .first()
         const styles = cleanStyles(marger.props().style)
 
-        expect(styles).toEqual([{ marginTop: '2.5rem' }])
+        expect(styles).toEqual([
+          { '@media (min-width: 0)': { marginTop: '2.5rem' } },
+        ])
       })
 
       it('is overrided by the default value', () => {
@@ -101,7 +103,9 @@ describe('<Marger />', () => {
           .first()
         const styles = cleanStyles(marger.props().style)
 
-        expect(styles).toEqual([{ marginTop: '7.5rem' }])
+        expect(styles).toEqual([
+          { '@media (min-width: 0)': { marginTop: '7.5rem' } },
+        ])
       })
     })
   })
@@ -152,7 +156,7 @@ describe('<Marger />', () => {
         const styles = cleanStyles(marger.props().style)
 
         expect(styles).toEqual([
-          { marginBottom: '2.5rem' },
+          { '@media (min-width: 0)': { marginBottom: '2.5rem' } },
           { '@media (min-width: 480px)': { marginBottom: '7.5rem' } },
           { '@media (min-width: 768px)': { marginBottom: '1.25rem' } },
         ])
@@ -171,7 +175,9 @@ describe('<Marger />', () => {
           .first()
         const styles = cleanStyles(marger.props().style)
 
-        expect(styles).toEqual([{ marginBottom: '2.5rem' }])
+        expect(styles).toEqual([
+          { '@media (min-width: 0)': { marginBottom: '2.5rem' } },
+        ])
       })
 
       it('is overrided by the default value', () => {
@@ -185,7 +191,9 @@ describe('<Marger />', () => {
           .first()
         const styles = cleanStyles(marger.props().style)
 
-        expect(styles).toEqual([{ marginBottom: '7.5rem' }])
+        expect(styles).toEqual([
+          { '@media (min-width: 0)': { marginBottom: '7.5rem' } },
+        ])
       })
     })
   })


### PR DESCRIPTION
Related to #1419.

Avec #1419, la gestion de la valeur par défaut (pour `default` ou `fromXxs`) se gérait de la manière suivante avec Radium : 
```js
<Marger top={ {
  default: 6,
  fromS: 10,
} } />
```
Je n'ai pas pris en compte la manière dont Radium gère les styles. Cela rendait donc un DOM avec la structure suivante : 
<img width="581" alt="screenshot 2018-11-30 at 14 38 03" src="https://user-images.githubusercontent.com/548778/49293407-5e668a80-f4b0-11e8-9340-efa621a04540.png">

L'attribut `style` étant inline, il a la précédence sur le style par rapport à la classe déclarée pour le noeud DOM. **On ne rentre donc jamais dans les media-queries ಠ_ಠ**. C'est bête, hein.

La PR propose du coup un petit trick en utilisant une media-query `min-width: 0` pour pallier ce souci de précédence.