### PR TITLE
[Styles] Add `fontStyles` helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Feature: Add `fontStyles` helper.
+
 ## [1.3.0] - 2018-12-27
 
-Features: 
+Features:
 - Add prop `id` on `Accordeon.Item`. This id would be given by the callback `onChange` on `Accordon` if setted.
 
 ## [1.2.0] - 2018-12-27

--- a/assets/javascripts/kitten/styles/font/index.js
+++ b/assets/javascripts/kitten/styles/font/index.js
@@ -1,0 +1,28 @@
+export const fontStyles = ({ weight = 'light' } = {}) => {
+  let styles = ['font-family: "Maax", Helvetica, Arial, sans-serif;']
+
+  switch (weight) {
+    case 'light':
+      styles.push('font-weight: 400;')
+      break
+    case 'regular':
+      styles.push('font-weight: 500;')
+      break
+    case 'bold':
+      styles.push('font-weight: 600;')
+      break
+    case 'regular-uppercase':
+      styles.push('font-weight: 500;')
+      styles.push('text-transform: uppercase;')
+      break
+    case 'bold-uppercase':
+      styles.push('font-weight: 600;')
+      styles.push('text-transform: uppercase;')
+      styles.push('letter-spacing: .1rem;')
+      break
+    default:
+      break
+  }
+
+  return styles
+}


### PR DESCRIPTION
Migration de la mixin `k-typographyFont` vers un helper JS. 

Ce helper ne touche que la `family` et le `weight` de la font. Je ne trouve pas cela intéressant d'y ajouter le `line-height` et toutes les options possibles de la font. Ca sera fait directement dans le CSS du composant.