### PR TITLE
[Field] Provide props to `Error` subcomponent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+Feature: Dispatch props to `Field.Error` subcomponent.
+
 ## [2.14.1] - 2019-07-15
 
 Fix:

--- a/assets/javascripts/kitten/components/form/field/components/error.js
+++ b/assets/javascripts/kitten/components/form/field/components/error.js
@@ -4,7 +4,7 @@ import { Text } from '../../../typography/text'
 
 export class FieldError extends Component {
   render() {
-    const { children } = this.props
+    const { children, ...others } = this.props
 
     return (
       <Marger top="1">
@@ -15,6 +15,7 @@ export class FieldError extends Component {
           weight="regular"
           lineHeight="normal"
           style={{ margin: 0 }}
+          {...others}
         >
           {children}
         </Text>


### PR DESCRIPTION
Closes #.

Screenshot:


TODO:

- [ ] Tests
- [ ] Changelog
- [ ] A11Y
- [ ] Stories
- [ ] BrowserStack
