### PR TITLE
[SimpleCard] Add `imageContainerBackground` and `imageContainerRatio` to image container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+Feature:
+- Add `imageContainerBackground` and `imageContainerRatio` props to `SimpleCard`
+
 ## [2.10.0] - 2019-06-07
 
 Feature:

--- a/assets/javascripts/kitten/components/cards/simple-card/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/cards/simple-card/__snapshots__/test.js.snap
@@ -5,7 +5,7 @@ exports[`<SimpleCard /> by default matches with snapshot 1`] = `
   className="k-Card k-Card--withoutBoxShadowOnHover simple-card__ContainerStyle-sc-1g5bppt-0 ixVVov"
 >
   <div
-    className="k-Card__imageContainer image__StyledImageContainer-sc-8olw7b-2 jTbmGy marger__StyledMarger-q3lecu-0 jgfcQX"
+    className="k-Card__imageContainer image__StyledImageContainer-sc-8olw7b-2 iPOTuX marger__StyledMarger-q3lecu-0 jgfcQX"
   >
     <img
       alt=""
@@ -21,7 +21,7 @@ exports[`<SimpleCard /> with withPlayerButtonOnImage props matches with snapshot
   className="k-Card k-Card--withoutBoxShadowOnHover simple-card__ContainerStyle-sc-1g5bppt-0 ixVVov"
 >
   <div
-    className="k-Card__imageContainer image__StyledImageContainer-sc-8olw7b-2 jTbmGy marger__StyledMarger-q3lecu-0 jgfcQX"
+    className="k-Card__imageContainer image__StyledImageContainer-sc-8olw7b-2 iPOTuX marger__StyledMarger-q3lecu-0 jgfcQX"
   >
     <div
       className="image__StyledPlayerButton-sc-8olw7b-1 hjoZil"
@@ -46,7 +46,7 @@ exports[`<SimpleCard /> without horizontalStroke prop matches snapshot 1`] = `
   className="k-Card k-Card--withoutBoxShadowOnHover simple-card__ContainerStyle-sc-1g5bppt-0 ixVVov"
 >
   <div
-    className="k-Card__imageContainer image__StyledImageContainer-sc-8olw7b-2 jTbmGy marger__StyledMarger-q3lecu-0 jgfcQX"
+    className="k-Card__imageContainer image__StyledImageContainer-sc-8olw7b-2 iPOTuX marger__StyledMarger-q3lecu-0 jgfcQX"
   >
     <img
       alt=""

--- a/assets/javascripts/kitten/components/cards/simple-card/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/cards/simple-card/__snapshots__/test.js.snap
@@ -5,17 +5,13 @@ exports[`<SimpleCard /> by default matches with snapshot 1`] = `
   className="k-Card k-Card--withoutBoxShadowOnHover simple-card__ContainerStyle-sc-1g5bppt-0 ixVVov"
 >
   <div
-    className="k-Card__imageContainer marger__StyledMarger-q3lecu-0 jgfcQX"
+    className="k-Card__imageContainer image__StyledImageContainer-sc-8olw7b-2 jTbmGy marger__StyledMarger-q3lecu-0 jgfcQX"
   >
-    <div
-      className="image__PlayerStyle-sc-8olw7b-2 jEOAJp"
-    >
-      <img
-        alt=""
-        className="k-Card__image image__ImageStyle-sc-8olw7b-0 bIBocY"
-        src="https://placehold.it/200x200/caf4fe/caf4fe"
-      />
-    </div>
+    <img
+      alt=""
+      className="k-Card__image image__StyledImage-sc-8olw7b-0 KMqEW"
+      src=""
+    />
   </div>
 </div>
 `;
@@ -25,27 +21,22 @@ exports[`<SimpleCard /> with withPlayerButtonOnImage props matches with snapshot
   className="k-Card k-Card--withoutBoxShadowOnHover simple-card__ContainerStyle-sc-1g5bppt-0 ixVVov"
 >
   <div
-    className="k-Card__imageContainer marger__StyledMarger-q3lecu-0 jgfcQX"
+    className="k-Card__imageContainer image__StyledImageContainer-sc-8olw7b-2 jTbmGy marger__StyledMarger-q3lecu-0 jgfcQX"
   >
     <div
-      className="image__PlayerStyle-sc-8olw7b-2 jEOAJp"
+      className="image__StyledPlayerButton-sc-8olw7b-1 hjoZil"
     >
-      <div
-        className="image__PlayerButtonStyle-sc-8olw7b-1 haNito"
+      <span
+        className="k-u-color-background1 k-u-size-default k-u-weight-regular"
       >
-        <span
-          aria-label={null}
-          className="k-u-color-background1 k-u-size-default k-u-weight-regular"
-        >
-          ►
-        </span>
-      </div>
-      <img
-        alt=""
-        className="k-Card__image image__ImageStyle-sc-8olw7b-0 bIBocY"
-        src="https://placehold.it/200x200/caf4fe/caf4fe"
-      />
+        ►
+      </span>
     </div>
+    <img
+      alt=""
+      className="k-Card__image image__StyledImage-sc-8olw7b-0 KMqEW"
+      src=""
+    />
   </div>
 </div>
 `;
@@ -55,17 +46,13 @@ exports[`<SimpleCard /> without horizontalStroke prop matches snapshot 1`] = `
   className="k-Card k-Card--withoutBoxShadowOnHover simple-card__ContainerStyle-sc-1g5bppt-0 ixVVov"
 >
   <div
-    className="k-Card__imageContainer marger__StyledMarger-q3lecu-0 jgfcQX"
+    className="k-Card__imageContainer image__StyledImageContainer-sc-8olw7b-2 jTbmGy marger__StyledMarger-q3lecu-0 jgfcQX"
   >
-    <div
-      className="image__PlayerStyle-sc-8olw7b-2 jEOAJp"
-    >
-      <img
-        alt=""
-        className="k-Card__image image__ImageStyle-sc-8olw7b-0 bIBocY"
-        src="https://placehold.it/200x200/caf4fe/caf4fe"
-      />
-    </div>
+    <img
+      alt=""
+      className="k-Card__image image__StyledImage-sc-8olw7b-0 KMqEW"
+      src=""
+    />
   </div>
 </div>
 `;

--- a/assets/javascripts/kitten/components/cards/simple-card/components/image.js
+++ b/assets/javascripts/kitten/components/cards/simple-card/components/image.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import { Text } from '../../../../components/typography/text'
 import { Marger } from '../../../../components/layout/marger'
 import { pxToRem } from '../../../../helpers/utils/typography'
@@ -25,10 +25,34 @@ const PlayerButtonStyle = styled.div`
   z-index: 2;
 `
 
-const PlayerStyle = styled.div`
+const StyledImageContainer = styled(Marger)`
   position: relative;
   transition: opacity ease 600ms, z-index ease 600ms;
   z-index: 1;
+
+  ${({ imageContainerBackground }) =>
+    imageContainerBackground
+      ? css`
+          background-color: ${imageContainerBackground};
+        `
+      : css`
+          background-color: #caf4fe;
+        `}
+
+  ${({ imageContainerRatio }) =>
+    imageContainerRatio &&
+    css`
+      overflow: hidden;
+      position: relative;
+      padding-top: ${imageContainerRatio}%;
+
+      & > img {
+        position: absolute;
+        top: 0;
+        height: auto;
+        text-align: center;
+      }
+    `}
 `
 
 export class Image extends PureComponent {
@@ -38,6 +62,8 @@ export class Image extends PureComponent {
       withPlayerButtonOnImage,
       arrowColor,
       ariaLabel,
+      imageContainerBackground,
+      imageContainerRatio,
     } = this.props
 
     const PlayerButtonOnImage = props => (
@@ -54,21 +80,21 @@ export class Image extends PureComponent {
     )
 
     return (
-      <Marger bottom="2" className="k-Card__imageContainer">
-        <PlayerStyle>
-          {withPlayerButtonOnImage && (
-            <PlayerButtonOnImage
-              arrowColor={arrowColor}
-              ariaLabel={ariaLabel}
-            />
-          )}
-          <ImageStyle
-            {...imageProps}
-            alt={imageProps.alt || ''}
-            className="k-Card__image"
-          />
-        </PlayerStyle>
-      </Marger>
+      <StyledImageContainer
+        bottom="2"
+        className="k-Card__imageContainer"
+        imageContainerBackground={imageContainerBackground}
+        imageContainerRatio={imageContainerRatio}
+      >
+        {withPlayerButtonOnImage && (
+          <PlayerButtonOnImage arrowColor={arrowColor} ariaLabel={ariaLabel} />
+        )}
+        <ImageStyle
+          {...imageProps}
+          alt={imageProps.alt || ''}
+          className="k-Card__image"
+        />
+      </StyledImageContainer>
     )
   }
 }
@@ -79,18 +105,20 @@ Image.propTypes = {
     alt: PropTypes.string.isRequired,
   }),
   withPlayerButtonOnImage: PropTypes.bool,
-  ariaLabel: PropTypes.string,
+  ariaLabel: PropTypes.string.isRequired,
   arrowColor: PropTypes.string,
   href: PropTypes.string,
+  imageContainerBackground: PropTypes.string,
+  imageContainerRatio: PropTypes.number,
 }
 
 Image.defaultProps = {
   imageProps: {
-    src: 'https://placehold.it/200x200/caf4fe/caf4fe',
+    src: '',
     alt: '',
   },
   withPlayerButtonOnImage: false,
-  ariaLabel: null,
   arrowColor: 'background1',
   href: '#',
+  imageContainerBackground: '#caf4fe',
 }

--- a/assets/javascripts/kitten/components/cards/simple-card/components/image.js
+++ b/assets/javascripts/kitten/components/cards/simple-card/components/image.js
@@ -99,7 +99,7 @@ Image.propTypes = {
     alt: PropTypes.string.isRequired,
   }),
   withPlayerButtonOnImage: PropTypes.bool,
-  ariaLabel: PropTypes.string.isRequired,
+  ariaLabel: PropTypes.string,
   arrowColor: PropTypes.string,
   href: PropTypes.string,
   imageContainerBackground: PropTypes.string,

--- a/assets/javascripts/kitten/components/cards/simple-card/components/image.js
+++ b/assets/javascripts/kitten/components/cards/simple-card/components/image.js
@@ -6,13 +6,13 @@ import { Marger } from '../../../../components/layout/marger'
 import { pxToRem } from '../../../../helpers/utils/typography'
 import COLORS from '../../../../constants/colors-config'
 
-const ImageStyle = styled.img`
+const StyledImage = styled.img`
   width: 100%;
   display: block;
 `
 const playerButtonSize = pxToRem(70)
 
-const PlayerButtonStyle = styled.div`
+const StyledPlayerButton = styled.div`
   width: ${playerButtonSize};
   height: ${playerButtonSize};
   background: ${COLORS.font1};
@@ -67,7 +67,7 @@ export class Image extends PureComponent {
     } = this.props
 
     const PlayerButtonOnImage = props => (
-      <PlayerButtonStyle>
+      <StyledPlayerButton>
         <Text
           size="default"
           weight="regular"
@@ -76,7 +76,7 @@ export class Image extends PureComponent {
         >
           ►
         </Text>
-      </PlayerButtonStyle>
+      </StyledPlayerButton>
     )
 
     return (
@@ -89,7 +89,7 @@ export class Image extends PureComponent {
         {withPlayerButtonOnImage && (
           <PlayerButtonOnImage arrowColor={arrowColor} ariaLabel={ariaLabel} />
         )}
-        <ImageStyle
+        <StyledImage
           {...imageProps}
           alt={imageProps.alt || ''}
           className="k-Card__image"

--- a/assets/javascripts/kitten/components/cards/simple-card/components/image.js
+++ b/assets/javascripts/kitten/components/cards/simple-card/components/image.js
@@ -30,14 +30,8 @@ const StyledImageContainer = styled(Marger)`
   transition: opacity ease 600ms, z-index ease 600ms;
   z-index: 1;
 
-  ${({ imageContainerBackground }) =>
-    imageContainerBackground
-      ? css`
-          background-color: ${imageContainerBackground};
-        `
-      : css`
-          background-color: #caf4fe;
-        `}
+  background-color: ${({ imageContainerBackground }) =>
+    imageContainerBackground};
 
   ${({ imageContainerRatio }) =>
     imageContainerRatio &&
@@ -120,5 +114,5 @@ Image.defaultProps = {
   withPlayerButtonOnImage: false,
   arrowColor: 'background1',
   href: '#',
-  imageContainerBackground: '#caf4fe',
+  imageContainerBackground: COLORS.line1,
 }

--- a/assets/javascripts/kitten/components/cards/simple-card/index.js
+++ b/assets/javascripts/kitten/components/cards/simple-card/index.js
@@ -5,6 +5,7 @@ import { Image } from './components/image'
 import { TitleComponent } from './components/title'
 import { Subtitle } from './components/subtitle'
 import { Paragraph } from './components/paragraph'
+import COLORS from '../../../constants/colors-config'
 
 const ContainerStyle = styled.a`
   line-height: 1;
@@ -23,12 +24,16 @@ class SimpleCardComponent extends Component {
       titleProps,
       subtitle,
       paragraph,
+      imageContainerRatio,
+      imageContainerBackground,
       ...others
     } = this.props
 
     return (
       <ContainerStyle {...others} as={href ? 'a' : 'div'} href={href}>
         <Image
+          imageContainerRatio={imageContainerRatio}
+          imageContainerBackground={imageContainerBackground}
           imageProps={imageProps}
           withPlayerButtonOnImage={withPlayerButtonOnImage}
           arrowColor={arrowColor}

--- a/assets/javascripts/kitten/components/cards/simple-card/stories.js
+++ b/assets/javascripts/kitten/components/cards/simple-card/stories.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import { withKnobs, text, boolean } from '@storybook/addon-knobs'
+import { withKnobs, text, boolean, number } from '@storybook/addon-knobs'
 import { SimpleCard } from './index'
 import { Marger } from '../../layout/marger'
 import { Container } from '../../grid/container'
@@ -8,7 +8,7 @@ import { Grid, GridCol } from '../../grid/grid'
 
 storiesOf('Cards/SimpleCard', module)
   .addDecorator(withKnobs)
-  .add('default', () => {
+  .add('Default', () => {
     return (
       <Marger top="4" bottom="4">
         <Container>
@@ -29,6 +29,35 @@ storiesOf('Cards/SimpleCard', module)
                   'With player button on image?',
                   true,
                 )}
+              />
+            </GridCol>
+          </Grid>
+        </Container>
+      </Marger>
+    )
+  })
+  .add('With imageContainerRatio', () => {
+    return (
+      <Marger top="4" bottom="4">
+        <Container>
+          <Grid>
+            <GridCol col="6" col-xs="4" col-m="3" col-l="2">
+              <SimpleCard
+                href="#"
+                imageProps={{
+                  src: text(
+                    'Image src',
+                    'https://placehold.it/160x90/555/caf4fe',
+                  ),
+                }}
+                title={text('Title', 'Title')}
+                subtitle={text('Subtitle', 'Subtitle')}
+                paragraph={text('Paragraph', 'Paragraph')}
+                withPlayerButtonOnImage={boolean(
+                  'With player button on image?',
+                  false,
+                )}
+                imageContainerRatio={number('Adjust Ratio', 56.65)}
               />
             </GridCol>
           </Grid>

--- a/assets/javascripts/kitten/components/cards/simple-card/stories.js
+++ b/assets/javascripts/kitten/components/cards/simple-card/stories.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import { withKnobs, text, boolean, number } from '@storybook/addon-knobs'
+import { withKnobs, text, boolean, number, color } from '@storybook/addon-knobs'
 import { SimpleCard } from './index'
 import { Marger } from '../../layout/marger'
 import { Container } from '../../grid/container'
@@ -57,7 +57,8 @@ storiesOf('Cards/SimpleCard', module)
                   'With player button on image?',
                   false,
                 )}
-                imageContainerRatio={number('Adjust Ratio', 56.65)}
+                imageContainerRatio={number('Adjust Ratio', 56.25)}
+                imageContainerBackground={color('Adjust Color', '#eee')}
               />
             </GridCol>
           </Grid>


### PR DESCRIPTION
Cette PR permettra de spécifier un ratio aux images des `SimpleCard`, pour améliorer le rendu du LazyLoad.

Closes #.

Screenshot:


TODO:

- [ ] Tests
- [ ] Changelog
- [ ] A11Y
- [ ] Stories
- [ ] BrowserStack
