### PR TITLE
[Details] Fix `open` prop propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Fix `open` prop propagation to `Details` component.
+
 ## [2.4.2] - 2019-05-02
 
 Fix:

--- a/assets/javascripts/kitten/components/details/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/details/__snapshots__/test.js.snap
@@ -22,6 +22,7 @@ exports[`<Details /> with default props matches with snapshot 1`] = `
 
 <details
   onToggle={[Function]}
+  open={false}
 >
   <summary
     className="c0"

--- a/assets/javascripts/kitten/components/details/index.js
+++ b/assets/javascripts/kitten/components/details/index.js
@@ -26,7 +26,7 @@ export const Details = ({
   onToggle,
   ...props
 }) => {
-  const [open, setOpen] = useState(openDefault)
+  const [open, setOpen] = useState(false)
 
   const handleToggle = event => {
     setOpen(!open)
@@ -34,7 +34,7 @@ export const Details = ({
   }
 
   return (
-    <details onToggle={handleToggle} {...props}>
+    <details onToggle={handleToggle} open={openDefault} {...props}>
       <Summary>{summaryRender({ open })}</Summary>
 
       {children}

--- a/assets/javascripts/kitten/components/details/stories.js
+++ b/assets/javascripts/kitten/components/details/stories.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { withInfo } from '@storybook/addon-info'
-import { withKnobs } from '@storybook/addon-knobs'
+import { withKnobs, boolean } from '@storybook/addon-knobs'
 import { info } from './info'
 import { Details } from './index'
 import { Marger } from '../layout/marger'
@@ -32,6 +32,7 @@ storiesOf('Details', module)
           <Grid>
             <GridCol>
               <Details
+                open={boolean('Open by default', false)}
                 summaryRender={({ open }) => (
                   <Link weight="regular" size="tiny" color="primary1">
                     {open && 'Close me!'}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13251,6 +13251,7 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
       "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -13260,7 +13261,8 @@
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/components/details/index.js
+++ b/src/components/details/index.js
@@ -37,7 +37,7 @@ var Details = function Details(_ref) {
       onToggle = _ref.onToggle,
       props = (0, _objectWithoutProperties2.default)(_ref, ["children", "summaryRender", "open", "onToggle"]);
 
-  var _useState = (0, _react.useState)(openDefault),
+  var _useState = (0, _react.useState)(false),
       _useState2 = (0, _slicedToArray2.default)(_useState, 2),
       open = _useState2[0],
       setOpen = _useState2[1];
@@ -48,7 +48,8 @@ var Details = function Details(_ref) {
   };
 
   return _react.default.createElement("details", (0, _extends2.default)({
-    onToggle: handleToggle
+    onToggle: handleToggle,
+    open: openDefault
   }, props), _react.default.createElement(Summary, null, summaryRender({
     open: open
   })), children);


### PR DESCRIPTION
La prop `open` n'était pas attachée à la balise `details`… ce qui rendait la prop … inutile.