### PR TITLE
Feature Add badge with icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fix: Add `VerticalStepper.Link` styles when is an `a`.
 - Fix: Fix `WarningIcon` warning.
 - Fix: Fix buggy settings on `StickyContainer`.
+- Feature: Add `Icon` and `color` props to `Badge` component.
 
 ## [2.1.0] - 2019-04-11
 

--- a/assets/javascripts/kitten/components/buttons/button/stories.js
+++ b/assets/javascripts/kitten/components/buttons/button/stories.js
@@ -220,7 +220,7 @@ storiesOf('Buttons/Button', module)
                 disabled={boolean('Disabled', false)}
               >
                 <span>{text('Text', 'MyButton')}</span>
-                <Badge color={text('Badge color', 'red')} Icon={Cart} spaced>
+                <Badge color={text('Badge color', 'red')} Icon={Cart}>
                   {text('Count', '2')}
                 </Badge>
               </Button>

--- a/assets/javascripts/kitten/components/buttons/button/stories.js
+++ b/assets/javascripts/kitten/components/buttons/button/stories.js
@@ -14,6 +14,8 @@ import { Marger } from '../../layout/marger'
 import { Container } from '../../grid/container'
 import { Grid, GridCol } from '../../grid/grid'
 import { BurgerIcon } from '../../icons/burger-icon'
+import { Badge } from '../../..'
+import Cart from '../../icons/cart'
 
 const svgSizeRange = {
   range: true,
@@ -205,3 +207,26 @@ storiesOf('Buttons/Button', module)
     },
     { info },
   )
+  .add('with badge', () => {
+    return (
+      <Marger top="4" bottom="4">
+        <Container>
+          <Grid>
+            <GridCol>
+              <Button
+                tiny={boolean('Tiny', false)}
+                big={boolean('Big', false)}
+                modifier={select('Modifier', modifierOptions, 'helium')}
+                disabled={boolean('Disabled', false)}
+              >
+                <span>{text('Text', 'MyButton')}</span>
+                <Badge color={text('Badge color', 'red')} Icon={Cart} spaced>
+                  {text('Count', '2')}
+                </Badge>
+              </Button>
+            </GridCol>
+          </Grid>
+        </Container>
+      </Marger>
+    )
+  })

--- a/assets/javascripts/kitten/components/icons/cart.js
+++ b/assets/javascripts/kitten/components/icons/cart.js
@@ -1,0 +1,13 @@
+import React from 'react'
+
+const Cart = props => (
+  <svg width={17} height={16} {...props}>
+    <path
+      d="M4.5 6V4a4 4 0 1 1 8 0v2h4l-2 10h-12L.5 6h4zm2 0h4V4a2 2 0 0 0-4 0v2z"
+      fill="#FFF"
+      fillRule="evenodd"
+    />
+  </svg>
+)
+
+export default Cart

--- a/assets/javascripts/kitten/components/icons/cart.js
+++ b/assets/javascripts/kitten/components/icons/cart.js
@@ -4,7 +4,7 @@ const Cart = props => (
   <svg width={17} height={16} {...props}>
     <path
       d="M4.5 6V4a4 4 0 1 1 8 0v2h4l-2 10h-12L.5 6h4zm2 0h4V4a2 2 0 0 0-4 0v2z"
-      fill="#FFF"
+      fill="#fff"
       fillRule="evenodd"
     />
   </svg>

--- a/assets/javascripts/kitten/components/notifications/__snapshots__/badge.test.js.snap
+++ b/assets/javascripts/kitten/components/notifications/__snapshots__/badge.test.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Badge /> with icon should match the snapshot 1`] = `
+<div>
+  <svg
+    height={16}
+    width={17}
+  >
+    <path
+      d="M4.5 6V4a4 4 0 1 1 8 0v2h4l-2 10h-12L.5 6h4zm2 0h4V4a2 2 0 0 0-4 0v2z"
+      fill="#FFF"
+      fillRule="evenodd"
+    />
+  </svg>
+  <span
+    className="k-Badge badge__StyledBadge-sc-7liuod-0 bifvHg"
+    color="red"
+    role="alert"
+  />
+</div>
+`;

--- a/assets/javascripts/kitten/components/notifications/__snapshots__/badge.test.js.snap
+++ b/assets/javascripts/kitten/components/notifications/__snapshots__/badge.test.js.snap
@@ -8,12 +8,12 @@ exports[`<Badge /> with icon should match the snapshot 1`] = `
   >
     <path
       d="M4.5 6V4a4 4 0 1 1 8 0v2h4l-2 10h-12L.5 6h4zm2 0h4V4a2 2 0 0 0-4 0v2z"
-      fill="#FFF"
+      fill="#fff"
       fillRule="evenodd"
     />
   </svg>
   <span
-    className="k-Badge badge__StyledBadge-sc-7liuod-0 bifvHg"
+    className="k-Badge badge__StyledBadge-sc-7liuod-0 jXPjAe"
     color="red"
     role="alert"
   />

--- a/assets/javascripts/kitten/components/notifications/badge.js
+++ b/assets/javascripts/kitten/components/notifications/badge.js
@@ -1,19 +1,49 @@
-import React, { Component } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled, { css } from 'styled-components'
 import classNames from 'classnames'
 
-export class Badge extends Component {
-  render() {
-    const { className, spaced, ...others } = this.props
+const StyledBadge = styled.span`
+  ${({ color }) =>
+    color &&
+    css`
+      background-color: ${color};
+    `}
+  ${({ withIcon }) =>
+    withIcon &&
+    css`
+      position: absolute;
+      margin-left: -8px;
+      margin-top: -4px;
+    `}
+`
 
-    const badgeClassName = classNames('k-Badge', className, {
-      'k-Badge--spaced': spaced,
-    })
+export const Badge = ({ className, spaced, Icon, ...others }) => {
+  return (
+    <div>
+      {Icon && <Icon />}
+      <StyledBadge
+        role="alert"
+        className={classNames('k-Badge', className, {
+          'k-Badge--spaced': spaced,
+        })}
+        withIcon={Icon !== null}
+        {...others}
+      />
+    </div>
+  )
+}
 
-    return <span role="alert" className={badgeClassName} {...others} />
-  }
+Badge.propTypes = {
+  className: PropTypes.string,
+  spaced: PropTypes.bool,
+  color: PropTypes.string,
+  Icon: PropTypes.func,
 }
 
 Badge.defaultProps = {
   className: null,
   spaced: false,
+  Icon: null,
+  color: null,
 }

--- a/assets/javascripts/kitten/components/notifications/badge.js
+++ b/assets/javascripts/kitten/components/notifications/badge.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled, { css } from 'styled-components'
 import classNames from 'classnames'
+import { pxToRem } from '../../helpers/utils/typography'
 
 const StyledBadge = styled.span`
   ${({ color }) =>
@@ -13,8 +14,8 @@ const StyledBadge = styled.span`
     withIcon &&
     css`
       position: absolute;
-      margin-left: -8px;
-      margin-top: -4px;
+      margin-left: ${pxToRem(-8)};
+      margin-top: ${pxToRem(-4)};
     `}
 `
 

--- a/assets/javascripts/kitten/components/notifications/badge.test.js
+++ b/assets/javascripts/kitten/components/notifications/badge.test.js
@@ -1,45 +1,45 @@
 import React from 'react'
 import { Badge } from './badge'
 
-describe('<Badge />', () => {
+fdescribe('<Badge />', () => {
   describe('by default', () => {
-    const badge = shallow(<Badge />)
+    const badge = render(<Badge />)
 
-    it('is a <span />', () => {
-      expect(badge.is('span')).toBe(true)
+    it('is a <div />', () => {
+      expect(badge.is('div')).toBe(true)
     })
 
     it('has a default class', () => {
-      expect(badge.hasClass('k-Badge')).toBe(true)
+      expect(badge.find('span').hasClass('k-Badge')).toBe(true)
     })
   })
 
   describe('with className prop', () => {
-    const badge = shallow(<Badge className="custom__class" />)
+    const badge = render(<Badge className="custom__class" />)
 
     it('has a custom class', () => {
-      expect(badge.hasClass('custom__class')).toBe(true)
+      expect(badge.find('span').hasClass('custom__class')).toBe(true)
     })
   })
 
   describe('with spaced prop', () => {
-    const badge = shallow(<Badge spaced />)
+    const badge = render(<Badge spaced />)
 
     it('has a good class', () => {
-      expect(badge.hasClass('k-Badge--spaced')).toBe(true)
+      expect(badge.find('span').hasClass('k-Badge--spaced')).toBe(true)
     })
   })
 
   describe('with other prop', () => {
-    const badge = shallow(<Badge aria-hidden="true" />)
-
+    const badge = render(<Badge aria-hidden="true" />)
+    console.log(badge.find('span'))
     it('has an aria-hidden attribute', () => {
-      expect(badge.props()['aria-hidden']).toBe('true')
+      expect(badge.find('span').prop('aria-hidden')).toBe('true')
     })
   })
 
   describe('with children', () => {
-    const badge = shallow(<Badge>42</Badge>)
+    const badge = render(<Badge>42</Badge>)
 
     it('has text', () => {
       expect(badge.text()).toBe('42')

--- a/assets/javascripts/kitten/components/notifications/badge.test.js
+++ b/assets/javascripts/kitten/components/notifications/badge.test.js
@@ -1,7 +1,9 @@
 import React from 'react'
 import { Badge } from './badge'
+import Cart from '../icons/cart'
+import renderer from 'react-test-renderer'
 
-fdescribe('<Badge />', () => {
+describe('<Badge />', () => {
   describe('by default', () => {
     const badge = render(<Badge />)
 
@@ -32,7 +34,6 @@ fdescribe('<Badge />', () => {
 
   describe('with other prop', () => {
     const badge = render(<Badge aria-hidden="true" />)
-    console.log(badge.find('span'))
     it('has an aria-hidden attribute', () => {
       expect(badge.find('span').prop('aria-hidden')).toBe('true')
     })
@@ -43,6 +44,13 @@ fdescribe('<Badge />', () => {
 
     it('has text', () => {
       expect(badge.text()).toBe('42')
+    })
+  })
+
+  describe('with icon', () => {
+    it('should match the snapshot', () => {
+      const tree = renderer.create(<Badge color="red" Icon={Cart} />).toJSON()
+      expect(tree).toMatchSnapshot()
     })
   })
 })


### PR DESCRIPTION
Permet de pouvoir ajouter un icon au badge pour pouvoir faire un truc du genre : 
![Capture d’écran 2019-04-18 à 12 07 41](https://user-images.githubusercontent.com/804738/56353826-94dc4200-61d2-11e9-9d7e-fe81977d225f.png)
