### PR TITLE
[Field] Cleanup Input styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Update `Field.Label` styles.
 - Feature: Update `CrowdfundingCard` with styled-components.
 
 ## [2.31.0] - 2019-10-01

--- a/assets/javascripts/kitten/components/form/field/__snapshots__/field.test.js.snap
+++ b/assets/javascripts/kitten/components/form/field/__snapshots__/field.test.js.snap
@@ -3,7 +3,7 @@
 exports[`<Field /> with <Field.Autocomplete /> matches with snapshot 1`] = `
 Array [
   <div
-    className="marger__StyledMarger-q3lecu-0 csmETU"
+    className="marger__StyledMarger-q3lecu-0 gkLTfi"
   >
     <div
       className="k-Line"
@@ -17,7 +17,7 @@ Array [
         className="k-Line__item"
       >
         <label
-          className="k-Label k-Label--tiny"
+          className="k-Label k-Label--micro"
           htmlFor="autocomplete"
           onClick={[Function]}
         >
@@ -27,7 +27,7 @@ Array [
     </div>
   </div>,
   <div
-    className="marger__StyledMarger-q3lecu-0 cHJBWz"
+    className="marger__StyledMarger-q3lecu-0 WSKaG"
   >
     <div
       className="autocomplete__Container-lfeqwe-0 dWXmqi"
@@ -55,7 +55,7 @@ Array [
 exports[`<Field /> with <Field.Input /> in error matches with snapshot 1`] = `
 Array [
   <div
-    className="marger__StyledMarger-q3lecu-0 csmETU"
+    className="marger__StyledMarger-q3lecu-0 gkLTfi"
   >
     <div
       className="k-Line"
@@ -69,7 +69,7 @@ Array [
         className="k-Line__item"
       >
         <label
-          className="k-Label k-Label--tiny"
+          className="k-Label k-Label--micro"
           htmlFor="input"
           onClick={[Function]}
         >
@@ -119,7 +119,7 @@ Array [
     </div>
   </div>,
   <div
-    className="marger__StyledMarger-q3lecu-0 cHJBWz"
+    className="marger__StyledMarger-q3lecu-0 WSKaG"
   >
     <input
       className="text-input__StyledInput-sc-11wej6v-1 eWAcap"
@@ -149,7 +149,7 @@ Array [
 exports[`<Field /> with <Field.Input /> matches with snapshot 1`] = `
 Array [
   <div
-    className="marger__StyledMarger-q3lecu-0 csmETU"
+    className="marger__StyledMarger-q3lecu-0 gkLTfi"
   >
     <div
       className="k-Line"
@@ -163,7 +163,7 @@ Array [
         className="k-Line__item"
       >
         <label
-          className="k-Label k-Label--tiny"
+          className="k-Label k-Label--micro"
           htmlFor="input"
           onClick={[Function]}
         >
@@ -213,7 +213,7 @@ Array [
     </div>
   </div>,
   <div
-    className="marger__StyledMarger-q3lecu-0 cHJBWz"
+    className="marger__StyledMarger-q3lecu-0 WSKaG"
   >
     <input
       className="text-input__StyledInput-sc-11wej6v-1 bVMChg"
@@ -229,7 +229,7 @@ Array [
 exports[`<Field /> with <Field.Password /> in error matches with snapshot 1`] = `
 Array [
   <div
-    className="marger__StyledMarger-q3lecu-0 csmETU"
+    className="marger__StyledMarger-q3lecu-0 gkLTfi"
   >
     <div
       className="k-Line"
@@ -243,7 +243,7 @@ Array [
         className="k-Line__item"
       >
         <label
-          className="k-Label k-Label--tiny"
+          className="k-Label k-Label--micro"
           htmlFor="input"
           onClick={[Function]}
         >
@@ -293,7 +293,7 @@ Array [
     </div>
   </div>,
   <div
-    className="marger__StyledMarger-q3lecu-0 cHJBWz"
+    className="marger__StyledMarger-q3lecu-0 WSKaG"
   >
     <div
       className="password-input__StyledPasswordInput-sc-1futz46-0 jORLcb"
@@ -353,7 +353,7 @@ Array [
 exports[`<Field /> with <Field.Password /> matches with snapshot 1`] = `
 Array [
   <div
-    className="marger__StyledMarger-q3lecu-0 csmETU"
+    className="marger__StyledMarger-q3lecu-0 gkLTfi"
   >
     <div
       className="k-Line"
@@ -367,7 +367,7 @@ Array [
         className="k-Line__item"
       >
         <label
-          className="k-Label k-Label--tiny"
+          className="k-Label k-Label--micro"
           htmlFor="input"
           onClick={[Function]}
         >
@@ -417,7 +417,7 @@ Array [
     </div>
   </div>,
   <div
-    className="marger__StyledMarger-q3lecu-0 cHJBWz"
+    className="marger__StyledMarger-q3lecu-0 WSKaG"
   >
     <div
       className="password-input__StyledPasswordInput-sc-1futz46-0 jORLcb"
@@ -463,7 +463,7 @@ Array [
 exports[`<Field /> with <Field.RadioButtonSet /> matches with snapshot 1`] = `
 Array [
   <div
-    className="marger__StyledMarger-q3lecu-0 csmETU"
+    className="marger__StyledMarger-q3lecu-0 gkLTfi"
   >
     <div
       className="k-Line"
@@ -477,7 +477,7 @@ Array [
         className="k-Line__item"
       >
         <label
-          className="k-Label k-Label--tiny"
+          className="k-Label k-Label--micro"
           htmlFor="option-a"
           onClick={[Function]}
         >
@@ -487,7 +487,7 @@ Array [
     </div>
   </div>,
   <div
-    className="marger__StyledMarger-q3lecu-0 cHJBWz"
+    className="marger__StyledMarger-q3lecu-0 WSKaG"
   >
     <div
       className="k-RadioButtonSet"
@@ -549,7 +549,7 @@ Array [
 exports[`<Field /> with <Field.Select /> matches with snapshot 1`] = `
 Array [
   <div
-    className="marger__StyledMarger-q3lecu-0 csmETU"
+    className="marger__StyledMarger-q3lecu-0 gkLTfi"
   >
     <div
       className="k-Line"
@@ -563,7 +563,7 @@ Array [
         className="k-Line__item"
       >
         <label
-          className="k-Label k-Label--tiny"
+          className="k-Label k-Label--micro"
           htmlFor="select"
           onClick={[Function]}
         >
@@ -573,7 +573,7 @@ Array [
     </div>
   </div>,
   <div
-    className="marger__StyledMarger-q3lecu-0 cHJBWz"
+    className="marger__StyledMarger-q3lecu-0 WSKaG"
   >
     <div
       className="k-Select"

--- a/assets/javascripts/kitten/components/form/field/components/autocomplete.js
+++ b/assets/javascripts/kitten/components/form/field/components/autocomplete.js
@@ -3,7 +3,7 @@ import { Marger } from '../../../layout/marger'
 import { Autocomplete } from '../../../form/autocomplete'
 
 export const FieldAutocomplete = props => (
-  <Marger top="1.5">
+  <Marger top="1">
     <Autocomplete {...props} />
   </Marger>
 )

--- a/assets/javascripts/kitten/components/form/field/components/input.js
+++ b/assets/javascripts/kitten/components/form/field/components/input.js
@@ -17,7 +17,7 @@ export const FieldInput = props => {
   }
 
   return (
-    <Marger top="1.5">
+    <Marger top="1">
       <Input {...props} />
     </Marger>
   )

--- a/assets/javascripts/kitten/components/form/field/components/label.js
+++ b/assets/javascripts/kitten/components/form/field/components/label.js
@@ -28,10 +28,10 @@ export class FieldLabel extends Component {
     } = this.props
 
     return (
-      <Marger bottom="1.5" {...others}>
+      <Marger bottom="1" {...others}>
         <Line style={{ lineHeight: 1 }}>
           <Line.Item>
-            <Label {...labelProps} size={labelProps.size || 'tiny'}>
+            <Label {...labelProps} size={labelProps.size || 'micro'}>
               {children}
             </Label>
           </Line.Item>

--- a/assets/javascripts/kitten/components/form/field/components/password.js
+++ b/assets/javascripts/kitten/components/form/field/components/password.js
@@ -3,7 +3,7 @@ import { Marger } from '../../../layout/marger'
 import { PasswordInput } from '../../password-input'
 
 export const FieldPassword = props => (
-  <Marger top="1.5">
+  <Marger top="1">
     <PasswordInput {...props} />
   </Marger>
 )

--- a/assets/javascripts/kitten/components/form/field/components/radio-button-set.js
+++ b/assets/javascripts/kitten/components/form/field/components/radio-button-set.js
@@ -5,7 +5,7 @@ import { RadioButtonSet } from '../../../form/radio-button-set'
 export class FieldRadioButtonSet extends Component {
   render() {
     return (
-      <Marger top="1.5">
+      <Marger top="1">
         <RadioButtonSet {...this.props} />
       </Marger>
     )

--- a/assets/javascripts/kitten/components/form/field/components/select.js
+++ b/assets/javascripts/kitten/components/form/field/components/select.js
@@ -5,7 +5,7 @@ import { SelectWithState } from '../../../form/select-with-state'
 export class FieldSelect extends Component {
   render() {
     return (
-      <Marger top="1.5">
+      <Marger top="1">
         <SelectWithState {...this.props} />
       </Marger>
     )

--- a/assets/javascripts/kitten/components/form/field/field.examples.js
+++ b/assets/javascripts/kitten/components/form/field/field.examples.js
@@ -34,6 +34,7 @@ export const FieldInputExample = ({
   errorMessage,
   limit,
   unit,
+  tiny,
 }) => (
   <FieldBase
     id={id}
@@ -45,6 +46,7 @@ export const FieldInputExample = ({
   >
     <Field.Input
       id={id}
+      tiny={tiny}
       limit={limit}
       unit={unit}
       name="field"
@@ -62,6 +64,7 @@ export const FieldPasswordExample = ({
   placeholder,
   error,
   errorMessage,
+  tiny,
 }) => (
   <FieldBase
     id={id}
@@ -73,6 +76,7 @@ export const FieldPasswordExample = ({
   >
     <Field.Password
       id={id}
+      tiny={tiny}
       name="field"
       iconLabel="Show password"
       hiddenIconLabel="Hide password"
@@ -140,6 +144,7 @@ export const FieldAutocompleteExample = ({
   error,
   errorMessage,
   items,
+  tiny,
 }) => (
   <FieldBase
     id={id}
@@ -151,6 +156,7 @@ export const FieldAutocompleteExample = ({
   >
     <Field.Autocomplete
       id={id}
+      tiny={tiny}
       name="field"
       placeholder={placeholder}
       error={error}

--- a/assets/javascripts/kitten/components/form/field/field.stories.js
+++ b/assets/javascripts/kitten/components/form/field/field.stories.js
@@ -31,6 +31,7 @@ storiesOf('Form/Field', module)
       <StoryGrid>
         <FieldInputExample
           id={text('ID', 'input')}
+          tiny={boolean('Tiny', false)}
           label={text('Label', 'Label')}
           tooltip={text('Tooltip', null)}
           tooltipId={text('Tooltip ID', 'tooltip')}
@@ -48,6 +49,7 @@ storiesOf('Form/Field', module)
       <StoryGrid>
         <FieldPasswordExample
           id={text('ID', 'input')}
+          tiny={boolean('Tiny', false)}
           label={text('Label', 'Label')}
           tooltip={text('Tooltip', null)}
           tooltipId={text('Tooltip ID', 'tooltip')}
@@ -63,6 +65,7 @@ storiesOf('Form/Field', module)
       <StoryGrid>
         <FieldRadioButtonSetExample
           id={text('ID', 'option-a')}
+          tiny={boolean('Tiny', false)}
           label={text('Label', 'Label')}
           tooltip={text('Tooltip', null)}
           tooltipId={text('Tooltip ID', 'tooltip')}
@@ -92,6 +95,7 @@ storiesOf('Form/Field', module)
       <StoryGrid>
         <FieldSelectExample
           id={text('ID', 'select')}
+          tiny={boolean('Tiny', false)}
           label={text('Label', 'Label')}
           tooltip={text('Tooltip', null)}
           tooltipId={text('Tooltip ID', 'tooltip')}
@@ -112,6 +116,7 @@ storiesOf('Form/Field', module)
       <StoryGrid>
         <FieldAutocompleteExample
           id={text('ID', 'select')}
+          tiny={boolean('Tiny', false)}
           label={text('Label', 'Label')}
           tooltip={text('Tooltip', null)}
           tooltipId={text('Tooltip ID', 'tooltip')}

--- a/assets/javascripts/kitten/components/form/field/field.test.js
+++ b/assets/javascripts/kitten/components/form/field/field.test.js
@@ -21,6 +21,7 @@ describe('<Field />', () => {
             tooltip="Tooltip"
             tooltipId="tooltip"
             placeholder="Placeholder…"
+            tiny={false}
           />,
         )
         .toJSON()
@@ -37,6 +38,7 @@ describe('<Field />', () => {
         .create(
           <FieldInputExample
             id="input"
+            tiny={false}
             label="Label"
             tooltip="Tooltip"
             tooltipId="tooltip"
@@ -59,6 +61,7 @@ describe('<Field />', () => {
         .create(
           <FieldPasswordExample
             id="input"
+            tiny={false}
             label="Label"
             tooltip="Tooltip"
             tooltipId="tooltip"
@@ -79,6 +82,7 @@ describe('<Field />', () => {
         .create(
           <FieldPasswordExample
             id="input"
+            tiny={false}
             label="Label"
             tooltip="Tooltip"
             tooltipId="tooltip"
@@ -101,6 +105,7 @@ describe('<Field />', () => {
         .create(
           <FieldRadioButtonSetExample
             id="option-a"
+            tiny={false}
             label="Label"
             items={[
               {
@@ -133,6 +138,7 @@ describe('<Field />', () => {
         .create(
           <FieldSelectExample
             id="select"
+            tiny={false}
             label="Label"
             placeholder="Select…"
             options={[
@@ -156,6 +162,7 @@ describe('<Field />', () => {
         .create(
           <FieldAutocompleteExample
             id="autocomplete"
+            tiny={false}
             label="Label"
             placeholder="Select…"
             items={['Foo', 'Bar']}


### PR DESCRIPTION
- Passe `micro` comme taille par défaut sur le `label`
- Réduit les marges entre le label et l'input
- Ajoute la props `tiny` sur les examples, stories et tests de `field`

Closes #https://app.clickup.com/t/ve5y5

TODO:

- [ ] Tests
- [ ] Changelog
- [ ] A11Y
- [ ] Stories
- [ ] BrowserStack
