### PR TITLE
add rawResults props to `<Autocomplete />`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Feature: Create `StrokeIcon` component.
 - Fix: Remove default `font-size` on `Field.Label`.
-- Feature: Add `icon` and `iconPosition` props to `<Autocomplete />`.
+- Feature: Add `icon`, `iconPosition` and `rawResults` props to `<Autocomplete />`.
 
 ## [2.28.0] - 2019-09-24
 

--- a/assets/javascripts/kitten/components/form/autocomplete/index.js
+++ b/assets/javascripts/kitten/components/form/autocomplete/index.js
@@ -162,6 +162,7 @@ export const Autocomplete = ({
   onSelect,
   icon,
   iconPosition,
+  rawResults,
   ...props
 }) => {
   const [items, setItems] = useState(defaultItems)
@@ -232,12 +233,16 @@ export const Autocomplete = ({
   }
 
   const updateSuggestions = () => {
-    const search = `${value}`.toLowerCase()
-    const newItems = defaultItems.filter(
-      item => item.toLowerCase().includes(search) && item !== value,
-    )
+    if (rawResults) {
+      setItems(defaultItems)
+    } else {
+      const search = `${value}`.toLowerCase()
+      const newItems = defaultItems.filter(
+        item => item.toLowerCase().includes(search) && item !== value,
+      )
 
-    setItems(newItems)
+      setItems(newItems)
+    }
     resetSelectedItem()
   }
 
@@ -338,6 +343,7 @@ Autocomplete.propTypes = {
   error: PropTypes.bool,
   icon: PropTypes.object,
   iconPosition: PropTypes.oneOf(['left', 'right']),
+  rawResults: PropTypes.bool,
   onChange: PropTypes.func,
   onBlur: PropTypes.func,
   onKeyDown: PropTypes.func,
@@ -346,6 +352,7 @@ Autocomplete.propTypes = {
 
 Autocomplete.defaultProps = {
   error: false,
+  rawResults: false,
   iconPosition: 'left',
   onChange: () => {},
   onBlur: () => {},


### PR DESCRIPTION
J'ai parfois envie d'afficher les résultats comme je les ai donné sans besoin de filtre supplémentaire. La prop `rawResults` est fait pour ça.