### PR TITLE
[Comments] Add like button event styles only when an event is attached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Add like button event styles only when an event is attached (`Comment`).
+
 ## [2.16.0] - 2019-07-17
 
 Features:

--- a/assets/javascripts/kitten/components/comments/comment/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/comments/comment/__snapshots__/test.js.snap
@@ -233,7 +233,7 @@ exports[`<Comment /> should match its empty snapshot 1`] = `
     >
       <button
         aria-pressed="true"
-        className="like-button__StyledButton-wk7ovs-0 gpEpYG"
+        className="like-button__StyledButton-wk7ovs-0 fyuygq"
         role="button"
       >
         

--- a/assets/javascripts/kitten/components/comments/comment/components/like-button.js
+++ b/assets/javascripts/kitten/components/comments/comment/components/like-button.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import { pxToRem } from '../../../../helpers/utils/typography'
 import TYPOGRAPHY from '../../../../constants/typography-config'
 import { HeartIcon } from '../../../../components/icons/heart-icon'
@@ -24,19 +24,29 @@ const StyledButton = styled.button`
   appareance: none;
   box-sizing: border-box;
   outline: none;
-  cursor: pointer;
 
-  :hover,
   &[aria-pressed='true'] {
     svg {
       fill: ${COLORS.error};
     }
   }
 
-  :focus,
-  :active {
-    border-color: ${COLORS.line2};
-  }
+  ${({ as, onClick }) =>
+    (as === 'a' || onClick) &&
+    css`
+      cursor: pointer;
+
+      :hover {
+        svg {
+          fill: ${COLORS.error};
+        }
+      }
+
+      :focus,
+      :active {
+        border-color: ${COLORS.line2};
+      }
+    `}
 `
 
 const StyledHeartIcon = styled(HeartIcon)`


### PR DESCRIPTION
Ajoute les styles des pseudo-classes `hover/focus/…` seulement si c'est un lien ou qu'il y a un `onClick` sur le bouton.