### PR TITLE
Fix `title` defaultProps on `ExportIcon` component

### DIFF
--- a/assets/javascripts/kitten/components/icons/export-icon/index.js
+++ b/assets/javascripts/kitten/components/icons/export-icon/index.js
@@ -22,5 +22,5 @@ ExportIcon.propTypes = {
 
 ExportIcon.defaultProps = {
   color: '#fff',
-  title: 'Export',
+  title: '',
 }


### PR DESCRIPTION
Closes #.

Screenshot:


TODO:

- [ ] Tests
- [ ] Changelog
- [ ] A11Y
- [ ] Stories
- [ ] BrowserStack
