### PR TITLE
Remove margin when `title` prop is empty on `CounterBlock` component.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Remove margin when `title` prop is empty.
+
 ## [1.4.1] - 2019-01-10
 
 Fix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
-- Fix: Remove margin when `title` prop is empty.
+- Fix: Remove margin when `title` prop is empty in `CounterBlock` component.
 
 ## [1.4.1] - 2019-01-10
 

--- a/assets/javascripts/kitten/components/meters/counter-block.js
+++ b/assets/javascripts/kitten/components/meters/counter-block.js
@@ -26,11 +26,13 @@ class CounterBlockBase extends Component {
 
     return (
       <StyleRoot style={styles.counterBlock}>
-        <Marger bottom={margin}>
-          <Title modifier={titleSize} margin={false} tag={titleTag}>
-            {title}
-          </Title>
-        </Marger>
+        {title && (
+          <Marger bottom={margin}>
+            <Title modifier={titleSize} margin={false} tag={titleTag}>
+              {title}
+            </Title>
+          </Marger>
+        )}
         <div style={styles.flexGrid}>
           <div style={styles.strokeContainer} className="k-u-hidden@m-down">
             <HorizontalStroke style={styles.stroke} size="big" />


### PR DESCRIPTION
Suite de la `PR`(https://github.com/KissKissBankBank/kkbb-lendopolis-clients/pull/704), qui supprime le `title` du composant `CounterBlock` sur Lendo. 

Sur le composant `CounterBlock` de kitten, une marge s'affichait même si le `title` était vide.
J'ai donc ajouté une condition sur la marge associée à cette props, pour éviter que la marge s'affiche quand le `title` n'est pas spécifié.

Screenshot:


TODO:

- [ ] Tests
- [x] Changelog
- [ ] A11Y
- [ ] Stories
