### PR TITLE
[Comment] Remove HTML warning to `Comment`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Remove HTML warning to `Comment`.
+
 ## [2.14.0] - 2019-07-11
 
 Feature:

--- a/assets/javascripts/kitten/components/comments/comment/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/comments/comment/__snapshots__/test.js.snap
@@ -58,7 +58,7 @@ exports[`<Comment /> should match a snapshot with a complex bottom notes 1`] = `
     <div
       className="marger__StyledMarger-q3lecu-0 gWrqvV"
     >
-      <p
+      <div
         className="k-u-color-font1 k-u-size-micro k-u-weight-bold comment__StyledBottomNotes-sc-8s8e85-5 kLqfi"
       >
         <div>
@@ -83,7 +83,7 @@ exports[`<Comment /> should match a snapshot with a complex bottom notes 1`] = `
             Notify abuse
           </a>
         </div>
-      </p>
+      </div>
     </div>
   </span>
 </div>

--- a/assets/javascripts/kitten/components/comments/comment/index.js
+++ b/assets/javascripts/kitten/components/comments/comment/index.js
@@ -110,7 +110,7 @@ export class Comment extends PureComponent {
           {bottomNotes && (
             <Marger top=".5">
               <StyledBottomNotes
-                tag="p"
+                tag="div"
                 color="font1"
                 size="micro"
                 weight="bold"

--- a/assets/javascripts/kitten/components/comments/comment/stories.js
+++ b/assets/javascripts/kitten/components/comments/comment/stories.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { withInfo } from '@storybook/addon-info'
-import { withKnobs, text, object } from '@storybook/addon-knobs'
+import { withKnobs, text, object, boolean } from '@storybook/addon-knobs'
 import { Comment } from './index'
 import { Grid, GridCol } from '../../../components/grid/grid'
 
@@ -70,6 +70,13 @@ storiesOf('Comments/Comment', module)
               'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris',
             )}
             ownerName={text('Owner name', 'Lorem ipsum')}
+            bottomNotes={
+              boolean('With bottom notes?', false) && (
+                <div>
+                  <p>Bottom notes</p>
+                </div>
+              )
+            }
           />
         </GridCol>
       </Grid>


### PR DESCRIPTION
PR qui supprime ce genre de warnings.

<img width="536" alt="Capture d’écran 2019-07-15 à 15 46 18" src="https://user-images.githubusercontent.com/736319/61222227-8f7f8c80-a71a-11e9-899f-0791c035fd31.png">
