### PR TITLE
[Header] Flexbox on IE10, IE11 bugfix

### DIFF
--- a/assets/stylesheets/kitten/components/headers/_header.scss
+++ b/assets/stylesheets/kitten/components/headers/_header.scss
@@ -77,8 +77,7 @@
 
   .k-Header__items--fixedSize,
   .k-Header__item--fixedSize {
-    flex: initial;
-    flex-shrink: 0;
+    flex: none;
   }
 
   .k-Header__item {


### PR DESCRIPTION
Closes #1532.

Screenshot:
![image](https://user-images.githubusercontent.com/1781070/52119306-f4d23c00-2618-11e9-963f-4d7aaabf6fff.png)


TODO:

- [ ] Tests
- [X] Changelog
- [ ] A11Y
- [ ] Stories
