### PR TITLE
Fix `BurgerIcon` : new `hover` behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix : `BurgerMenu` changed `hover` behaviour
+
 ## [1.4.0] - 2019-01-10
 
 Features:

--- a/assets/javascripts/kitten/components/icons/burger-icon/__snapshots__/burger-icon.test.js.snap
+++ b/assets/javascripts/kitten/components/icons/burger-icon/__snapshots__/burger-icon.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<BurgerIcon /> default matches the snapshot 1`] = `
 <svg
-  className="burger-icon__StyledItem-sc-2o2fz7-0 KAWMe"
+  className="burger-icon__StyledItem-sc-2o2fz7-0 imQsOJ"
   height="10"
   viewBox="0 0 12 10"
   width="12"
@@ -34,7 +34,7 @@ exports[`<BurgerIcon /> default matches the snapshot 1`] = `
 
 exports[`<BurgerIcon /> with no \`title\` (\`iconTitle\` to \`null\`) matches the snapshot 1`] = `
 <svg
-  className="burger-icon__StyledItem-sc-2o2fz7-0 KAWMe"
+  className="burger-icon__StyledItem-sc-2o2fz7-0 imQsOJ"
   height="10"
   viewBox="0 0 12 10"
   width="12"
@@ -63,7 +63,7 @@ exports[`<BurgerIcon /> with no \`title\` (\`iconTitle\` to \`null\`) matches th
 
 exports[`<BurgerIcon /> with the prop \`isActive\` set to \`true\` matches the snapshot 1`] = `
 <svg
-  className="burger-icon__StyledItem-sc-2o2fz7-0 kyfXrg"
+  className="burger-icon__StyledItem-sc-2o2fz7-0 euPzVJ"
   height="10"
   viewBox="0 0 12 10"
   width="12"

--- a/assets/javascripts/kitten/components/icons/burger-icon/index.js
+++ b/assets/javascripts/kitten/components/icons/burger-icon/index.js
@@ -6,13 +6,14 @@ import COLORS from '../../../constants/colors-config'
 const StyledItem = styled.svg`
   overflow: visible;
 
-  rect {
-    fill: ${props => props.mainColor};
-    transition: transform 0.2s ease-out, fill 0.15s;
+  fill: ${props => props.mainColor};
+
+  :hover {
+    fill: ${props => props.hoverColor};
   }
 
-  :hover rect {
-    fill: ${props => props.hoverColor};
+  rect {
+    transition: transform 0.2s ease-out, fill 0.15s;
   }
 
   ${({ isActive }) =>


### PR DESCRIPTION
Le `hover` s'appliquait aux éléments intérieurs au SVG, maintenant il s'applique au SVG en entier.