### PR TITLE
[SimpleCarousel] Set `id` attribute as required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: `SimpleCarousel`, set `id` attribute as required
+
 ## [2.11.0] - 2019-06-20
 
 Features:

--- a/assets/javascripts/kitten/components/carousel/__snapshots__/simple-carousel.test.js.snap
+++ b/assets/javascripts/kitten/components/carousel/__snapshots__/simple-carousel.test.js.snap
@@ -9,8 +9,8 @@ Array [
   >
     <div
       aria-hidden={false}
-      aria-labelledby="carouselTab_0"
-      id="carouselItem_0"
+      aria-labelledby="_carouselTab_0"
+      id="_carouselItem_0"
       role="tabpanel"
     >
       <p>
@@ -19,8 +19,8 @@ Array [
     </div>
     <div
       aria-hidden={true}
-      aria-labelledby="carouselTab_1"
-      id="carouselItem_1"
+      aria-labelledby="_carouselTab_1"
+      id="_carouselItem_1"
       role="tabpanel"
     >
       <p>
@@ -35,10 +35,10 @@ Array [
     style={Object {}}
   >
     <button
-      aria-controls="carouselItem_0"
+      aria-controls="_carouselItem_0"
       aria-selected={true}
       className="simple-carousel__StyledPaginationButton-t6k8ig-2 lcjxHC"
-      id="carouselTab_0"
+      id="_carouselTab_0"
       onClick={[Function]}
       role="tab"
       style={Object {}}
@@ -51,10 +51,10 @@ Array [
       </span>
     </button>
     <button
-      aria-controls="carouselItem_1"
+      aria-controls="_carouselItem_1"
       aria-selected={false}
       className="simple-carousel__StyledPaginationButton-t6k8ig-2 lcjxHC"
-      id="carouselTab_1"
+      id="_carouselTab_1"
       onClick={[Function]}
       role="tab"
       style={Object {}}
@@ -78,8 +78,8 @@ exports[`<SimpleCarousel /> with only one item matches with snapshot 1`] = `
 >
   <div
     aria-hidden={false}
-    aria-labelledby="carouselTab_0"
-    id="carouselItem_0"
+    aria-labelledby="_carouselTab_0"
+    id="_carouselItem_0"
     role="tabpanel"
   >
     <p>

--- a/assets/javascripts/kitten/components/carousel/simple-carousel.js
+++ b/assets/javascripts/kitten/components/carousel/simple-carousel.js
@@ -62,7 +62,7 @@ const StyledPaginationButton = styled.button`
 
 export class SimpleCarousel extends Component {
   static propTypes = {
-    id: PropTypes.string,
+    id: PropTypes.string.isRequired,
     containerStyle: PropTypes.object,
     activePaginationColor: PropTypes.string,
     paginationColor: PropTypes.string,
@@ -147,7 +147,7 @@ export class SimpleCarousel extends Component {
 
     const { totalPagesCount, currentPageNumber } = this.state
     const rangePage = createRangeFromZeroTo(totalPagesCount)
-    const id = this.props.id ? this.props.id + '_' : ''
+    const id = this.props.id + '_'
 
     return (
       <>


### PR DESCRIPTION
🛑 Attention ! 🛑

L'attribut `id` devient obligatoire, donc cette PR peut être considérée comme un Breaking Change.
 
Closes #.

Screenshot:


TODO:

- [x] Tests
- [ ] Changelog
- [ ] A11Y
- [ ] Stories
- [ ] BrowserStack
