### PR TITLE
[Icon] Create `StrokeIcon` component.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Feature: Create `StrokeIcon` component.
 - Fix: Remove default `font-size` on `Field.Label`.
 
 ## [2.28.0] - 2019-09-24

--- a/assets/javascripts/kitten/components/icons/icons.stories.js
+++ b/assets/javascripts/kitten/components/icons/icons.stories.js
@@ -41,6 +41,7 @@ import { QuestionMarkIcon } from './question-mark-icon'
 import { SearchIcon } from './search-icon'
 import { SofortIcon } from './sofort-icon'
 import { StarIcon } from './star-icon'
+import { StrokeIcon } from './stroke-icon'
 import { TwitterIcon } from './twitter-icon'
 import { TypologyTagIcon } from './typology-tag-icon'
 import { VisaIcon } from './visa-icon'
@@ -149,6 +150,7 @@ storiesOf('Icons/List', module).add('default', () => {
         <IconContainer children={<CopyIcon />} />
         <IconContainer children={<BubbleIcon />} />
         <IconContainer children={<ExportIcon />} />
+        <IconContainer children={<StrokeIcon />} />
       </Group>
     </Container>
   )

--- a/assets/javascripts/kitten/components/icons/stroke-icon/index.js
+++ b/assets/javascripts/kitten/components/icons/stroke-icon/index.js
@@ -1,0 +1,25 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+export const StrokeIcon = ({ color, title, ...props }) => (
+  <svg
+    width="8"
+    height="2"
+    viewBox="0 0 8 2"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    {title && <title>{title}</title>}
+    <path fill={color} d="M0 0h8v2H0z" />
+  </svg>
+)
+
+StrokeIcon.propTypes = {
+  color: PropTypes.string,
+  title: PropTypes.string,
+}
+
+StrokeIcon.defaultProps = {
+  color: '#fff',
+  title: '',
+}


### PR DESCRIPTION
Closes #.

Screenshot:


TODO:

- [ ] Tests
- [ ] Changelog
- [ ] A11Y
- [ ] Stories
- [ ] BrowserStack
