### PR TITLE
[Fix] Remove test warnings on `SelectWithState` for `htmlFor` and `autoComplete` props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
-- Fix: `SelectWithState` fix test warnings about `htmlFor` and `autoComplete` props
+- Fix: `SelectWithState` fix warnings about `htmlFor` and `autoComplete` props
 
 ## [1.17.0] - 2019-02-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: `SelectWithState` fix test warnings about `htmlFor` and `autoComplete` props
+
 ## [1.17.0] - 2019-02-21
 
 Feature:

--- a/assets/javascripts/kitten/components/form/select-with-state.js
+++ b/assets/javascripts/kitten/components/form/select-with-state.js
@@ -79,13 +79,13 @@ export class SelectWithState extends Component {
     return (
       <div className={selectClassName}>
         {labelText && (
-          <label className="k-Select__label" for={this.props.id}>
+          <label className="k-Select__label" htmlFor={this.props.id}>
             {labelText}
           </label>
         )}
         {autoFill && (
           <input
-            autocomplete={autoFill}
+            autoComplete={autoFill}
             x-autocompletetype={autoFill}
             xautocompletetype={autoFill}
             autocompletetype={autoFill}

--- a/assets/javascripts/kitten/components/form/select-with-state.test.js
+++ b/assets/javascripts/kitten/components/form/select-with-state.test.js
@@ -180,7 +180,7 @@ describe('<SelectWithState />', () => {
 
       expect(select.exists('input')).toBe(true)
       const input = select.find('input')
-      expect(input.props().autocomplete).toBe(autoFillName)
+      expect(input.props().autoComplete).toBe(autoFillName)
       expect(input.props()['x-autocompletetype']).toBe(autoFillName)
       expect(input.props().xautocompletetype).toBe(autoFillName)
       expect(input.props().name).toBe(autoFillName)
@@ -195,7 +195,7 @@ describe('<SelectWithState />', () => {
           value="foo"
         />,
       )
-      const input = select.find({ autocomplete: autoFillName })
+      const input = select.find({ autoComplete: autoFillName })
       input.simulate('change', { target: { value: '2010' } })
       expect(select.state().value).toBe('2010')
     })


### PR DESCRIPTION
TODO:

- [X] Tests
- [X] Changelog
- [X] A11Y
- [?] Stories
