### PR TITLE
[CommentForm] Add `textareaId` prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Feature: Add `textareaId` prop to `CommentForm`.
 - Fix: Fix `AdaptableGrid` width.
 
 ## [2.22.0] - 2019-08-28

--- a/assets/javascripts/kitten/components/comments/comment-form/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/comments/comment-form/__snapshots__/test.js.snap
@@ -60,9 +60,8 @@ exports[`<CommentForm /> should match a snapshot with a complex avatar badge 1`]
         className="comment-form__StyledTextarea-sc-1yidca9-3 GUTNa"
         defaultValue=""
         disabled={false}
-        onBlur={[Function]}
+        id={null}
         onChange={[Function]}
-        onFocus={[Function]}
         placeholder="Leave a comment on the project"
         rows="1"
       />
@@ -124,9 +123,8 @@ exports[`<CommentForm /> should match its empty snapshot 1`] = `
         className="comment-form__StyledTextarea-sc-1yidca9-3 GUTNa"
         defaultValue=""
         disabled={false}
-        onBlur={[Function]}
+        id="custom-textarea-id"
         onChange={[Function]}
-        onFocus={[Function]}
         placeholder="Leave a comment on the project"
         rows="1"
       />

--- a/assets/javascripts/kitten/components/comments/comment-form/index.js
+++ b/assets/javascripts/kitten/components/comments/comment-form/index.js
@@ -123,6 +123,7 @@ export class CommentForm extends PureComponent {
     commentLabel: PropTypes.string,
     ariaId: PropTypes.string,
     avatarBadge: PropTypes.node,
+    textareaId: PropTypes.string,
   }
 
   static defaultProps = {

--- a/assets/javascripts/kitten/components/comments/comment-form/index.js
+++ b/assets/javascripts/kitten/components/comments/comment-form/index.js
@@ -135,24 +135,16 @@ export class CommentForm extends PureComponent {
     ariaId: '',
     commentLabel: '',
     avatarBadge: '',
+    textareaId: null,
   }
 
   constructor(props) {
     super(props)
 
     this.state = {
-      isFocused: false,
       value: this.props.defaultValue,
       height: 'auto',
     }
-  }
-
-  handleFocus = () => {
-    this.setState({ isFocused: true })
-  }
-
-  handleBlur = () => {
-    this.setState({ isFocused: false })
   }
 
   handleChange = e => {
@@ -196,14 +188,14 @@ export class CommentForm extends PureComponent {
       defaultValue,
       commentLabel,
       ariaId,
-      error,
-      errorMessage,
+      textareaId,
     } = this.props
 
     return (
       <StyledGridCol>
         <StyledInput>
           <StyledTextarea
+            id={textareaId}
             aria-label={commentLabel}
             aria-describedby={ariaId}
             aria-invalid="false"
@@ -212,15 +204,15 @@ export class CommentForm extends PureComponent {
             key="comment-form"
             disabled={isDisabled}
             placeholder={placeholder}
-            onFocus={this.handleFocus}
-            onBlur={this.handleBlur}
             onChange={this.handleChange}
             rows="1"
           />
+
           <StyledArrow>
             <StyledArrowBefore />
           </StyledArrow>
         </StyledInput>
+
         {this.renderError()}
         {this.renderButton()}
       </StyledGridCol>

--- a/assets/javascripts/kitten/components/comments/comment-form/stories.js
+++ b/assets/javascripts/kitten/components/comments/comment-form/stories.js
@@ -46,7 +46,12 @@ const info = {
 
     ### With avatarBadge
     ~~~js
-    <Comment avatarBadge="…" />
+    <CommentForm avatarBadge="…" />
+    ~~~
+
+    ### With textarea ID
+    ~~~js
+    <CommentForm textareaId="…" />
     ~~~
   `,
   header: false,

--- a/assets/javascripts/kitten/components/comments/comment-form/test.js
+++ b/assets/javascripts/kitten/components/comments/comment-form/test.js
@@ -27,6 +27,7 @@ describe('<CommentForm />', () => {
     const tree = renderer
       .create(
         <CommentForm
+          textareaId="custom-textarea-id"
           avatarImgProps={{
             src: '#image',
             alt: 'Image alt',

--- a/src/components/comments/comment-form/index.js
+++ b/src/components/comments/comment-form/index.js
@@ -123,18 +123,6 @@ function (_PureComponent) {
     (0, _classCallCheck2.default)(this, CommentForm);
     _this = (0, _possibleConstructorReturn2.default)(this, (0, _getPrototypeOf2.default)(CommentForm).call(this, props));
 
-    _this.handleFocus = function () {
-      _this.setState({
-        isFocused: true
-      });
-    };
-
-    _this.handleBlur = function () {
-      _this.setState({
-        isFocused: false
-      });
-    };
-
     _this.handleChange = function (e) {
       var element = e.target;
 
@@ -153,7 +141,6 @@ function (_PureComponent) {
     };
 
     _this.state = {
-      isFocused: false,
       value: _this.props.defaultValue,
       height: 'auto'
     };
@@ -180,9 +167,9 @@ function (_PureComponent) {
           defaultValue = _this$props2.defaultValue,
           commentLabel = _this$props2.commentLabel,
           ariaId = _this$props2.ariaId,
-          error = _this$props2.error,
-          errorMessage = _this$props2.errorMessage;
+          textareaId = _this$props2.textareaId;
       return _react.default.createElement(StyledGridCol, null, _react.default.createElement(StyledInput, null, _react.default.createElement(StyledTextarea, {
+        id: textareaId,
         "aria-label": commentLabel,
         "aria-describedby": ariaId,
         "aria-invalid": "false",
@@ -191,8 +178,6 @@ function (_PureComponent) {
         key: "comment-form",
         disabled: isDisabled,
         placeholder: placeholder,
-        onFocus: this.handleFocus,
-        onBlur: this.handleBlur,
         onChange: this.handleChange,
         rows: "1"
       }), _react.default.createElement(StyledArrow, null, _react.default.createElement(StyledArrowBefore, null))), this.renderError(), this.renderButton());
@@ -255,5 +240,6 @@ CommentForm.defaultProps = {
   defaultValue: '',
   ariaId: '',
   commentLabel: '',
-  avatarBadge: ''
+  avatarBadge: '',
+  textareaId: null
 };

--- a/src/components/comments/comment-form/index.js
+++ b/src/components/comments/comment-form/index.js
@@ -229,7 +229,8 @@ CommentForm.propTypes = {
   defaultValue: _propTypes.default.string,
   commentLabel: _propTypes.default.string,
   ariaId: _propTypes.default.string,
-  avatarBadge: _propTypes.default.node
+  avatarBadge: _propTypes.default.node,
+  textareaId: _propTypes.default.string
 };
 CommentForm.defaultProps = {
   onSubmit: function onSubmit() {},


### PR DESCRIPTION
Possibilité d'ajouter un ID sur le `textarea` pour permettre de le sélectionner en JS.

Ce qui a déclenché le dev : permettre l'auto-focus du formulaire d'ajout d'un commentaire.

J'en ai profité pour virer du code mort lié au focus qu'il restait suite à la migration Radium > styled-components.