### PR TITLE
Error message on  <Autocomplete />

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Feature: Create `StrokeIcon` component.
 - Fix: Remove default `font-size` on `Field.Label`.
-- Feature: Add `icon`, `iconPosition`, `updateSuggestionsStrategy` and `isLoading` props to `<Autocomplete />`.
+- Feature: Add `icon`, `iconPosition`, `updateSuggestionsStrategy`, `isLoading`, `noResultMessage` and `shouldShowNoResultMessage` props to `<Autocomplete />`.
 
 ## [2.28.0] - 2019-09-24
 

--- a/assets/javascripts/kitten/components/form/autocomplete/index.js
+++ b/assets/javascripts/kitten/components/form/autocomplete/index.js
@@ -363,9 +363,6 @@ export const Autocomplete = ({
                 {noResultMessage}
               </NoResultItem>
             </Suggestions>
-            <VisuallyHidden lang="en" aria-live="assertive">
-              no result available.
-            </VisuallyHidden>
           </>
         )}
 

--- a/assets/javascripts/kitten/components/form/autocomplete/index.js
+++ b/assets/javascripts/kitten/components/form/autocomplete/index.js
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react'
 import styled, { css } from 'styled-components'
+import isFunction from 'lodash/fp/isFunction'
 import PropTypes from 'prop-types'
 import { pxToRem, stepToRem } from '../../../helpers/utils/typography'
 import TYPOGRAPHY from '../../../constants/typography-config'
@@ -144,6 +145,16 @@ const Suggestions = styled.ul`
     `}
 `
 
+const NoResultItem = styled.li`
+  padding: ${pxToRem(10)} ${pxToRem(15)};
+
+  ${TYPOGRAPHY.fontStyles.light};
+  font-size: ${stepToRem(-1)};
+  font-style: italic;
+  line-height: 1.3;
+  color: ${COLORS.font1};
+`
+
 const Item = styled.li`
   padding: ${pxToRem(10)} ${pxToRem(15)};
 
@@ -181,6 +192,8 @@ export const Autocomplete = ({
   iconPosition,
   updateSuggestionsStrategy,
   isLoading,
+  noResultMessage,
+  shouldShowNoResultMessage,
   ...props
 }) => {
   const [items, setItems] = useState(defaultItems)
@@ -189,6 +202,9 @@ export const Autocomplete = ({
   const [showSuggestions, setShowSuggestions] = useState(false)
   const inputEl = useRef(null)
   const suggestionsEl = useRef(null)
+  const showNoResultMessage = isFunction(shouldShowNoResultMessage)
+    ? shouldShowNoResultMessage({ items, value })
+    : shouldShowNoResultMessage
 
   useEffect(() => {
     updateSuggestions()
@@ -331,6 +347,28 @@ export const Autocomplete = ({
         </StyledIcon>
       )}
 
+      {showSuggestions &&
+        items.length === 0 &&
+        noResultMessage &&
+        showNoResultMessage && (
+          <>
+            <Suggestions
+              ref={suggestionsEl}
+              id={`${props.name}-results`}
+              role="listbox"
+              tabIndex="-1"
+              itemsLength="1"
+            >
+              <NoResultItem role="option" tabIndex="-1">
+                {noResultMessage}
+              </NoResultItem>
+            </Suggestions>
+            <VisuallyHidden lang="en" aria-live="assertive">
+              no result available.
+            </VisuallyHidden>
+          </>
+        )}
+
       {showSuggestions && items.length > 0 && (
         <>
           <Suggestions
@@ -370,6 +408,11 @@ Autocomplete.propTypes = {
   icon: PropTypes.object,
   iconPosition: PropTypes.oneOf(['left', 'right']),
   updateSuggestionsStrategy: PropTypes.func,
+  noResultMessage: PropTypes.string,
+  shouldShowNoResultMessage: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.func,
+  ]),
   onChange: PropTypes.func,
   onBlur: PropTypes.func,
   onKeyDown: PropTypes.func,
@@ -379,6 +422,7 @@ Autocomplete.propTypes = {
 
 Autocomplete.defaultProps = {
   error: false,
+  shouldShowNoResultMessage: true,
   iconPosition: 'left',
   onChange: () => {},
   onBlur: () => {},

--- a/assets/javascripts/kitten/components/form/autocomplete/stories.js
+++ b/assets/javascripts/kitten/components/form/autocomplete/stories.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { withInfo } from '@storybook/addon-info'
-import { withKnobs, optionsKnob, boolean } from '@storybook/addon-knobs'
+import { withKnobs, optionsKnob, text, boolean } from '@storybook/addon-knobs'
 import { Marger } from '../../layout/marger'
 import { Container } from '../../grid/container'
 import { Grid, GridCol } from '../../grid/grid'
@@ -198,6 +198,11 @@ storiesOf('Form/Autocomplete', module)
               name="autocomplete"
               placeholder="Search a kitten…"
               isLoading={boolean('isLoading', false)}
+              noResultMessage={text('noResultMessage', undefined)}
+              shouldShowNoResultMessage={boolean(
+                'shouldShowNoResultMessage',
+                true,
+              )}
               items={items}
             />
 
@@ -224,6 +229,11 @@ storiesOf('Form/Autocomplete', module)
               placeholder="Search a kitten…"
               isLoading={boolean('isLoading', false)}
               icon={<LocationIcon />}
+              noResultMessage={text('noResultMessage', undefined)}
+              shouldShowNoResultMessage={boolean(
+                'shouldShowNoResultMessage',
+                true,
+              )}
               iconPosition={optionsKnob(
                 'iconPosition',
                 {


### PR DESCRIPTION
Donne les outils pour gérer un message s'il n'y a aucun résultat avec les props  `noResultMessage` et `shouldShowNoResultMessage` 