### PR TITLE
[Modal] Remove `PropType`-related warning in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Remove console Warning in `Modal` component.
+
 ## [2.20.0] - 2019-08-23
 
 Features:
@@ -20,8 +22,6 @@ Fixes:
 - Remove styles (`:hover` styles on `ListTable.Row`) not in the Spec.
 - Move `ListTable.Row` `...others` props propagation
   on `row` element instead of `list` element.
-
-
 
 ## [2.19.1] - 2019-08-20
 

--- a/assets/javascripts/kitten/components/modals/modal/index.js
+++ b/assets/javascripts/kitten/components/modals/modal/index.js
@@ -87,7 +87,9 @@ export class Modal extends Component {
           ariaHideApp={false}
           onRequestClose={this.close}
           contentLabel={label}
-          bodyOpenClassName={disableOutsideScroll && 'k-Modal__body--open'}
+          bodyOpenClassName={
+            disableOutsideScroll ? 'k-Modal__body--open' : null
+          }
           {...modalProps}
         >
           {content}


### PR DESCRIPTION
Closes #.

Screenshot:


TODO:

- [X] Tests
- [ ] Changelog
- [x] A11Y
- [x] Stories
- [x] BrowserStack
