### PR TITLE
Specify type button for button-question-mark-icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [unreleased]
 
 - Fix: Remove margin when `title` prop is empty in `CounterBlock` component.
+- Fix: Force `type="button"` on `buttonQuestionMarkIcon` component.
 
 ## [1.4.1] - 2019-01-10
 

--- a/assets/javascripts/kitten/components/buttons/button-question-mark-icon.js
+++ b/assets/javascripts/kitten/components/buttons/button-question-mark-icon.js
@@ -7,6 +7,7 @@ export const ButtonQuestionMarkIcon = props => (
     className="k-ButtonIcon--tooltip--nano"
     modifier="helium"
     size="nano"
+    type="button"
     rounded
     {...props}
   >

--- a/assets/javascripts/kitten/components/buttons/button-question-mark-icon.test.js
+++ b/assets/javascripts/kitten/components/buttons/button-question-mark-icon.test.js
@@ -15,6 +15,10 @@ describe('ButtonQuestionMarkIcon />', () => {
     it('has a <QuestionMarkIcon />', () => {
       expect(button.find(QuestionMarkIcon).exists()).toBe(true)
     })
+
+    it('should be type of button', () => {
+      expect(button.props().type).toBe('button')
+    })
   })
 
   describe('with other props', () => {

--- a/assets/javascripts/kitten/components/form/field/__snapshots__/field.test.js.snap
+++ b/assets/javascripts/kitten/components/form/field/__snapshots__/field.test.js.snap
@@ -38,6 +38,7 @@ Array [
             data-for="tooltip"
             data-tip={true}
             tabIndex={null}
+            type="button"
           >
             <svg
               className="k-ButtonIcon__svg"
@@ -132,6 +133,7 @@ Array [
             data-for="tooltip"
             data-tip={true}
             tabIndex={null}
+            type="button"
           >
             <svg
               className="k-ButtonIcon__svg"

--- a/src/components/buttons/button-question-mark-icon.js
+++ b/src/components/buttons/button-question-mark-icon.js
@@ -20,6 +20,7 @@ var ButtonQuestionMarkIcon = function ButtonQuestionMarkIcon(props) {
     className: "k-ButtonIcon--tooltip--nano",
     modifier: "helium",
     size: "nano",
+    type: "button",
     rounded: true
   }, props), _react.default.createElement(_questionMarkIcon.QuestionMarkIcon, {
     className: "k-ButtonIcon__svg"


### PR DESCRIPTION
Si on ne spécifie ps le type d'un bouton dans un formulaire, certains navigateurs (chrome) mettent la valeur `type` à `submit` par défaut. Ce qui est dommage. Sur shipping-address quand on clique sur l'icône on submit le formulaire !
