### PR TITLE
No need to add suffix -next for our releases anymore

### DIFF
--- a/bin/publish
+++ b/bin/publish
@@ -7,7 +7,7 @@ PACKAGE_VERSION=$(cat package.json \
   | sed 's/[",]//g' \
   | tr -d '[[:space:]]')
 
-REALEASE_TAG="v$PACKAGE_VERSION-next"
+REALEASE_TAG="v$PACKAGE_VERSION"
 
 echo "Preparing to publish $PACKAGE_VERSION version linked to tag $REALEASE_TAG."
 


### PR DESCRIPTION
Après le clean des tags (qui est en cours en ce moment même)