### PR TITLE
[Feature] Add autoFill prop to Select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [unreleased]
 
 - Feature: Add `autoFill` prop to `Field.Select` component.
-
+- Fix: Fix `Field.Select` label by using `for=` instead of `id=`.
 - Feature: Add `activePaginationColor`, `paginationColor` and `paginationAlign`
   props on `SimpleCarousel`.
 - Fix: Adds the ability to edit and add styles on `BulletList`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
-Feature : Add `autoFill` prop to `Field.Select` component.
+
+- Feature: Add `autoFill` prop to `Field.Select` component.
 
 - Feature: Add `activePaginationColor`, `paginationColor` and `paginationAlign`
   props on `SimpleCarousel`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
+Feature : Add `autoFill` prop to `Field.Select` component.
 
 ## [1.6.0] - 2019-01-17
 

--- a/assets/javascripts/kitten/components/form/select-with-state.js
+++ b/assets/javascripts/kitten/components/form/select-with-state.js
@@ -21,12 +21,15 @@ export class SelectWithState extends Component {
     this.state = {
       value: props.value,
     }
-
-    this.handleChange = this.handleChange.bind(this)
-    this.onKeyDown = this.onKeyDown.bind(this)
   }
 
-  handleChange(val) {
+  componentDidUpdate(prevProps) {
+    if (prevProps.value !== this.props.value) {
+      this.setState({ value: this.props.value })
+    }
+  }
+
+  handleChange = val => {
     const value = val && val.value ? val : { value: null, label: null }
 
     this.setState({ value: value })
@@ -34,7 +37,7 @@ export class SelectWithState extends Component {
     this.props.onInputChange({ value: value, name: this.props.name })
   }
 
-  onKeyDown(event) {
+  onKeyDown = event => {
     const enterKeyCode = 13
     const spaceKeyCode = 32
 

--- a/assets/javascripts/kitten/components/form/select-with-state.js
+++ b/assets/javascripts/kitten/components/form/select-with-state.js
@@ -11,6 +11,7 @@
 //      } />
 //
 import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import Select from 'react-select'
 
@@ -48,16 +49,6 @@ export class SelectWithState extends Component {
     }
   }
 
-  renderLabel() {
-    if (!this.props.labelText) return
-
-    return (
-      <label className="k-Select__label" id={this.props.id}>
-        {this.props.labelText}
-      </label>
-    )
-  }
-
   render() {
     const {
       value,
@@ -67,6 +58,8 @@ export class SelectWithState extends Component {
       error,
       valid,
       disabled,
+      labelText,
+      autoFill,
       ...other
     } = this.props
 
@@ -79,7 +72,27 @@ export class SelectWithState extends Component {
 
     return (
       <div className={selectClassName}>
-        {this.renderLabel()}
+        {labelText && (
+          <label className="k-Select__label" id={this.props.id}>
+            {labelText}
+          </label>
+        )}
+        {autoFill && (
+          <input
+            autocomplete={autoFill}
+            x-autocompletetype={autoFill}
+            xautocompletetype={autoFill}
+            autocompletetype={autoFill}
+            id={autoFill}
+            name={autoFill}
+            style={{
+              position: 'absolute',
+              zIndex: '-1',
+              opacity: '0',
+            }}
+            onChange={e => this.setState({ value: e.target.value })}
+          />
+        )}
         <SelectWithMultiLevel
           value={this.state.value}
           onKeyDown={this.onKeyDown}
@@ -138,6 +151,10 @@ class SelectWithMultiLevel extends Component {
   }
 }
 
+SelectWithState.propTypes = {
+  autoFill: PropTypes.string,
+}
+
 SelectWithState.defaultProps = {
   onChange: function() {},
   onInputChange: function() {},
@@ -152,6 +169,7 @@ SelectWithState.defaultProps = {
   tiny: false,
   name: null,
   inputProps: {},
+  autoFill: undefined,
 }
 
 // DEPRECATED: do not use default export.

--- a/assets/javascripts/kitten/components/form/select-with-state.js
+++ b/assets/javascripts/kitten/components/form/select-with-state.js
@@ -73,7 +73,7 @@ export class SelectWithState extends Component {
     return (
       <div className={selectClassName}>
         {labelText && (
-          <label className="k-Select__label" id={this.props.id}>
+          <label className="k-Select__label" for={this.props.id}>
             {labelText}
           </label>
         )}

--- a/assets/javascripts/kitten/components/form/select-with-state.js
+++ b/assets/javascripts/kitten/components/form/select-with-state.js
@@ -83,7 +83,6 @@ export class SelectWithState extends Component {
             x-autocompletetype={autoFill}
             xautocompletetype={autoFill}
             autocompletetype={autoFill}
-            id={autoFill}
             name={autoFill}
             style={{
               position: 'absolute',

--- a/assets/javascripts/kitten/components/form/select-with-state.test.js
+++ b/assets/javascripts/kitten/components/form/select-with-state.test.js
@@ -160,4 +160,45 @@ describe('<SelectWithState />', () => {
       expect(select.state().value).toBe('bar')
     })
   })
+
+  describe('with autofill', () => {
+    it('should not create extra input if autofill is undefined', () => {
+      select = mount(<SelectWithState options={options} value="foo" />)
+
+      expect(select.exists('input')).toBe(false)
+    })
+
+    it('should create input element with revelant props if autofill is setted', () => {
+      const autoFillName = 'cc-number'
+      select = mount(
+        <SelectWithState
+          autoFill={autoFillName}
+          options={options}
+          value="foo"
+        />,
+      )
+
+      expect(select.exists('input')).toBe(true)
+      const input = select.find('input')
+      expect(input.props().autocomplete).toBe(autoFillName)
+      expect(input.props()['x-autocompletetype']).toBe(autoFillName)
+      expect(input.props().xautocompletetype).toBe(autoFillName)
+      expect(input.props().name).toBe(autoFillName)
+      expect(input.props().id).toBe(autoFillName)
+    })
+
+    it('should update select value on input change', () => {
+      const autoFillName = 'cc-number'
+      select = mount(
+        <SelectWithState
+          autoFill={autoFillName}
+          options={options}
+          value="foo"
+        />,
+      )
+      const input = select.find({ id: autoFillName })
+      input.simulate('change', { target: { value: '2010' } })
+      expect(select.state().value).toBe('2010')
+    })
+  })
 })

--- a/assets/javascripts/kitten/components/form/select-with-state.test.js
+++ b/assets/javascripts/kitten/components/form/select-with-state.test.js
@@ -151,4 +151,13 @@ describe('<SelectWithState />', () => {
       expect(onInputChangeSpy.calledWith(onInputChangeValue)).toBe(true)
     })
   })
+
+  describe('update props', () => {
+    it('should update select value on prop change', () => {
+      select = mount(<SelectWithState options={options} value="foo" />)
+      expect(select.state().value).toBe('foo')
+      select.setProps({ value: 'bar' })
+      expect(select.state().value).toBe('bar')
+    })
+  })
 })

--- a/assets/javascripts/kitten/components/form/select-with-state.test.js
+++ b/assets/javascripts/kitten/components/form/select-with-state.test.js
@@ -184,7 +184,6 @@ describe('<SelectWithState />', () => {
       expect(input.props()['x-autocompletetype']).toBe(autoFillName)
       expect(input.props().xautocompletetype).toBe(autoFillName)
       expect(input.props().name).toBe(autoFillName)
-      expect(input.props().id).toBe(autoFillName)
     })
 
     it('should update select value on input change', () => {
@@ -196,7 +195,7 @@ describe('<SelectWithState />', () => {
           value="foo"
         />,
       )
-      const input = select.find({ id: autoFillName })
+      const input = select.find({ autocomplete: autoFillName })
       input.simulate('change', { target: { value: '2010' } })
       expect(select.state().value).toBe('2010')
     })

--- a/assets/javascripts/kitten/karl/pages/contribute/payment-choices/components/payment-choices.js
+++ b/assets/javascripts/kitten/karl/pages/contribute/payment-choices/components/payment-choices.js
@@ -35,14 +35,7 @@ class PaymentChoices extends Component {
 
     this.state = {
       selectedItem: null,
-      expMonth: undefined,
-      expYear: undefined,
     }
-  }
-
-  handleExpChange = ({ target }) => {
-    const [month, year] = target.value.split('/')
-    this.setState({ expMonth: month, expYear: parseInt(year) })
   }
 
   handleChange = selectedItem => this.setState({ selectedItem })
@@ -147,7 +140,7 @@ class PaymentChoices extends Component {
                                     id="month"
                                     name="month"
                                     placeholder="Mois"
-                                    value={this.state.expMonth}
+                                    autoFill="cc-exp-month"
                                     options={[
                                       { value: '01', label: '01' },
                                       { value: '02', label: '02' },
@@ -164,18 +157,6 @@ class PaymentChoices extends Component {
                                     ]}
                                     error={error}
                                   />
-                                  <input
-                                    name="cc-exp"
-                                    id="frmCCExp"
-                                    placeholder="MM-YYYY"
-                                    autoComplete="cc-exp"
-                                    style={{
-                                      position: 'absolute',
-                                      zIndex: '-1',
-                                      opacity: '0',
-                                    }}
-                                    onChange={this.handleExpChange}
-                                  />
                                 </GridCol>
 
                                 <GridCol col="6">
@@ -183,7 +164,7 @@ class PaymentChoices extends Component {
                                     id="year"
                                     name="year"
                                     placeholder="Année"
-                                    value={this.state.expYear}
+                                    autoFill="cc-exp-year"
                                     options={[
                                       { value: 2018, label: '18' },
                                       { value: 2019, label: '19' },

--- a/assets/javascripts/kitten/karl/pages/contribute/payment-choices/components/payment-choices.js
+++ b/assets/javascripts/kitten/karl/pages/contribute/payment-choices/components/payment-choices.js
@@ -35,7 +35,14 @@ class PaymentChoices extends Component {
 
     this.state = {
       selectedItem: null,
+      expMonth: undefined,
+      expYear: undefined,
     }
+  }
+
+  handleExpChange = ({ target }) => {
+    const [month, year] = target.value.split('/')
+    this.setState({ expMonth: month, expYear: parseInt(year) })
   }
 
   handleChange = selectedItem => this.setState({ selectedItem })
@@ -116,6 +123,7 @@ class PaymentChoices extends Component {
                               <Field.Input
                                 id="card-number"
                                 placeholder="XXXX XXXX XXXX XXXX"
+                                autoComplete="cc-number"
                                 error={error}
                               />
 
@@ -139,11 +147,34 @@ class PaymentChoices extends Component {
                                     id="month"
                                     name="month"
                                     placeholder="Mois"
+                                    value={this.state.expMonth}
                                     options={[
-                                      { value: 1, label: 'Janvier' },
-                                      { value: 2, label: 'Février' },
+                                      { value: '01', label: '01' },
+                                      { value: '02', label: '02' },
+                                      { value: '03', label: '03' },
+                                      { value: '04', label: '04' },
+                                      { value: '05', label: '05' },
+                                      { value: '06', label: '06' },
+                                      { value: '07', label: '07' },
+                                      { value: '08', label: '08' },
+                                      { value: '09', label: '09' },
+                                      { value: '10', label: '10' },
+                                      { value: '11', label: '11' },
+                                      { value: '12', label: '12' },
                                     ]}
                                     error={error}
+                                  />
+                                  <input
+                                    name="cc-exp"
+                                    id="frmCCExp"
+                                    placeholder="MM-YYYY"
+                                    autoComplete="cc-exp"
+                                    style={{
+                                      position: 'absolute',
+                                      zIndex: '-1',
+                                      opacity: '0',
+                                    }}
+                                    onChange={this.handleExpChange}
                                   />
                                 </GridCol>
 
@@ -152,11 +183,16 @@ class PaymentChoices extends Component {
                                     id="year"
                                     name="year"
                                     placeholder="Année"
+                                    value={this.state.expYear}
                                     options={[
-                                      { value: 2018, label: '2018' },
-                                      { value: 2019, label: '2019' },
-                                      { value: 2020, label: '2020' },
-                                      { value: 2021, label: '2021' },
+                                      { value: 2018, label: '18' },
+                                      { value: 2019, label: '19' },
+                                      { value: 2020, label: '20' },
+                                      { value: 2021, label: '21' },
+                                      { value: 2022, label: '22' },
+                                      { value: 2023, label: '23' },
+                                      { value: 2024, label: '24' },
+                                      { value: 2025, label: '25' },
                                     ]}
                                     error={error}
                                   />

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@kisskissbankbank/kitten",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -13355,7 +13355,7 @@
     },
     "raw-loader": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/raw-loader/-/raw-loader-0.5.1.tgz",
       "integrity": "sha1-DD0L6u2KAclm2Xh793goElKpeao=",
       "dev": true
     },


### PR DESCRIPTION
PR qui va permettre de gérer l'autofill des champs month et year de la carte de crédit.

j'ai besoin d'un input pour avoir les valeurs par le navigateur. Input que je dois pour l'instant cacher à l'utilisateur... sans utiliser `display: none` ( ce serait trop facile). Du coup j'ai fait un petit tour de passe-passe qui semble fonctionner... Dites moi si vous avez mieux !