### PR TITLE
[VerticalStepper] Fix Step warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   from `fromXxs` to `fromXl` and `default` and object values in
   `'top'`, `'right'`, `'bottom'`, `'left'`.
 - Fix: `SelectWithState` fix warnings about `htmlFor` and `autoComplete` props
+- Fix: Fix `VerticalStepper.Step` warning.
 - Fix: Change positioning (from absolute to flex) on button in `TextInputWithButton` component.
 
 ## [1.17.0] - 2019-02-21

--- a/assets/javascripts/kitten/components/steppers/vertical-stepper/components/step.js
+++ b/assets/javascripts/kitten/components/steppers/vertical-stepper/components/step.js
@@ -8,7 +8,7 @@ import { STEP_CLASSNAME, LINK_CLASSNAME } from '../index'
 
 export class Step extends Component {
   static propTypes = {
-    href: PropTypes.string.isRequired,
+    href: PropTypes.string,
     valid: PropTypes.bool,
     success: PropTypes.bool,
     error: PropTypes.bool,
@@ -17,6 +17,7 @@ export class Step extends Component {
   }
 
   static defaultProps = {
+    href: null,
     valid: false,
     success: false,
     error: false,

--- a/src/components/steppers/vertical-stepper/components/step.js
+++ b/src/components/steppers/vertical-stepper/components/step.js
@@ -79,7 +79,7 @@ function (_Component) {
 
 exports.Step = Step;
 Step.propTypes = {
-  href: _propTypes.default.string.isRequired,
+  href: _propTypes.default.string,
   valid: _propTypes.default.bool,
   success: _propTypes.default.bool,
   error: _propTypes.default.bool,
@@ -87,6 +87,7 @@ Step.propTypes = {
   disabled: _propTypes.default.bool
 };
 Step.defaultProps = {
+  href: null,
   valid: false,
   success: false,
   error: false,
@@ -97,7 +98,7 @@ Step.defaultProps = {
 var StyledItem = _styledComponents.default.li.withConfig({
   displayName: "step__StyledItem",
   componentId: "sc-1you76f-0"
-})(["margin ", " 0;"], (0, _typography.pxToRem)(30));
+})(["margin ", " 0 ", ";"], (0, _typography.pxToRem)(30), (0, _typography.pxToRem)(28));
 
 var StyledLink = _styledComponents.default.a.withConfig({
   displayName: "step__StyledLink",

--- a/src/components/steppers/vertical-stepper/components/step.js
+++ b/src/components/steppers/vertical-stepper/components/step.js
@@ -98,7 +98,7 @@ Step.defaultProps = {
 var StyledItem = _styledComponents.default.li.withConfig({
   displayName: "step__StyledItem",
   componentId: "sc-1you76f-0"
-})(["margin ", " 0 ", ";"], (0, _typography.pxToRem)(30), (0, _typography.pxToRem)(28));
+})(["margin ", " 0;"], (0, _typography.pxToRem)(30));
 
 var StyledLink = _styledComponents.default.a.withConfig({
   displayName: "step__StyledLink",


### PR DESCRIPTION
Le `href` n'est plus requis sur `VerticalStepper.Step`.