### PR TITLE
[AdaptableGrid] Pass className prop to enable styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Feature: Pass `className` prop to `AdaptableGrid` and `AdaptableGridCol` to
+  enable styling with `styled-components`.
+
 ## [2.21.0] - 2019-08-27
 
 Features:

--- a/assets/javascripts/kitten/components/grid/adaptable-grid/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/grid/adaptable-grid/__snapshots__/test.js.snap
@@ -17,6 +17,23 @@ exports[`<AdaptableGrid /> by default matches with snapshot 1`] = `
 </div>
 `;
 
+exports[`<AdaptableGrid /> with className matches with snapshot 1`] = `
+<div
+  className="my_classname adaptable-grid__StyledGrid-txsbu0-0 kscnci"
+>
+  <div
+    className="my_second_classname adaptable-grid__StyledGridCol-txsbu0-1 gxolfR"
+  >
+    Test
+  </div>
+  <div
+    className="my_third_classname adaptable-grid__StyledGridCol-txsbu0-1 gxolfR"
+  >
+    Test
+  </div>
+</div>
+`;
+
 exports[`<AdaptableGrid /> with custom HTML tags matches with snapshot 1`] = `
 <dl
   className="adaptable-grid__StyledGrid-txsbu0-0 kscnci"

--- a/assets/javascripts/kitten/components/grid/adaptable-grid/index.js
+++ b/assets/javascripts/kitten/components/grid/adaptable-grid/index.js
@@ -13,11 +13,17 @@ export const AdaptableGrid = ({
   colNumber,
   colAlign,
   as,
+  className,
   ...other
 }) => {
   const gridProperties = { colAlign, colNumber, gutter }
   return (
-    <StyledGrid gutter={gutter} colAlign={colAlign} as={as}>
+    <StyledGrid
+      gutter={gutter}
+      colAlign={colAlign}
+      as={as}
+      className={className}
+    >
       <GridProperties.Provider value={gridProperties}>
         {children}
       </GridProperties.Provider>
@@ -25,7 +31,14 @@ export const AdaptableGrid = ({
   )
 }
 
-export const AdaptableGridCol = ({ children, col, offset, as, ...other }) => {
+export const AdaptableGridCol = ({
+  children,
+  col,
+  offset,
+  as,
+  className,
+  ...other
+}) => {
   const [styles, setStyles] = useState(null)
   const { colAlign, colNumber, gutter } = useContext(GridProperties)
   const marginDirection = colAlign === 'right' ? 'right' : 'left'
@@ -74,6 +87,7 @@ export const AdaptableGridCol = ({ children, col, offset, as, ...other }) => {
       props={{ ...other }}
       stylesByMediaQuery={styles}
       as={as}
+      className={className}
     >
       {children}
     </StyledGridCol>

--- a/assets/javascripts/kitten/components/grid/adaptable-grid/test.js
+++ b/assets/javascripts/kitten/components/grid/adaptable-grid/test.js
@@ -43,6 +43,27 @@ describe('<AdaptableGrid />', () => {
     })
   })
 
+  describe('with className', () => {
+    beforeEach(() => {
+      component = renderer
+        .create(
+          <AdaptableGrid className="my_classname">
+            <AdaptableGridCol className="my_second_classname">
+              Test
+            </AdaptableGridCol>
+            <AdaptableGridCol className="my_third_classname">
+              Test
+            </AdaptableGridCol>
+          </AdaptableGrid>,
+        )
+        .toJSON()
+    })
+
+    it('matches with snapshot', () => {
+      expect(component).toMatchSnapshot()
+    })
+  })
+
   describe('with some props', () => {
     beforeEach(() => {
       component = renderer


### PR DESCRIPTION
## Description

Afin de pouvoir ajouter des styles sur `AdaptableGrid` et `AdaptableGridCol` avec `styled-components`, j'ajoute la propagation de la prop `className`. Ne sachant pas comment le composant a été pensé à l'origine, je préfère scoper le passage de cette prop uniquement et pas de tout le `...others`.

Pour pouvoir faire ça correctement par exemple (car aujourd'hui, ça ne pourrait pas fonctionner) : 
```js
const StyledGrid = styled(AdaptableGrid)`
  color: red;
`
```