### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ $ yarn login
 - Update the `KARL_CHANGELOG.md` file:
   * Update the version with the version of the library.
   * Add a new `[unreleased]` section.
+- Update the `package.json` file:
+  * Update the version with the version of the library.
 - Run this command:
 
 ```sh


### PR DESCRIPTION
Il manquait l'info de la MAJ de la version de `Kitten` sur `package.json`  lors de la realease de `Kitten`.

Closes https://github.com/KissKissBankBank/kitten/pull/1454