### PR TITLE
[List] Remove a HTML warning on `List.ButtonItem`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Remove a HTML warning on `List.ButtonItem`.
+
 ## [2.4.4] - 2019-05-06
 
 Fix:

--- a/assets/javascripts/kitten/components/lists/list/components/button-item.js
+++ b/assets/javascripts/kitten/components/lists/list/components/button-item.js
@@ -119,7 +119,7 @@ export const ButtonItem = ({
 
   return (
     <Item
-      role={others.as !== 'a' ? 'button' : false}
+      role={others.as !== 'a' ? 'button' : null}
       tabIndex={disabled ? '-1' : '0'}
       onClick={disabled ? null : onClick}
       onKeyPress={disabled ? null : handleKeyPress}


### PR DESCRIPTION
Une erreur HTML apparait quand le `role={ false }`, ce n'est pas valide.