### PR TITLE
[Storybook] Fix decorator when scripts are reloaded

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,11 +1,13 @@
 import { configure } from '@storybook/react'
-import './decorators/grid'
+import { addDecorator } from '@storybook/react'
+import GridDecorator from './decorators/grid'
 import './stylesheets/app-kitten.scss'
 
 // automatically import all files ending in *.stories.js
-const req = require.context('../assets/javascripts', true, /.stories.js$/)
 function loadStories() {
+  const req = require.context('../assets/javascripts', true, /.stories.js$/)
   req.keys().forEach(filename => req(filename))
 }
 
+addDecorator(GridDecorator)
 configure(loadStories, module)

--- a/.storybook/decorators/grid.js
+++ b/.storybook/decorators/grid.js
@@ -1,5 +1,4 @@
 import React, { Fragment } from 'react'
-import { addDecorator } from '@storybook/react';
 import { DevGrid } from 'kitten/components/dev/dev-grid'
 
 const GridDecorator = (storyFn) => (
@@ -9,4 +8,4 @@ const GridDecorator = (storyFn) => (
   </Fragment>
 )
 
-addDecorator(GridDecorator)
+export default GridDecorator


### PR DESCRIPTION
Actuellement lors d'un rechargement de script via le hot reloading, on perd les decorator ajoutés à Storybook. Cette PR corrige ce bug.