### PR TITLE
Add forceOneLine prop to TextCopy component.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Feature: Create `ExportIcon` component.
 - Feature: Update `EmailIcon` component.
+- Feature: Add `forceOneLine` prop to `TextCopy` component.
 
 ## [2.16.2] - 2019-07-19
 

--- a/assets/javascripts/kitten/components/text-copy/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/text-copy/__snapshots__/test.js.snap
@@ -6,8 +6,7 @@ exports[`<TextCopy /> should match snapshot 1`] = `
   onClick={[Function]}
 >
   <span
-    className="k-u-size-default k-u-weight-light text-copy__StyledText-sc-1ikj7bl-1 dQfUFz"
-    forceOneLine={false}
+    className="text-copy__StyledText-sc-1ikj7bl-1 dQfUFz"
   >
     <span>
       Text To Copy
@@ -41,8 +40,7 @@ exports[`<TextCopy /> should match snapshot with description 1`] = `
     This is a description
   </span>
   <span
-    className="k-u-size-default k-u-weight-light text-copy__StyledText-sc-1ikj7bl-1 dQfUFz"
-    forceOneLine={false}
+    className="text-copy__StyledText-sc-1ikj7bl-1 dQfUFz"
   >
     <span>
       Text To Copy
@@ -76,8 +74,7 @@ exports[`<TextCopy /> should match snapshot with one line forced 1`] = `
     This is a description
   </span>
   <span
-    className="k-u-size-default k-u-weight-light text-copy__StyledText-sc-1ikj7bl-1 iNiyhX"
-    forceOneLine={true}
+    className="text-copy__StyledText-sc-1ikj7bl-1 iNiyhX"
   >
     <span>
       Text To Copy

--- a/assets/javascripts/kitten/components/text-copy/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/text-copy/__snapshots__/test.js.snap
@@ -7,6 +7,7 @@ exports[`<TextCopy /> should match snapshot 1`] = `
 >
   <span
     className="k-u-size-default k-u-weight-light text-copy__StyledText-sc-1ikj7bl-1 dQfUFz"
+    forceOneLine={false}
   >
     <span>
       Text To Copy
@@ -41,6 +42,42 @@ exports[`<TextCopy /> should match snapshot with description 1`] = `
   </span>
   <span
     className="k-u-size-default k-u-weight-light text-copy__StyledText-sc-1ikj7bl-1 dQfUFz"
+    forceOneLine={false}
+  >
+    <span>
+      Text To Copy
+    </span>
+  </span>
+  <div
+    aria-hidden={true}
+    className="text-copy__IconWrapper-sc-1ikj7bl-2 iMhRTo"
+  >
+    <svg
+      height="20"
+      width="20"
+    >
+      <path
+        d="M8.586 10a2 2 0 0 0-2.829 0L2.93 12.828a2 2 0 0 0 0 2.829l1.414 1.414a2 2 0 0 0 2.829 0L10 14.243a2 2 0 0 0 0-2.829l-.707.707a1 1 0 0 1-1.414-1.414L8.586 10zM10 8.586l.707-.707a1 1 0 1 1 1.414 1.414l-.707.707a2 2 0 0 0 2.829 0l2.828-2.828a2 2 0 0 0 0-2.829L15.657 2.93a2 2 0 0 0-2.829 0L10 5.757a2 2 0 0 0 0 2.829zm2.578 3.992a3.99 3.99 0 0 1-1.164 3.079l-2.828 2.828a4 4 0 0 1-5.657 0l-1.414-1.414a4 4 0 0 1 0-5.657l2.828-2.828a3.99 3.99 0 0 1 3.079-1.164 3.99 3.99 0 0 1 1.164-3.079l2.828-2.828a4 4 0 0 1 5.657 0l1.414 1.414a4 4 0 0 1 0 5.657l-2.828 2.828a3.99 3.99 0 0 1-3.079 1.164z"
+        fill="#000"
+      />
+    </svg>
+  </div>
+</div>
+`;
+
+exports[`<TextCopy /> should match snapshot with one line forced 1`] = `
+<div
+  className="text-copy__Wrapper-sc-1ikj7bl-0 eooUpn"
+  onClick={[Function]}
+>
+  <span
+    className="visually-hidden__StyledElement-sc-3bas83-0 eAKyRD"
+  >
+    This is a description
+  </span>
+  <span
+    className="k-u-size-default k-u-weight-light text-copy__StyledText-sc-1ikj7bl-1 iNiyhX"
+    forceOneLine={true}
   >
     <span>
       Text To Copy

--- a/assets/javascripts/kitten/components/text-copy/index.js
+++ b/assets/javascripts/kitten/components/text-copy/index.js
@@ -1,6 +1,6 @@
 import React, { useRef, useCallback, useState } from 'react'
 import PropTypes from 'prop-types'
-import styled, { keyframes } from 'styled-components'
+import styled, { keyframes, css } from 'styled-components'
 import COLORS from '../../constants/colors-config'
 import { pxToRem } from '../../helpers/utils/typography'
 import { CopyIcon } from '../icons/copy-icon'
@@ -29,6 +29,13 @@ const Wrapper = styled.div`
 
 const StyledText = styled(Text)`
   padding: ${pxToRem(10)} ${pxToRem(15)};
+  ${({ forceOneLine }) =>
+    forceOneLine &&
+    css`
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    `}
 `
 
 const IconWrapper = styled.div`
@@ -52,6 +59,7 @@ export const TextCopy = ({
   textToCopy,
   alertMessage,
   description,
+  forceOneLine,
 }) => {
   const [shouldShowMessage, isMessageShown] = useState(false)
   const textRef = useRef(null)
@@ -79,7 +87,7 @@ export const TextCopy = ({
     <>
       <Wrapper onClick={copyText}>
         {description && <VisuallyHidden>{description}</VisuallyHidden>}
-        <StyledText weight="light" size="default">
+        <StyledText weight="light" size="default" forceOneLine={forceOneLine}>
           <span ref={textRef}>{children}</span>
         </StyledText>
         <IconWrapper aria-hidden={true}>
@@ -107,10 +115,12 @@ TextCopy.propTypes = {
   alertMessage: PropTypes.string,
   textToCopy: PropTypes.string,
   description: PropTypes.string,
+  forceOneLine: PropTypes.bool,
 }
 
 TextCopy.defaultProps = {
   alertMessage: undefined,
   textToCopy: undefined,
   description: undefined,
+  forceOneLine: false,
 }

--- a/assets/javascripts/kitten/components/text-copy/index.js
+++ b/assets/javascripts/kitten/components/text-copy/index.js
@@ -27,7 +27,9 @@ const Wrapper = styled.div`
   cursor: pointer;
 `
 
-const StyledText = styled(Text)`
+const StyledText = styled(({ className, children }) => (
+  <Text className={className}>{children}</Text>
+))`
   padding: ${pxToRem(10)} ${pxToRem(15)};
   ${({ forceOneLine }) =>
     forceOneLine &&

--- a/assets/javascripts/kitten/components/text-copy/stories.js
+++ b/assets/javascripts/kitten/components/text-copy/stories.js
@@ -2,7 +2,7 @@ import { Container } from '../grid/container'
 import { Marger } from '../..'
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import { withKnobs, text } from '@storybook/addon-knobs'
+import { withKnobs, text, boolean } from '@storybook/addon-knobs'
 import { TextCopy } from './index'
 
 const StoryContainer = ({ children }) => (
@@ -21,6 +21,7 @@ storiesOf('TextCopy', module)
         <TextCopy
           textToCopy={text('Other text to Copy', undefined)}
           alertMessage={text('Alert Message', 'Copied link !')}
+          forceOneLine={boolean('Force one line', false)}
         >
           {text('Text', 'My text to copy on click')}
         </TextCopy>

--- a/assets/javascripts/kitten/components/text-copy/test.js
+++ b/assets/javascripts/kitten/components/text-copy/test.js
@@ -22,4 +22,18 @@ describe('<TextCopy />', () => {
       .toJSON()
     expect(component).toMatchSnapshot()
   })
+  it('should match snapshot with one line forced', () => {
+    const component = renderer
+      .create(
+        <TextCopy
+          alertMessage="Text copied!"
+          description="This is a description"
+          forceOneLine
+        >
+          Text To Copy
+        </TextCopy>,
+      )
+      .toJSON()
+    expect(component).toMatchSnapshot()
+  })
 })


### PR DESCRIPTION
Permet de forcer le texte à ne s'affiche que sur une seule ligne comme ceci : 

<img width="297" alt="Capture d’écran 2019-07-24 à 12 46 45" src="https://user-images.githubusercontent.com/804738/61787905-23cfaa80-ae11-11e9-95bb-f4b8b851b6a7.png">
