### PR TITLE
Update Field : input, label and select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
+Features:
+- Add `withoutMarger` prop to `Field.Input`, `Field.Label` and `Field.Select`.
+- Add `unit` prop to `Field.Input`.
+
 
 ## [1.22.0] - 2019-03-18
 

--- a/assets/javascripts/kitten/components/form/field/__snapshots__/field.test.js.snap
+++ b/assets/javascripts/kitten/components/form/field/__snapshots__/field.test.js.snap
@@ -73,7 +73,6 @@ Array [
       className="k-TextInput is-error"
       disabled={false}
       id="input"
-      limit={null}
       name="field"
       placeholder="Placeholder…"
       type="text"
@@ -169,7 +168,6 @@ Array [
       className="k-TextInput"
       disabled={false}
       id="input"
-      limit={null}
       name="field"
       placeholder="Placeholder…"
       type="text"

--- a/assets/javascripts/kitten/components/form/field/components/input.js
+++ b/assets/javascripts/kitten/components/form/field/components/input.js
@@ -1,25 +1,37 @@
-import React, { Component } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 import { Marger } from '../../../layout/marger'
 import { TextInput } from '../../../form/text-input'
 import { TextInputWithLimit } from '../../../form/text-input-with-limit'
+import { TextInputWithUnit } from '../../text-input-with-unit.js'
 
-export class FieldInput extends Component {
-  static propTypes = {
-    limit: PropTypes.number,
+export const FieldInput = props => {
+  const { limit, unit, withoutMargin } = props
+  let Input = TextInput
+  if (limit) {
+    Input = TextInputWithLimit
+  }
+  if (unit) {
+    Input = TextInputWithUnit
   }
 
-  static defaultProps = {
-    limit: null,
+  if (withoutMargin) {
+    return <Input {...props} />
   }
 
-  render() {
-    const Input = this.props.limit ? TextInputWithLimit : TextInput
+  return (
+    <Marger top="1.5">
+      <Input {...props} />
+    </Marger>
+  )
+}
+FieldInput.propTypes = {
+  limit: PropTypes.number,
+  unit: PropTypes.string,
+  withoutMargin: PropTypes.bool,
+}
 
-    return (
-      <Marger top="1.5">
-        <Input {...this.props} />
-      </Marger>
-    )
-  }
+FieldInput.defaultProps = {
+  limit: undefined,
+  unit: undefined,
 }

--- a/assets/javascripts/kitten/components/form/field/components/label.js
+++ b/assets/javascripts/kitten/components/form/field/components/label.js
@@ -5,36 +5,44 @@ import { Label } from '../../../form/label'
 import { Tooltip } from '../../../tooltips/tooltip'
 import { Line } from '../../../layout/line'
 
-export class FieldLabel extends Component {
-  static propTypes = {
-    tooltip: PropTypes.string,
-    labelProps: PropTypes.object,
+export const FieldLabel = ({
+  children,
+  tooltip,
+  tooltipId,
+  labelProps,
+  withoutMargin,
+}) => {
+  const InnerLabel = (
+    <Line style={{ lineHeight: 1 }}>
+      <Line.Item>
+        <Label {...labelProps} size="tiny">
+          {children}
+        </Label>
+      </Line.Item>
+
+      {tooltip && (
+        <Line.Item>
+          <Tooltip id={tooltipId}>{tooltip}</Tooltip>
+        </Line.Item>
+      )}
+    </Line>
+  )
+
+  if (withoutMargin) {
+    return InnerLabel
   }
 
-  static defaultProps = {
-    tooltip: null,
-    labelProps: {},
-  }
+  return <Marger bottom="1.5">{InnerLabel}</Marger>
+}
 
-  render() {
-    const { children, tooltip, tooltipId, labelProps } = this.props
+FieldLabel.propTypes = {
+  tooltip: PropTypes.string,
+  labelProps: PropTypes.object,
+  withoutMargin: PropTypes.bool,
+}
 
-    return (
-      <Marger bottom="1.5">
-        <Line style={{ lineHeight: 1 }}>
-          <Line.Item>
-            <Label {...labelProps} size="tiny">
-              {children}
-            </Label>
-          </Line.Item>
-
-          {tooltip && (
-            <Line.Item>
-              <Tooltip id={tooltipId}>{tooltip}</Tooltip>
-            </Line.Item>
-          )}
-        </Line>
-      </Marger>
-    )
-  }
+FieldLabel.defaultProps = {
+  tooltip: null,
+  labelProps: {},
+  withoutMargin: false,
 }

--- a/assets/javascripts/kitten/components/form/field/components/select.js
+++ b/assets/javascripts/kitten/components/form/field/components/select.js
@@ -1,9 +1,22 @@
 import React, { Component } from 'react'
 import { Marger } from '../../../layout/marger'
 import { SelectWithState } from '../../../form/select-with-state'
+import PropTypes from 'prop-types'
 
 export class FieldSelect extends Component {
+  static propTypes = {
+    withoutMargin: PropTypes.bool,
+  }
+
+  static defaultProps = {
+    withoutMargin: false,
+  }
+
   render() {
+    if (this.props.withoutMargin) {
+      return <SelectWithState {...this.props} />
+    }
+
     return (
       <Marger top="1.5">
         <SelectWithState {...this.props} />

--- a/src/components/form/field/components/input.js
+++ b/src/components/form/field/components/input.js
@@ -1,7 +1,5 @@
 "use strict";
 
-var _interopRequireWildcard = require("@babel/runtime/helpers/interopRequireWildcard");
-
 var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
 
 Object.defineProperty(exports, "__esModule", {
@@ -9,17 +7,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.FieldInput = void 0;
 
-var _classCallCheck2 = _interopRequireDefault(require("@babel/runtime/helpers/classCallCheck"));
-
-var _createClass2 = _interopRequireDefault(require("@babel/runtime/helpers/createClass"));
-
-var _possibleConstructorReturn2 = _interopRequireDefault(require("@babel/runtime/helpers/possibleConstructorReturn"));
-
-var _getPrototypeOf2 = _interopRequireDefault(require("@babel/runtime/helpers/getPrototypeOf"));
-
-var _inherits2 = _interopRequireDefault(require("@babel/runtime/helpers/inherits"));
-
-var _react = _interopRequireWildcard(require("react"));
+var _react = _interopRequireDefault(require("react"));
 
 var _propTypes = _interopRequireDefault(require("prop-types"));
 
@@ -29,32 +17,38 @@ var _textInput = require("../../../form/text-input");
 
 var _textInputWithLimit = require("../../../form/text-input-with-limit");
 
-var FieldInput =
-/*#__PURE__*/
-function (_Component) {
-  (0, _inherits2.default)(FieldInput, _Component);
+var _textInputWithUnit = require("../../text-input-with-unit.js");
 
-  function FieldInput() {
-    (0, _classCallCheck2.default)(this, FieldInput);
-    return (0, _possibleConstructorReturn2.default)(this, (0, _getPrototypeOf2.default)(FieldInput).apply(this, arguments));
+var FieldInput = function FieldInput(props) {
+  var limit = props.limit,
+      unit = props.unit,
+      withoutMargin = props.withoutMargin;
+  var Input = _textInput.TextInput;
+
+  if (limit) {
+    Input = _textInputWithLimit.TextInputWithLimit;
   }
 
-  (0, _createClass2.default)(FieldInput, [{
-    key: "render",
-    value: function render() {
-      var Input = this.props.limit ? _textInputWithLimit.TextInputWithLimit : _textInput.TextInput;
-      return _react.default.createElement(_marger.Marger, {
-        top: "1.5"
-      }, _react.default.createElement(Input, this.props));
-    }
-  }]);
-  return FieldInput;
-}(_react.Component);
+  if (unit) {
+    Input = _textInputWithUnit.TextInputWithUnit;
+  }
+
+  if (withoutMargin) {
+    return _react.default.createElement(Input, props);
+  }
+
+  return _react.default.createElement(_marger.Marger, {
+    top: "1.5"
+  }, _react.default.createElement(Input, props));
+};
 
 exports.FieldInput = FieldInput;
 FieldInput.propTypes = {
-  limit: _propTypes.default.number
+  limit: _propTypes.default.number,
+  unit: _propTypes.default.string,
+  withoutMargin: _propTypes.default.bool
 };
 FieldInput.defaultProps = {
-  limit: null
+  limit: undefined,
+  unit: undefined
 };

--- a/src/components/form/field/components/label.js
+++ b/src/components/form/field/components/label.js
@@ -11,16 +11,6 @@ exports.FieldLabel = void 0;
 
 var _extends2 = _interopRequireDefault(require("@babel/runtime/helpers/extends"));
 
-var _classCallCheck2 = _interopRequireDefault(require("@babel/runtime/helpers/classCallCheck"));
-
-var _createClass2 = _interopRequireDefault(require("@babel/runtime/helpers/createClass"));
-
-var _possibleConstructorReturn2 = _interopRequireDefault(require("@babel/runtime/helpers/possibleConstructorReturn"));
-
-var _getPrototypeOf2 = _interopRequireDefault(require("@babel/runtime/helpers/getPrototypeOf"));
-
-var _inherits2 = _interopRequireDefault(require("@babel/runtime/helpers/inherits"));
-
 var _react = _interopRequireWildcard(require("react"));
 
 var _propTypes = _interopRequireDefault(require("prop-types"));
@@ -33,46 +23,40 @@ var _tooltip = require("../../../tooltips/tooltip");
 
 var _line = require("../../../layout/line");
 
-var FieldLabel =
-/*#__PURE__*/
-function (_Component) {
-  (0, _inherits2.default)(FieldLabel, _Component);
+var FieldLabel = function FieldLabel(_ref) {
+  var children = _ref.children,
+      tooltip = _ref.tooltip,
+      tooltipId = _ref.tooltipId,
+      labelProps = _ref.labelProps,
+      withoutMargin = _ref.withoutMargin;
 
-  function FieldLabel() {
-    (0, _classCallCheck2.default)(this, FieldLabel);
-    return (0, _possibleConstructorReturn2.default)(this, (0, _getPrototypeOf2.default)(FieldLabel).apply(this, arguments));
+  var InnerLabel = _react.default.createElement(_line.Line, {
+    style: {
+      lineHeight: 1
+    }
+  }, _react.default.createElement(_line.Line.Item, null, _react.default.createElement(_label.Label, (0, _extends2.default)({}, labelProps, {
+    size: "tiny"
+  }), children)), tooltip && _react.default.createElement(_line.Line.Item, null, _react.default.createElement(_tooltip.Tooltip, {
+    id: tooltipId
+  }, tooltip)));
+
+  if (withoutMargin) {
+    return InnerLabel;
   }
 
-  (0, _createClass2.default)(FieldLabel, [{
-    key: "render",
-    value: function render() {
-      var _this$props = this.props,
-          children = _this$props.children,
-          tooltip = _this$props.tooltip,
-          tooltipId = _this$props.tooltipId,
-          labelProps = _this$props.labelProps;
-      return _react.default.createElement(_marger.Marger, {
-        bottom: "1.5"
-      }, _react.default.createElement(_line.Line, {
-        style: {
-          lineHeight: 1
-        }
-      }, _react.default.createElement(_line.Line.Item, null, _react.default.createElement(_label.Label, (0, _extends2.default)({}, labelProps, {
-        size: "tiny"
-      }), children)), tooltip && _react.default.createElement(_line.Line.Item, null, _react.default.createElement(_tooltip.Tooltip, {
-        id: tooltipId
-      }, tooltip))));
-    }
-  }]);
-  return FieldLabel;
-}(_react.Component);
+  return _react.default.createElement(_marger.Marger, {
+    bottom: "1.5"
+  }, InnerLabel);
+};
 
 exports.FieldLabel = FieldLabel;
 FieldLabel.propTypes = {
   tooltip: _propTypes.default.string,
-  labelProps: _propTypes.default.object
+  labelProps: _propTypes.default.object,
+  withoutMargin: _propTypes.default.bool
 };
 FieldLabel.defaultProps = {
   tooltip: null,
-  labelProps: {}
+  labelProps: {},
+  withoutMargin: false
 };

--- a/src/components/form/field/components/select.js
+++ b/src/components/form/field/components/select.js
@@ -25,6 +25,8 @@ var _marger = require("../../../layout/marger");
 
 var _selectWithState = require("../../../form/select-with-state");
 
+var _propTypes = _interopRequireDefault(require("prop-types"));
+
 var FieldSelect =
 /*#__PURE__*/
 function (_Component) {
@@ -38,6 +40,10 @@ function (_Component) {
   (0, _createClass2.default)(FieldSelect, [{
     key: "render",
     value: function render() {
+      if (this.props.withoutMargin) {
+        return _react.default.createElement(_selectWithState.SelectWithState, this.props);
+      }
+
       return _react.default.createElement(_marger.Marger, {
         top: "1.5"
       }, _react.default.createElement(_selectWithState.SelectWithState, this.props));
@@ -47,3 +53,9 @@ function (_Component) {
 }(_react.Component);
 
 exports.FieldSelect = FieldSelect;
+FieldSelect.propTypes = {
+  withoutMargin: _propTypes.default.bool
+};
+FieldSelect.defaultProps = {
+  withoutMargin: false
+};


### PR DESCRIPTION
- Ajout de la prop `withoutMarger` sur les fields. Il y a quelques fois où nous n'avons pas envie d'avoir le marger à "1.5". Par exemple quand le `Label` suit un `Input` dans un `Grid`. Les `Marger` ne se fusionnent pas et nous on finit donc avec un margin de "3".
- J'ajoute aussi `unit` pour le `Field.Input`.
