### PR TITLE
Add old input refs on text-input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+Fix: - Take back input refs on `TextInput`.
+
 ## [2.17.0] - 2019-07-24
 
 Features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
-Fix: - Take back input refs on `TextInput`.
+Fix:
+- Take back input refs on `TextInput`.
 
 ## [2.17.0] - 2019-07-24
 

--- a/assets/javascripts/kitten/components/form/text-input-with-unit/index.js
+++ b/assets/javascripts/kitten/components/form/text-input-with-unit/index.js
@@ -137,6 +137,7 @@ export class TextInputWithUnit extends PureComponent {
           error={error}
           tiny={tiny}
           disabled={disabled}
+          {...others}
         />
         <StyledInputUnit
           valid={valid}

--- a/assets/javascripts/kitten/components/form/text-input/index.js
+++ b/assets/javascripts/kitten/components/form/text-input/index.js
@@ -165,6 +165,7 @@ export class TextInput extends PureComponent {
       return (
         <StyledTextarea>
           <StyledInputTextarea
+            ref={input => (this.input = input)}
             valid={valid}
             error={error}
             disabled={disabled}
@@ -179,6 +180,7 @@ export class TextInput extends PureComponent {
     } else {
       return (
         <StyledInput
+          ref={input => (this.input = input)}
           valid={valid}
           error={error}
           disabled={disabled}

--- a/src/components/form/text-input-with-unit/index.js
+++ b/src/components/form/text-input-with-unit/index.js
@@ -103,7 +103,7 @@ function (_PureComponent) {
         error: error,
         tiny: tiny,
         disabled: disabled
-      })), _react.default.createElement(StyledInputUnit, {
+      }, others)), _react.default.createElement(StyledInputUnit, {
         valid: valid,
         error: error,
         disabled: disabled,

--- a/src/components/form/text-input/index.js
+++ b/src/components/form/text-input/index.js
@@ -102,6 +102,8 @@ function (_PureComponent) {
   (0, _createClass2.default)(TextInput, [{
     key: "render",
     value: function render() {
+      var _this = this;
+
       var _this$props = this.props,
           valid = _this$props.valid,
           error = _this$props.error,
@@ -114,6 +116,9 @@ function (_PureComponent) {
 
       if (tag === 'textarea') {
         return _react.default.createElement(StyledTextarea, null, _react.default.createElement(StyledInputTextarea, (0, _extends2.default)({
+          ref: function ref(input) {
+            return _this.input = input;
+          },
           valid: valid,
           error: error,
           disabled: disabled,
@@ -123,6 +128,9 @@ function (_PureComponent) {
         }, others)), _react.default.createElement(StyledGradientTextarea, null));
       } else {
         return _react.default.createElement(StyledInput, (0, _extends2.default)({
+          ref: function ref(input) {
+            return _this.input = input;
+          },
           valid: valid,
           error: error,
           disabled: disabled,


### PR DESCRIPTION
Corrige le bug sur Lendo qui ne retrouvait plus les refs des input..