### PR TITLE
[Fix] IE11 Button height compatibility fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+Fix: IE11 Button height compatibility fix
+
 ## [2.6.0] - 2019-05-15
 
 Feature:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
-Fix: IE11 Button height compatibility fix
+- Fix: IE11 Button height compatibility fix
 
 ## [2.6.0] - 2019-05-15
 

--- a/assets/javascripts/kitten/components/buttons/button-group/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/buttons/button-group/__snapshots__/test.js.snap
@@ -122,6 +122,13 @@ exports[`<ButtonGroup /> with some props matches with snapshot 1`] = `
   z-index: 1;
 }
 
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c2 {
+    width: 12.5rem;
+    height: 3.13rem;
+  }
+}
+
 <div
   className="c0"
   role="group"

--- a/assets/javascripts/kitten/components/buttons/button/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/buttons/button/__snapshots__/test.js.snap
@@ -87,6 +87,13 @@ exports[`<Button /> with \`as\` prop matches with snapshot 1`] = `
   fill: #fff;
 }
 
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c0 {
+    width: 12.5rem;
+    height: 3.13rem;
+  }
+}
+
 <input
   className="c0"
   type="submit"
@@ -185,6 +192,20 @@ exports[`<Button /> with \`big\` prop matches with snapshot 1`] = `
   fill: #fff;
 }
 
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c0 {
+    width: 12.5rem;
+    height: 3.13rem;
+  }
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c0 {
+    width: 13.75rem;
+    height: 4.38rem;
+  }
+}
+
 <button
   className="c0"
 >
@@ -278,6 +299,13 @@ exports[`<Button /> with \`borderRadius\` prop matches with snapshot 1`] = `
 
 .c0:disabled svg {
   fill: #fff;
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c0 {
+    width: 12.5rem;
+    height: 3.13rem;
+  }
 }
 
 <button
@@ -376,6 +404,13 @@ exports[`<Button /> with \`fluid\` prop matches with snapshot 1`] = `
   fill: #fff;
 }
 
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c0 {
+    width: 12.5rem;
+    height: 3.13rem;
+  }
+}
+
 <button
   className="c0"
 >
@@ -468,6 +503,13 @@ exports[`<Button /> with \`modifier\` prop matches with snapshot 1`] = `
 
 .c0:disabled svg {
   fill: #fff;
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c0 {
+    width: 12.5rem;
+    height: 3.13rem;
+  }
 }
 
 <button
@@ -566,6 +608,20 @@ exports[`<Button /> with \`tiny\` prop matches with snapshot 1`] = `
 
 .c0:disabled svg {
   fill: #fff;
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c0 {
+    width: 12.5rem;
+    height: 3.13rem;
+  }
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c0 {
+    width: 10rem;
+    height: 2.5rem;
+  }
 }
 
 <button
@@ -667,6 +723,13 @@ exports[`<Button /> with icon matches with snapshot 1`] = `
   fill: #fff;
 }
 
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c0 {
+    width: 12.5rem;
+    height: 3.13rem;
+  }
+}
+
 <button
   className="c0"
 >
@@ -759,6 +822,13 @@ exports[`<Button /> with some elements matches with snapshot 1`] = `
 
 .c0:disabled svg {
   fill: #fff;
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c0 {
+    width: 12.5rem;
+    height: 3.13rem;
+  }
 }
 
 <button
@@ -858,6 +928,13 @@ exports[`<Button /> with text matches with snapshot 1`] = `
 
 .c0:disabled svg {
   fill: #fff;
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c0 {
+    width: 12.5rem;
+    height: 3.13rem;
+  }
 }
 
 <button

--- a/assets/javascripts/kitten/components/buttons/button/button.js
+++ b/assets/javascripts/kitten/components/buttons/button/button.js
@@ -85,6 +85,10 @@ export const DEFAULT = css`
   min-height: ${pxToRem(50)};
   padding: 0 ${pxToRem(30)};
   font-size: ${pxToRem(14)};
+  @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+    width: ${pxToRem(200)};
+    height: ${pxToRem(50)};
+  }
 `
 
 export const TINY = css`
@@ -92,6 +96,10 @@ export const TINY = css`
   min-height: ${pxToRem(40)};
   padding: 0 ${pxToRem(20)};
   font-size: ${pxToRem(14)};
+  @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+    width: ${pxToRem(160)};
+    height: ${pxToRem(40)};
+  }
 `
 
 export const BIG = css`
@@ -99,6 +107,10 @@ export const BIG = css`
   min-height: ${pxToRem(70)};
   padding: 0 ${pxToRem(40)};
   font-size: ${pxToRem(16)};
+  @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+    width: ${pxToRem(220)};
+    height: ${pxToRem(70)};
+  }
 `
 
 export class Button extends Component {

--- a/assets/javascripts/kitten/components/cards/reward-edition/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/cards/reward-edition/__snapshots__/test.js.snap
@@ -147,6 +147,20 @@ exports[`<RewardEdition /> with some props matches with snapshot 1`] = `
   border-color: #eee;
 }
 
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c4 {
+    width: 12.5rem;
+    height: 3.13rem;
+  }
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c4 {
+    width: 10rem;
+    height: 2.5rem;
+  }
+}
+
 @media (max-width:767px) {
   .c5 {
     padding: 1.88rem;


### PR DESCRIPTION
## Before

![Screenshot 2019-05-17 at 17 38 55](https://user-images.githubusercontent.com/1781070/57939842-78afeb80-78cb-11e9-97d9-8e67fdf0dd47.png)
![Screenshot 2019-05-17 at 17 39 51](https://user-images.githubusercontent.com/1781070/57939839-78175500-78cb-11e9-8ae2-c2d724d4d05a.png)
![Screenshot 2019-05-17 at 17 39 27](https://user-images.githubusercontent.com/1781070/57939840-78afeb80-78cb-11e9-820a-22de43183bc7.png)

## After

![Screenshot 2019-05-17 at 17 42 00](https://user-images.githubusercontent.com/1781070/57939863-836a8080-78cb-11e9-9a19-117ee2095f6b.png)
![Screenshot 2019-05-17 at 17 41 30](https://user-images.githubusercontent.com/1781070/57939864-836a8080-78cb-11e9-98d1-33dea79d2b27.png)
![Screenshot 2019-05-17 at 17 42 17](https://user-images.githubusercontent.com/1781070/57939861-836a8080-78cb-11e9-90d2-2d413f524b4f.png)

Closes #.

Screenshot:


TODO:

- [ ] Tests
- [x] Changelog
- [ ] A11Y
- [x] Stories
- [x] BrowserStack
