### PR TITLE
Clicking on TextCopy input just select the text (no copy)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
-Feature: 
+Features: 
 - Add `withoutBorder` prop to `RewardCard`.
+- Clicking on `TextCopy input just select the text (no copy in clipboard)
 
 Fix:
 - Take back input refs on `TextInput`.

--- a/assets/javascripts/kitten/components/text-copy/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/text-copy/__snapshots__/test.js.snap
@@ -2,11 +2,12 @@
 
 exports[`<TextCopy /> should match snapshot 1`] = `
 <div
-  className="text-copy__Wrapper-sc-1ikj7bl-0 eooUpn"
-  onClick={[Function]}
+  className="text-copy__Wrapper-sc-1ikj7bl-0 hsoZhM"
 >
   <span
-    className="text-copy__StyledText-sc-1ikj7bl-1 dQfUFz"
+    className="k-u-size-default k-u-weight-light text-copy__StyledText-sc-1ikj7bl-1 bOrRYf"
+    forceOneLine={false}
+    onClick={[Function]}
   >
     <span>
       Text To Copy
@@ -14,7 +15,8 @@ exports[`<TextCopy /> should match snapshot 1`] = `
   </span>
   <div
     aria-hidden={true}
-    className="text-copy__IconWrapper-sc-1ikj7bl-2 iMhRTo"
+    className="text-copy__IconWrapper-sc-1ikj7bl-2 fXiZvS"
+    onClick={[Function]}
   >
     <svg
       height="20"
@@ -31,8 +33,7 @@ exports[`<TextCopy /> should match snapshot 1`] = `
 
 exports[`<TextCopy /> should match snapshot with description 1`] = `
 <div
-  className="text-copy__Wrapper-sc-1ikj7bl-0 eooUpn"
-  onClick={[Function]}
+  className="text-copy__Wrapper-sc-1ikj7bl-0 hsoZhM"
 >
   <span
     className="visually-hidden__StyledElement-sc-3bas83-0 eAKyRD"
@@ -40,7 +41,9 @@ exports[`<TextCopy /> should match snapshot with description 1`] = `
     This is a description
   </span>
   <span
-    className="text-copy__StyledText-sc-1ikj7bl-1 dQfUFz"
+    className="k-u-size-default k-u-weight-light text-copy__StyledText-sc-1ikj7bl-1 bOrRYf"
+    forceOneLine={false}
+    onClick={[Function]}
   >
     <span>
       Text To Copy
@@ -48,7 +51,8 @@ exports[`<TextCopy /> should match snapshot with description 1`] = `
   </span>
   <div
     aria-hidden={true}
-    className="text-copy__IconWrapper-sc-1ikj7bl-2 iMhRTo"
+    className="text-copy__IconWrapper-sc-1ikj7bl-2 fXiZvS"
+    onClick={[Function]}
   >
     <svg
       height="20"
@@ -65,8 +69,7 @@ exports[`<TextCopy /> should match snapshot with description 1`] = `
 
 exports[`<TextCopy /> should match snapshot with one line forced 1`] = `
 <div
-  className="text-copy__Wrapper-sc-1ikj7bl-0 eooUpn"
-  onClick={[Function]}
+  className="text-copy__Wrapper-sc-1ikj7bl-0 hsoZhM"
 >
   <span
     className="visually-hidden__StyledElement-sc-3bas83-0 eAKyRD"
@@ -74,7 +77,9 @@ exports[`<TextCopy /> should match snapshot with one line forced 1`] = `
     This is a description
   </span>
   <span
-    className="text-copy__StyledText-sc-1ikj7bl-1 iNiyhX"
+    className="k-u-size-default k-u-weight-light text-copy__StyledText-sc-1ikj7bl-1 zsAbu"
+    forceOneLine={true}
+    onClick={[Function]}
   >
     <span>
       Text To Copy
@@ -82,7 +87,8 @@ exports[`<TextCopy /> should match snapshot with one line forced 1`] = `
   </span>
   <div
     aria-hidden={true}
-    className="text-copy__IconWrapper-sc-1ikj7bl-2 iMhRTo"
+    className="text-copy__IconWrapper-sc-1ikj7bl-2 fXiZvS"
+    onClick={[Function]}
   >
     <svg
       height="20"

--- a/assets/javascripts/kitten/components/text-copy/index.js
+++ b/assets/javascripts/kitten/components/text-copy/index.js
@@ -24,24 +24,26 @@ const Wrapper = styled.div`
   justify-content: space-between;
   border: ${pxToRem(2)} solid ${COLORS.line1};
   background-color: ${COLORS.background1};
-  cursor: pointer;
 `
 
-const StyledText = styled(({ className, children }) => (
-  <Text className={className}>{children}</Text>
+const StyledText = styled(({ className, children, ...others }) => (
+  <Text className={className} {...others}>
+    {children}
+  </Text>
 ))`
   padding: ${pxToRem(10)} ${pxToRem(15)};
+  width: 100%;
   ${({ forceOneLine }) =>
     forceOneLine &&
     css`
       overflow: hidden;
       white-space: nowrap;
-      text-overflow: ellipsis;
     `}
 `
 
 const IconWrapper = styled.div`
   display: flex;
+  cursor: pointer;
   align-items: center;
   padding: ${pxToRem(10)};
   border-left: ${pxToRem(2)} solid ${COLORS.line1};
@@ -65,6 +67,11 @@ export const TextCopy = ({
 }) => {
   const [shouldShowMessage, isMessageShown] = useState(false)
   const textRef = useRef(null)
+  const selectText = useCallback(() => {
+    const range = document.createRange()
+    range.selectNode(textRef.current)
+    window.getSelection().addRange(range)
+  })
   const copyText = useCallback(() => {
     isMessageShown(false)
     if (textToCopy) {
@@ -78,21 +85,24 @@ export const TextCopy = ({
       range.selectNode(textRef.current)
       window.getSelection().addRange(range)
     } else {
-      const range = document.createRange()
-      range.selectNode(textRef.current)
-      window.getSelection().addRange(range)
+      selectText()
       document.execCommand('copy')
     }
     setTimeout(() => isMessageShown(true), 1)
   })
   return (
     <>
-      <Wrapper onClick={copyText}>
+      <Wrapper>
         {description && <VisuallyHidden>{description}</VisuallyHidden>}
-        <StyledText weight="light" size="default" forceOneLine={forceOneLine}>
+        <StyledText
+          weight="light"
+          size="default"
+          forceOneLine={forceOneLine}
+          onClick={selectText}
+        >
           <span ref={textRef}>{children}</span>
         </StyledText>
-        <IconWrapper aria-hidden={true}>
+        <IconWrapper aria-hidden={true} onClick={copyText}>
           <CopyIcon />
         </IconWrapper>
         {alertMessage && shouldShowMessage && (

--- a/src/components/text-copy/index.js
+++ b/src/components/text-copy/index.js
@@ -11,6 +11,10 @@ exports.TextCopy = void 0;
 
 var _slicedToArray2 = _interopRequireDefault(require("@babel/runtime/helpers/slicedToArray"));
 
+var _extends2 = _interopRequireDefault(require("@babel/runtime/helpers/extends"));
+
+var _objectWithoutProperties2 = _interopRequireDefault(require("@babel/runtime/helpers/objectWithoutProperties"));
+
 var _react = _interopRequireWildcard(require("react"));
 
 var _propTypes = _interopRequireDefault(require("prop-types"));
@@ -34,26 +38,27 @@ var fadeIn = (0, _styledComponents.keyframes)(["0%{opacity:0;}100%{opacity:1;}"]
 var Wrapper = _styledComponents.default.div.withConfig({
   displayName: "text-copy__Wrapper",
   componentId: "sc-1ikj7bl-0"
-})(["position:relative;display:flex;align-items:center;justify-content:space-between;border:", " solid ", ";background-color:", ";cursor:pointer;"], (0, _typography.pxToRem)(2), _colorsConfig.default.line1, _colorsConfig.default.background1);
+})(["position:relative;display:flex;align-items:center;justify-content:space-between;border:", " solid ", ";background-color:", ";"], (0, _typography.pxToRem)(2), _colorsConfig.default.line1, _colorsConfig.default.background1);
 
 var StyledText = (0, _styledComponents.default)(function (_ref) {
   var className = _ref.className,
-      children = _ref.children;
-  return _react.default.createElement(_text.Text, {
+      children = _ref.children,
+      others = (0, _objectWithoutProperties2.default)(_ref, ["className", "children"]);
+  return _react.default.createElement(_text.Text, (0, _extends2.default)({
     className: className
-  }, children);
+  }, others), children);
 }).withConfig({
   displayName: "text-copy__StyledText",
   componentId: "sc-1ikj7bl-1"
-})(["padding:", " ", ";", ""], (0, _typography.pxToRem)(10), (0, _typography.pxToRem)(15), function (_ref2) {
+})(["padding:", " ", ";width:100%;", ""], (0, _typography.pxToRem)(10), (0, _typography.pxToRem)(15), function (_ref2) {
   var forceOneLine = _ref2.forceOneLine;
-  return forceOneLine && (0, _styledComponents.css)(["overflow:hidden;white-space:nowrap;text-overflow:ellipsis;"]);
+  return forceOneLine && (0, _styledComponents.css)(["overflow:hidden;white-space:nowrap;"]);
 });
 
 var IconWrapper = _styledComponents.default.div.withConfig({
   displayName: "text-copy__IconWrapper",
   componentId: "sc-1ikj7bl-2"
-})(["display:flex;align-items:center;padding:", ";border-left:", " solid ", ";align-self:stretch;box-sizing:border-box;"], (0, _typography.pxToRem)(10), (0, _typography.pxToRem)(2), _colorsConfig.default.line1);
+})(["display:flex;cursor:pointer;align-items:center;padding:", ";border-left:", " solid ", ";align-self:stretch;box-sizing:border-box;"], (0, _typography.pxToRem)(10), (0, _typography.pxToRem)(2), _colorsConfig.default.line1);
 
 var StyledArrowContainer = (0, _styledComponents.default)(_arrowContainer.ArrowContainer).withConfig({
   displayName: "text-copy__StyledArrowContainer",
@@ -73,6 +78,11 @@ var TextCopy = function TextCopy(_ref3) {
       isMessageShown = _useState2[1];
 
   var textRef = (0, _react.useRef)(null);
+  var selectText = (0, _react.useCallback)(function () {
+    var range = document.createRange();
+    range.selectNode(textRef.current);
+    window.getSelection().addRange(range);
+  });
   var copyText = (0, _react.useCallback)(function () {
     isMessageShown(false);
 
@@ -87,11 +97,7 @@ var TextCopy = function TextCopy(_ref3) {
       range.selectNode(textRef.current);
       window.getSelection().addRange(range);
     } else {
-      var _range = document.createRange();
-
-      _range.selectNode(textRef.current);
-
-      window.getSelection().addRange(_range);
+      selectText();
       document.execCommand('copy');
     }
 
@@ -99,16 +105,16 @@ var TextCopy = function TextCopy(_ref3) {
       return isMessageShown(true);
     }, 1);
   });
-  return _react.default.createElement(_react.default.Fragment, null, _react.default.createElement(Wrapper, {
-    onClick: copyText
-  }, description && _react.default.createElement(_visuallyHidden.VisuallyHidden, null, description), _react.default.createElement(StyledText, {
+  return _react.default.createElement(_react.default.Fragment, null, _react.default.createElement(Wrapper, null, description && _react.default.createElement(_visuallyHidden.VisuallyHidden, null, description), _react.default.createElement(StyledText, {
     weight: "light",
     size: "default",
-    forceOneLine: forceOneLine
+    forceOneLine: forceOneLine,
+    onClick: selectText
   }, _react.default.createElement("span", {
     ref: textRef
   }, children)), _react.default.createElement(IconWrapper, {
-    "aria-hidden": true
+    "aria-hidden": true,
+    onClick: copyText
   }, _react.default.createElement(_copyIcon.CopyIcon, null)), alertMessage && shouldShowMessage && _react.default.createElement(StyledArrowContainer, {
     color: _colorsConfig.default.primary1,
     position: "top",


### PR DESCRIPTION
Petite update du comportement de composant `Textcopy` pour ne sélectionner que le texte quand on clique dessus. Le clique sur l'icon copie le texte directement dans le clipboard.
