### PR TITLE
[Popover] Add `SimplePopover` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Feature: Add `SimplePopover` component.
+
 ## [2.37.2] - 2019-11-07
 
 Fix:

--- a/assets/javascripts/kitten/components/popovers/simple-popover/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/popovers/simple-popover/__snapshots__/test.js.snap
@@ -313,6 +313,17 @@ exports[`<SimplePopover /> SimplePopover with multiple props matches with snapsh
   flex-basis: 100%;
   margin-bottom: 1.25rem;
   background-color: #fff;
+  opacity: 1;
+  visibility: visible;
+  -webkit-transition: opacity 0.3s ease,visibility 0s ease;
+  transition: opacity 0.3s ease,visibility 0s ease;
+  -webkit-transition-delay: 0s,0.3s;
+  transition-delay: 0s,0.3s;
+}
+
+.c0[aria-hidden='true'] {
+  opacity: 0;
+  visibility: hidden;
 }
 
 .c3 {
@@ -450,12 +461,12 @@ exports[`<SimplePopover /> SimplePopover with multiple props matches with snapsh
     <div
       className="c4"
     >
-      <h1
+      <h2
         className="k-Title k-Title--senary k-Title--withoutMargin"
         id="popover-title"
       >
         This popover has a title
-      </h1>
+      </h2>
     </div>
     <div
       className="c5"
@@ -613,6 +624,17 @@ exports[`<SimplePopover /> simple SimplePopover  matches with snapshot 1`] = `
   flex-basis: 100%;
   margin-bottom: 1.25rem;
   background-color: #fff;
+  opacity: 1;
+  visibility: visible;
+  -webkit-transition: opacity 0.3s ease,visibility 0s ease;
+  transition: opacity 0.3s ease,visibility 0s ease;
+  -webkit-transition-delay: 0s,0.3s;
+  transition-delay: 0s,0.3s;
+}
+
+.c0[aria-hidden='true'] {
+  opacity: 0;
+  visibility: hidden;
 }
 
 .c1 {
@@ -678,12 +700,12 @@ exports[`<SimplePopover /> simple SimplePopover  matches with snapshot 1`] = `
     <div
       className="c3"
     >
-      <h1
+      <h2
         className="k-Title k-Title--senary k-Title--withoutMargin"
         id="popover-title"
       >
         
-      </h1>
+      </h2>
     </div>
     <div
       className="c4"

--- a/assets/javascripts/kitten/components/popovers/simple-popover/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/popovers/simple-popover/__snapshots__/test.js.snap
@@ -386,7 +386,7 @@ exports[`<SimplePopover /> SimplePopover with multiple props matches with snapsh
   }
 }
 
-@media (min-width:640px) {
+@media (min-width:40rem) {
   .c0 {
     padding: 3.125rem 2.5rem;
   }
@@ -637,7 +637,7 @@ exports[`<SimplePopover /> simple SimplePopover  matches with snapshot 1`] = `
   }
 }
 
-@media (min-width:640px) {
+@media (min-width:40rem) {
   .c0 {
     padding: 3.125rem 2.5rem;
   }

--- a/assets/javascripts/kitten/components/popovers/simple-popover/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/popovers/simple-popover/__snapshots__/test.js.snap
@@ -1,0 +1,697 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<SimplePopover /> SimplePopover with multiple props matches with snapshot 1`] = `
+.c4 {
+  margin-bottom: 0.3125rem;
+}
+
+.c5 {
+  margin-top: 0.3125rem;
+  margin-bottom: 0.625rem;
+}
+
+.c7 {
+  margin-top: 1.875rem;
+}
+
+.c2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  position: relative;
+  box-sizing: border-box;
+  min-width: 12.5rem;
+  min-height: 3.125rem;
+  padding: 0 1.875rem;
+  font-size: 0.875rem;
+  font-family: Maax,Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-size: 0.875rem;
+  color: #222;
+  line-height: 1.3;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  -webkit-appareance: none;
+  -moz-appareance: none;
+  appareance: none;
+  outline: none;
+  cursor: pointer;
+  min-width: 10rem;
+  min-height: 2.5rem;
+  padding: 0 1.25rem;
+  font-size: 0.875rem;
+  min-width: initial;
+  min-height: initial;
+  width: 3.125rem;
+  height: 3.125rem;
+  padding: 0;
+  width: 2.5rem;
+  height: 2.5rem;
+  border: 0.125rem solid #222;
+  background-color: #222;
+  color: #fff;
+  -webkit-transition: background-color 0.2s,color 0.2s,border-color 0.2s;
+  transition: background-color 0.2s,color 0.2s,border-color 0.2s;
+}
+
+.c2:disabled {
+  cursor: not-allowed;
+}
+
+.c2 >:nth-child(n) {
+  margin-right: 0.625rem;
+  text-align: left;
+}
+
+.c2 >:last-child {
+  margin-right: 0;
+}
+
+.c2 svg {
+  fill: #fff;
+}
+
+.c2:hover,
+.c2:focus {
+  border-color: #05a8e6;
+  background-color: #05a8e6;
+  color: #fff;
+}
+
+.c2:hover svg,
+.c2:focus svg {
+  fill: #fff;
+}
+
+.c2:active {
+  border-color: #0496cc;
+  background-color: #0496cc;
+  color: #fff;
+}
+
+.c2:active svg {
+  fill: #fff;
+}
+
+.c2:disabled {
+  border-color: #d8d8d8;
+  background-color: #d8d8d8;
+  color: #fff;
+}
+
+.c2:disabled svg {
+  fill: #fff;
+}
+
+.c8 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  position: relative;
+  box-sizing: border-box;
+  min-width: 12.5rem;
+  min-height: 3.125rem;
+  padding: 0 1.875rem;
+  font-size: 0.875rem;
+  font-family: Maax,Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-size: 0.875rem;
+  color: #222;
+  line-height: 1.3;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  -webkit-appareance: none;
+  -moz-appareance: none;
+  appareance: none;
+  outline: none;
+  cursor: pointer;
+  min-width: 10rem;
+  min-height: 2.5rem;
+  padding: 0 1.25rem;
+  font-size: 0.875rem;
+  border: 0.125rem solid #eee;
+  background-color: #fff;
+  color: #222;
+  -webkit-transition: background-color 0.2s,color 0.2s,border-color 0.2s;
+  transition: background-color 0.2s,color 0.2s,border-color 0.2s;
+}
+
+.c8:disabled {
+  cursor: not-allowed;
+}
+
+.c8 >:nth-child(n) {
+  margin-right: 0.625rem;
+  text-align: left;
+}
+
+.c8 >:last-child {
+  margin-right: 0;
+}
+
+.c8 svg {
+  fill: #222;
+}
+
+.c8:hover,
+.c8:focus {
+  border-color: #05a8e6;
+  background-color: #05a8e6;
+  color: #fff;
+}
+
+.c8:hover svg,
+.c8:focus svg {
+  fill: #fff;
+}
+
+.c8:active {
+  border-color: #0496cc;
+  background-color: #0496cc;
+  color: #fff;
+}
+
+.c8:active svg {
+  fill: #fff;
+}
+
+.c8:disabled {
+  border-color: #d8d8d8;
+  background-color: #d8d8d8;
+  color: #fff;
+}
+
+.c8:disabled svg {
+  fill: #fff;
+}
+
+.c9 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  position: relative;
+  box-sizing: border-box;
+  min-width: 12.5rem;
+  min-height: 3.125rem;
+  padding: 0 1.875rem;
+  font-size: 0.875rem;
+  font-family: Maax,Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-size: 0.875rem;
+  color: #222;
+  line-height: 1.3;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  -webkit-appareance: none;
+  -moz-appareance: none;
+  appareance: none;
+  outline: none;
+  cursor: pointer;
+  min-width: 10rem;
+  min-height: 2.5rem;
+  padding: 0 1.25rem;
+  font-size: 0.875rem;
+  border: 0.125rem solid #19b4fa;
+  background-color: #19b4fa;
+  color: #fff;
+  -webkit-transition: background-color 0.2s,color 0.2s,border-color 0.2s;
+  transition: background-color 0.2s,color 0.2s,border-color 0.2s;
+}
+
+.c9:disabled {
+  cursor: not-allowed;
+}
+
+.c9 >:nth-child(n) {
+  margin-right: 0.625rem;
+  text-align: left;
+}
+
+.c9 >:last-child {
+  margin-right: 0;
+}
+
+.c9 svg {
+  fill: #fff;
+}
+
+.c9:hover,
+.c9:focus {
+  border-color: #05a8e6;
+  background-color: #05a8e6;
+  color: #fff;
+}
+
+.c9:hover svg,
+.c9:focus svg {
+  fill: #fff;
+}
+
+.c9:active {
+  border-color: #0496cc;
+  background-color: #0496cc;
+  color: #fff;
+}
+
+.c9:active svg {
+  fill: #fff;
+}
+
+.c9:disabled {
+  border-color: #d8d8d8;
+  background-color: #d8d8d8;
+  color: #fff;
+}
+
+.c9:disabled svg {
+  fill: #fff;
+}
+
+.c0 {
+  padding: 2.5rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  border: solid #eee 0.125rem;
+  box-sizing: border-box;
+  max-width: 34.6875rem;
+  -webkit-flex-basis: 100%;
+  -ms-flex-preferred-size: 100%;
+  flex-basis: 100%;
+  margin-bottom: 1.25rem;
+  background-color: #fff;
+}
+
+.c3 {
+  display: none;
+  min-width: 5rem;
+  min-height: 5rem;
+  margin-right: 2.5rem;
+  border-radius: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  background-color: #bae8fd;
+}
+
+.c1 {
+  position: absolute;
+  top: -0.125rem;
+  right: -0.125rem;
+  -webkit-transition: background-color 0.2s,color 0.2s,border-color 0.2s;
+  transition: background-color 0.2s,color 0.2s,border-color 0.2s;
+}
+
+.c6 > * + * {
+  margin-top: 1.25rem;
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c2 {
+    width: 12.5rem;
+    height: 3.125rem;
+  }
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c2 {
+    width: 10rem;
+    height: 2.5rem;
+  }
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c8 {
+    width: 12.5rem;
+    height: 3.125rem;
+  }
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c8 {
+    width: 10rem;
+    height: 2.5rem;
+  }
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c9 {
+    width: 12.5rem;
+    height: 3.125rem;
+  }
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c9 {
+    width: 10rem;
+    height: 2.5rem;
+  }
+}
+
+@media (min-width:640px) {
+  .c0 {
+    padding: 3.125rem 2.5rem;
+  }
+}
+
+@media (min-width:640px) {
+  .c3 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+  }
+}
+
+@media (min-width:640px) {
+  .c6 > * + * {
+    margin-top: 0;
+    margin-left: 1.25rem;
+  }
+}
+
+<div
+  aria-hidden={false}
+  aria-labelledby="popover-title"
+  className="c0"
+  role="dialog"
+>
+  <button
+    aria-label="Close"
+    className="c1 c2"
+    onClick={[Function]}
+    type="button"
+  >
+    <svg
+      fill="#fff"
+      height="8"
+      viewBox="0 0 8 8"
+      width="8"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title>
+        Cross
+      </title>
+      <path
+        d="M.464 6.12L6.12.465 7.537 1.88 1.88 7.535z"
+      />
+      <path
+        d="M1.88.464L7.535 6.12 6.12 7.537.465 1.88z"
+      />
+    </svg>
+  </button>
+  <div
+    className="c3"
+  >
+    <p>
+      illus
+    </p>
+  </div>
+  <div>
+    <div
+      className="c4"
+    >
+      <h1
+        className="k-Title k-Title--senary k-Title--withoutMargin"
+        id="popover-title"
+      >
+        This popover has a title
+      </h1>
+    </div>
+    <div
+      className="c5"
+    >
+      <p
+        className="k-Paragraph k-Paragraph--quaternary"
+      >
+        Maecenas sed diam eget risus varius blandit sit amet non magna. Donec id elit non mi porta gravida at eget metus. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. 
+      </p>
+    </div>
+    <div
+      className="c6 c7"
+    >
+      <button
+        className="c8"
+        onClick={[Function]}
+      >
+        J’ai compris
+      </button>
+      <button
+        className="c9"
+        onClick={[Function]}
+      >
+        Mes préférences
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<SimplePopover /> simple SimplePopover  matches with snapshot 1`] = `
+.c3 {
+  margin-bottom: 0.3125rem;
+}
+
+.c4 {
+  margin-top: 0.3125rem;
+  margin-bottom: 0.625rem;
+}
+
+.c2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  position: relative;
+  box-sizing: border-box;
+  min-width: 12.5rem;
+  min-height: 3.125rem;
+  padding: 0 1.875rem;
+  font-size: 0.875rem;
+  font-family: Maax,Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-size: 0.875rem;
+  color: #222;
+  line-height: 1.3;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  -webkit-appareance: none;
+  -moz-appareance: none;
+  appareance: none;
+  outline: none;
+  cursor: pointer;
+  min-width: 10rem;
+  min-height: 2.5rem;
+  padding: 0 1.25rem;
+  font-size: 0.875rem;
+  min-width: initial;
+  min-height: initial;
+  width: 3.125rem;
+  height: 3.125rem;
+  padding: 0;
+  width: 2.5rem;
+  height: 2.5rem;
+  border: 0.125rem solid #222;
+  background-color: #222;
+  color: #fff;
+  -webkit-transition: background-color 0.2s,color 0.2s,border-color 0.2s;
+  transition: background-color 0.2s,color 0.2s,border-color 0.2s;
+}
+
+.c2:disabled {
+  cursor: not-allowed;
+}
+
+.c2 >:nth-child(n) {
+  margin-right: 0.625rem;
+  text-align: left;
+}
+
+.c2 >:last-child {
+  margin-right: 0;
+}
+
+.c2 svg {
+  fill: #fff;
+}
+
+.c2:hover,
+.c2:focus {
+  border-color: #05a8e6;
+  background-color: #05a8e6;
+  color: #fff;
+}
+
+.c2:hover svg,
+.c2:focus svg {
+  fill: #fff;
+}
+
+.c2:active {
+  border-color: #0496cc;
+  background-color: #0496cc;
+  color: #fff;
+}
+
+.c2:active svg {
+  fill: #fff;
+}
+
+.c2:disabled {
+  border-color: #d8d8d8;
+  background-color: #d8d8d8;
+  color: #fff;
+}
+
+.c2:disabled svg {
+  fill: #fff;
+}
+
+.c0 {
+  padding: 2.5rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  border: solid #eee 0.125rem;
+  box-sizing: border-box;
+  max-width: 34.6875rem;
+  -webkit-flex-basis: 100%;
+  -ms-flex-preferred-size: 100%;
+  flex-basis: 100%;
+  margin-bottom: 1.25rem;
+  background-color: #fff;
+}
+
+.c1 {
+  position: absolute;
+  top: -0.125rem;
+  right: -0.125rem;
+  -webkit-transition: background-color 0.2s,color 0.2s,border-color 0.2s;
+  transition: background-color 0.2s,color 0.2s,border-color 0.2s;
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c2 {
+    width: 12.5rem;
+    height: 3.125rem;
+  }
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c2 {
+    width: 10rem;
+    height: 2.5rem;
+  }
+}
+
+@media (min-width:640px) {
+  .c0 {
+    padding: 3.125rem 2.5rem;
+  }
+}
+
+<div
+  aria-hidden={false}
+  aria-labelledby="popover-title"
+  className="c0"
+  role="dialog"
+>
+  <button
+    aria-label="Close"
+    className="c1 c2"
+    onClick={[Function]}
+    type="button"
+  >
+    <svg
+      fill="#fff"
+      height="8"
+      viewBox="0 0 8 8"
+      width="8"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title>
+        Cross
+      </title>
+      <path
+        d="M.464 6.12L6.12.465 7.537 1.88 1.88 7.535z"
+      />
+      <path
+        d="M1.88.464L7.535 6.12 6.12 7.537.465 1.88z"
+      />
+    </svg>
+  </button>
+  <div>
+    <div
+      className="c3"
+    >
+      <h1
+        className="k-Title k-Title--senary k-Title--withoutMargin"
+        id="popover-title"
+      >
+        
+      </h1>
+    </div>
+    <div
+      className="c4"
+    >
+      <p
+        className="k-Paragraph k-Paragraph--quaternary"
+      >
+        
+      </p>
+    </div>
+  </div>
+</div>
+`;

--- a/assets/javascripts/kitten/components/popovers/simple-popover/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/popovers/simple-popover/__snapshots__/test.js.snap
@@ -421,6 +421,7 @@ exports[`<SimplePopover /> SimplePopover with multiple props matches with snapsh
     type="button"
   >
     <svg
+      aria-hidden={true}
       fill="#fff"
       height="8"
       viewBox="0 0 8 8"
@@ -655,6 +656,7 @@ exports[`<SimplePopover /> simple SimplePopover  matches with snapshot 1`] = `
     type="button"
   >
     <svg
+      aria-hidden={true}
       fill="#fff"
       height="8"
       viewBox="0 0 8 8"

--- a/assets/javascripts/kitten/components/popovers/simple-popover/index.js
+++ b/assets/javascripts/kitten/components/popovers/simple-popover/index.js
@@ -84,7 +84,7 @@ export const SimplePopover = ({
   titleId,
   closeButtonLabel,
   title,
-  content,
+  text,
   illustration,
   illustrationBackground,
   buttons,
@@ -118,7 +118,7 @@ export const SimplePopover = ({
         </Title>
       </Marger>
       <Marger top=".5" bottom="1">
-        <Paragraph modifier="quaternary">{content}</Paragraph>
+        <Paragraph modifier="quaternary">{text}</Paragraph>
       </Marger>
       {buttons.length > 0 && (
         <ButtonsContainer top="3">
@@ -147,7 +147,7 @@ SimplePopover.defaultProps = {
   titleId: 'popover-title',
   closeButtonLabel: 'Close',
   title: '',
-  content: '',
+  text: '',
   illustration: null,
   illustrationBackground: COLORS.primary4,
   buttons: [],
@@ -159,7 +159,7 @@ SimplePopover.propTypes = {
   titleId: PropTypes.string,
   closeButtonLabel: PropTypes.string,
   title: PropTypes.string,
-  content: PropTypes.string,
+  text: PropTypes.string,
   illustration: PropTypes.object,
   illustrationBackground: PropTypes.string,
   buttons: PropTypes.array,

--- a/assets/javascripts/kitten/components/popovers/simple-popover/index.js
+++ b/assets/javascripts/kitten/components/popovers/simple-popover/index.js
@@ -99,11 +99,11 @@ export const SimplePopover = ({
   onCloseClick,
   titleId,
   closeButtonLabel,
-  popoverTitle,
-  popoverContent,
-  popoverIllustration,
-  popoverIllustrationBackground,
-  popoverButtons,
+  title,
+  content,
+  illustration,
+  illustrationBackground,
+  buttons,
   ...simplePopoverProps
 }) => (
   <PopoverContainer
@@ -123,23 +123,23 @@ export const SimplePopover = ({
     >
       <CrossIcon width="8" height="8" fill={COLORS.background1} />
     </CrossIconButton>
-    {popoverIllustration && (
-      <IconContainer backgroundColor={popoverIllustrationBackground}>
-        {popoverIllustration}
+    {illustration && (
+      <IconContainer backgroundColor={illustrationBackground}>
+        {illustration}
       </IconContainer>
     )}
     <div>
       <Marger bottom=".5">
         <Title id={titleId} modifier="senary" margin={false}>
-          {popoverTitle}
+          {title}
         </Title>
       </Marger>
       <Marger top=".5" bottom="1">
-        <Paragraph modifier="quaternary">{popoverContent}</Paragraph>
+        <Paragraph modifier="quaternary">{content}</Paragraph>
       </Marger>
-      {popoverButtons.length > 0 && (
+      {buttons.length > 0 && (
         <ButtonsContainer top="3">
-          {popoverButtons.map(({ label, clickOptions, ...buttonProps }, i) => {
+          {buttons.map(({ label, clickOptions, ...buttonProps }, i) => {
             const clickHandler =
               clickOptions && clickOptions.closeOnClick && onCloseClick
 
@@ -163,11 +163,11 @@ SimplePopover.defaultProps = {
   onCloseClick: () => {},
   titleId: 'popover-title',
   closeButtonLabel: 'Close',
-  popoverTitle: '',
-  popoverContent: '',
-  popoverIllustration: null,
-  popoverIllustrationBackground: COLORS.primary4,
-  popoverButtons: [],
+  title: '',
+  content: '',
+  illustration: null,
+  illustrationBackground: COLORS.primary4,
+  buttons: [],
 }
 
 SimplePopover.propTypes = {
@@ -175,9 +175,9 @@ SimplePopover.propTypes = {
   onCloseClick: PropTypes.func,
   titleId: PropTypes.string,
   closeButtonLabel: PropTypes.string,
-  popoverTitle: PropTypes.string,
-  popoverContent: PropTypes.string,
-  popoverIllustration: PropTypes.object,
-  popoverIllustrationBackground: PropTypes.string,
-  popoverButtons: PropTypes.array,
+  title: PropTypes.string,
+  content: PropTypes.string,
+  illustration: PropTypes.object,
+  illustrationBackground: PropTypes.string,
+  buttons: PropTypes.array,
 }

--- a/assets/javascripts/kitten/components/popovers/simple-popover/index.js
+++ b/assets/javascripts/kitten/components/popovers/simple-popover/index.js
@@ -1,0 +1,183 @@
+import React, { useState } from 'react'
+import PropTypes from 'prop-types'
+import styled, { css, keyframes } from 'styled-components'
+import { Marger } from '../../../components/layout/marger'
+import { CrossIcon } from '../../../components/icons/cross-icon'
+import COLORS from '../../../constants/colors-config'
+import { pxToRem } from '../../../helpers/utils/typography'
+import { Title } from '../../../components/typography/title'
+import { Text } from '../../../components/typography/text'
+import { Paragraph } from '../../../components/typography/paragraph'
+import { CONTAINER_PADDING_THIN } from '../../../constants/grid-config'
+import { ScreenConfig } from '../../../constants/screen-config'
+import { Button } from '../../../components/buttons/button/button'
+
+const borderSize = 2
+
+const tourFadeOut = () =>
+  keyframes`
+  0 {
+    opacity: 1;
+    visibility: visible;
+  }
+  99% {
+    opacity: 0;
+    visibility: visible;
+  }
+  100% {
+    opacity: 0;
+    visibility: hidden;
+  }
+`
+
+const StyledLoudSpeaker = styled.div`
+  display: block;
+  margin: 0 auto;
+`
+
+const PopoverContainer = styled.div`
+  padding: ${pxToRem(40)};
+  display: flex;
+  align-items: center;
+  position: relative;
+  border: solid ${COLORS.line1} ${pxToRem(borderSize)};
+  box-sizing: border-box;
+  max-width: ${pxToRem(555)};
+  flex-basis: 100%;
+  margin-bottom: ${pxToRem(CONTAINER_PADDING_THIN)};
+  background-color: ${COLORS.background1};
+
+  @media (min-width: ${ScreenConfig.S.min}px) {
+    padding: ${pxToRem(50)} ${pxToRem(40)};
+  }
+
+  ${({ hide }) =>
+    hide &&
+    css`
+      animation-name: ${tourFadeOut};
+      animation-fill-mode: forwards;
+      animation-duration: 0.5s;
+      animation-timing-function: ease-in-quart;
+    `}
+`
+
+const IconContainer = styled.div`
+  display: none;
+  min-width: ${pxToRem(80)};
+  min-height: ${pxToRem(80)};
+  margin-right: ${pxToRem(40)};
+  border-radius: 100%;
+  align-items: center;
+  justify-content: center;
+  background-color: ${({ backgroundColor }) => backgroundColor};
+
+  @media (min-width: ${ScreenConfig.S.min}px) {
+    display: flex;
+  }
+`
+
+const CrossIconButton = styled(Button)`
+  position: absolute;
+  top: -${pxToRem(borderSize)};
+  right: -${pxToRem(borderSize)};
+  transition: background-color 0.2s, color 0.2s, border-color 0.2s;
+`
+
+const ButtonsContainer = styled(Marger)`
+  & > * + * {
+    margin-top: ${pxToRem(20)};
+
+    @media (min-width: ${ScreenConfig.S.min}px) {
+      margin-top: 0;
+      margin-left: ${pxToRem(20)};
+    }
+  }
+`
+
+export const SimplePopover = ({
+  isVisible,
+  onCloseClick,
+  titleId,
+  closeButtonLabel,
+  popoverTitle,
+  popoverContent,
+  popoverIllustration,
+  popoverIllustrationBackground,
+  popoverButtons,
+  ...simplePopoverProps
+}) => (
+  <PopoverContainer
+    {...simplePopoverProps}
+    role="dialog"
+    aria-hidden={!isVisible}
+    aria-labelledby={titleId}
+    hide={!isVisible}
+  >
+    <CrossIconButton
+      aria-label={closeButtonLabel}
+      onClick={onCloseClick}
+      type="button"
+      modifier="beryllium"
+      tiny
+      icon
+    >
+      <CrossIcon width="8" height="8" fill={COLORS.background1} />
+    </CrossIconButton>
+    {popoverIllustration && (
+      <IconContainer backgroundColor={popoverIllustrationBackground}>
+        {popoverIllustration}
+      </IconContainer>
+    )}
+    <div>
+      <Marger bottom=".5">
+        <Title id={titleId} modifier="senary" margin={false}>
+          {popoverTitle}
+        </Title>
+      </Marger>
+      <Marger top=".5" bottom="1">
+        <Paragraph modifier="quaternary">{popoverContent}</Paragraph>
+      </Marger>
+      {popoverButtons.length > 0 && (
+        <ButtonsContainer top="3">
+          {popoverButtons.map(({ label, clickOptions, ...buttonProps }, i) => {
+            const clickHandler =
+              clickOptions && clickOptions.closeOnClick && onCloseClick
+
+            return (
+              <Button
+                onClick={clickHandler}
+                key={i}
+                children={label}
+                {...buttonProps}
+              />
+            )
+          })}
+        </ButtonsContainer>
+      )}
+    </div>
+  </PopoverContainer>
+)
+
+SimplePopover.defaultProps = {
+  isVisible: true,
+  onCloseClick: () => {},
+  titleId: 'popover-title',
+  closeButtonLabel: 'Close',
+  popoverTitle: '',
+  popoverContent: '',
+  popoverIllustration: null,
+  popoverIllustrationBackground: COLORS.primary4,
+  popoverButtons: [],
+}
+
+SimplePopover.propTypes = {
+  isVisible: PropTypes.bool,
+  onCloseClick: PropTypes.func,
+  titleId: PropTypes.string,
+  closeButtonLabel: PropTypes.string,
+  popoverTitle: PropTypes.string,
+  popoverContent: PropTypes.string,
+  popoverIllustration: PropTypes.object,
+  popoverIllustrationBackground: PropTypes.string,
+  popoverButtons: PropTypes.array,
+}

--- a/assets/javascripts/kitten/components/popovers/simple-popover/index.js
+++ b/assets/javascripts/kitten/components/popovers/simple-popover/index.js
@@ -14,22 +14,6 @@ import { Button } from '../../../components/buttons/button/button'
 
 const borderSize = 2
 
-const tourFadeOut = () =>
-  keyframes`
-  0 {
-    opacity: 1;
-    visibility: visible;
-  }
-  99% {
-    opacity: 0;
-    visibility: visible;
-  }
-  100% {
-    opacity: 0;
-    visibility: hidden;
-  }
-`
-
 const StyledLoudSpeaker = styled.div`
   display: block;
   margin: 0 auto;
@@ -46,19 +30,19 @@ const PopoverContainer = styled.div`
   flex-basis: 100%;
   margin-bottom: ${pxToRem(CONTAINER_PADDING_THIN)};
   background-color: ${COLORS.background1};
+  opacity: 1;
+  visibility: visible;
+  transition: opacity 0.3s ease, visibility 0s ease;
+  transition-delay: 0s, 0.3s;
 
   @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
     padding: ${pxToRem(50)} ${pxToRem(40)};
   }
 
-  ${({ hide }) =>
-    hide &&
-    css`
-      animation-name: ${tourFadeOut};
-      animation-fill-mode: forwards;
-      animation-duration: 0.5s;
-      animation-timing-function: ease-in-quart;
-    `}
+  &[aria-hidden='true'] {
+    opacity: 0;
+    visibility: hidden;
+  }
 `
 
 const IconContainer = styled.div`
@@ -111,7 +95,6 @@ export const SimplePopover = ({
     role="dialog"
     aria-hidden={!isVisible}
     aria-labelledby={titleId}
-    hide={!isVisible}
   >
     <CrossIconButton
       aria-label={closeButtonLabel}

--- a/assets/javascripts/kitten/components/popovers/simple-popover/index.js
+++ b/assets/javascripts/kitten/components/popovers/simple-popover/index.js
@@ -121,7 +121,7 @@ export const SimplePopover = ({
       tiny
       icon
     >
-      <CrossIcon width="8" height="8" fill={COLORS.background1} />
+      <CrossIcon aria-hidden width="8" height="8" fill={COLORS.background1} />
     </CrossIconButton>
     {illustration && (
       <IconContainer backgroundColor={illustrationBackground}>

--- a/assets/javascripts/kitten/components/popovers/simple-popover/index.js
+++ b/assets/javascripts/kitten/components/popovers/simple-popover/index.js
@@ -113,7 +113,7 @@ export const SimplePopover = ({
     )}
     <div>
       <Marger bottom=".5">
-        <Title id={titleId} modifier="senary" margin={false}>
+        <Title id={titleId} modifier="senary" margin={false} tag="h2">
           {title}
         </Title>
       </Marger>

--- a/assets/javascripts/kitten/components/popovers/simple-popover/stories.js
+++ b/assets/javascripts/kitten/components/popovers/simple-popover/stories.js
@@ -32,10 +32,10 @@ storiesOf('Popovers & Tours/SimplePopover', module)
           onCloseClick={closeClick}
           titleId="popover-title"
           closeButtonLabel="Close"
-          popoverTitle="This popover has a title"
-          popoverContent="Maecenas sed diam eget risus varius blandit sit amet non magna. Donec id elit non mi porta gravida at eget metus. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. "
-          popoverIllustration={<p>🐱</p>}
-          popoverButtons={[
+          title="This popover has a title"
+          content="Maecenas sed diam eget risus varius blandit sit amet non magna. Donec id elit non mi porta gravida at eget metus. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. "
+          illustration={<p>🐱</p>}
+          buttons={[
             {
               label: 'Cancel',
               modifier: 'hydrogen',

--- a/assets/javascripts/kitten/components/popovers/simple-popover/stories.js
+++ b/assets/javascripts/kitten/components/popovers/simple-popover/stories.js
@@ -59,3 +59,70 @@ storiesOf('Popovers & Tours/SimplePopover', module)
       </StoryContainer>
     )
   })
+  .add('without illustration', () => {
+    const [isVisible, setVisibility] = useState(true)
+
+    const closeClick = () => {
+      console.log('Close or Cancel clicked')
+      setVisibility(false)
+    }
+
+    return (
+      <StoryContainer>
+        <SimplePopover
+          isVisible={isVisible}
+          onCloseClick={closeClick}
+          titleId="popover-title"
+          closeButtonLabel="Close"
+          title="This popover has a title"
+          content="Maecenas sed diam eget risus varius blandit sit amet non magna. Donec id elit non mi porta gravida at eget metus. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. "
+          buttons={[
+            {
+              label: 'Cancel',
+              modifier: 'hydrogen',
+              tiny: true,
+              clickOptions: {
+                closeOnClick: true,
+              },
+            },
+            {
+              label: 'OK',
+              modifier: 'helium',
+              tiny: true,
+              onClick: () => console.log('Ok clicked'),
+            },
+          ]}
+        />
+
+        {!isVisible && (
+          <Button onClick={() => setVisibility(true)}>Show Popover</Button>
+        )}
+      </StoryContainer>
+    )
+  })
+  .add('without buttons', () => {
+    const [isVisible, setVisibility] = useState(true)
+
+    const closeClick = () => {
+      console.log('Close clicked')
+      setVisibility(false)
+    }
+
+    return (
+      <StoryContainer>
+        <SimplePopover
+          isVisible={isVisible}
+          onCloseClick={closeClick}
+          titleId="popover-title"
+          closeButtonLabel="Close"
+          title="This popover has a title"
+          content="Maecenas sed diam eget risus varius blandit sit amet non magna. Donec id elit non mi porta gravida at eget metus. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. "
+          illustration={<p>🐱</p>}
+        />
+
+        {!isVisible && (
+          <Button onClick={() => setVisibility(true)}>Show Popover</Button>
+        )}
+      </StoryContainer>
+    )
+  })

--- a/assets/javascripts/kitten/components/popovers/simple-popover/stories.js
+++ b/assets/javascripts/kitten/components/popovers/simple-popover/stories.js
@@ -1,0 +1,61 @@
+import React, { useState } from 'react'
+import { storiesOf } from '@storybook/react'
+import { withKnobs, number, color } from '@storybook/addon-knobs'
+import { SimplePopover } from './index'
+import { Marger } from '../../layout/marger'
+import { Container } from '../../grid/container'
+import COLORS from '../../../constants/colors-config'
+import { Button } from '../../../components/buttons/button/button'
+
+const StoryContainer = ({ children }) => (
+  <Container>
+    <Marger top="10" style={{ marginLeft: 60 }}>
+      {children}
+    </Marger>
+  </Container>
+)
+
+storiesOf('Popovers & Tours/SimplePopover', module)
+  .addDecorator(withKnobs)
+  .add('default', () => {
+    const [isVisible, setVisibility] = useState(true)
+
+    const closeClick = () => {
+      console.log('Close or Cancel clicked')
+      setVisibility(false)
+    }
+
+    return (
+      <StoryContainer>
+        <SimplePopover
+          isVisible={isVisible}
+          onCloseClick={closeClick}
+          titleId="popover-title"
+          closeButtonLabel="Close"
+          popoverTitle="This popover has a title"
+          popoverContent="Maecenas sed diam eget risus varius blandit sit amet non magna. Donec id elit non mi porta gravida at eget metus. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. "
+          popoverIllustration={<p>🐱</p>}
+          popoverButtons={[
+            {
+              label: 'Cancel',
+              modifier: 'hydrogen',
+              tiny: true,
+              clickOptions: {
+                closeOnClick: true,
+              },
+            },
+            {
+              label: 'OK',
+              modifier: 'helium',
+              tiny: true,
+              onClick: () => console.log('Ok clicked'),
+            },
+          ]}
+        />
+
+        {!isVisible && (
+          <Button onClick={() => setVisibility(true)}>Show Popover</Button>
+        )}
+      </StoryContainer>
+    )
+  })

--- a/assets/javascripts/kitten/components/popovers/simple-popover/stories.js
+++ b/assets/javascripts/kitten/components/popovers/simple-popover/stories.js
@@ -33,7 +33,7 @@ storiesOf('Popovers & Tours/SimplePopover', module)
           titleId="popover-title"
           closeButtonLabel="Close"
           title="This popover has a title"
-          content="Maecenas sed diam eget risus varius blandit sit amet non magna. Donec id elit non mi porta gravida at eget metus. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. "
+          text="Maecenas sed diam eget risus varius blandit sit amet non magna. Donec id elit non mi porta gravida at eget metus. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. "
           illustration={<p>🐱</p>}
           buttons={[
             {
@@ -75,7 +75,7 @@ storiesOf('Popovers & Tours/SimplePopover', module)
           titleId="popover-title"
           closeButtonLabel="Close"
           title="This popover has a title"
-          content="Maecenas sed diam eget risus varius blandit sit amet non magna. Donec id elit non mi porta gravida at eget metus. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. "
+          text="Maecenas sed diam eget risus varius blandit sit amet non magna. Donec id elit non mi porta gravida at eget metus. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. "
           buttons={[
             {
               label: 'Cancel',
@@ -116,7 +116,7 @@ storiesOf('Popovers & Tours/SimplePopover', module)
           titleId="popover-title"
           closeButtonLabel="Close"
           title="This popover has a title"
-          content="Maecenas sed diam eget risus varius blandit sit amet non magna. Donec id elit non mi porta gravida at eget metus. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. "
+          text="Maecenas sed diam eget risus varius blandit sit amet non magna. Donec id elit non mi porta gravida at eget metus. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. "
           illustration={<p>🐱</p>}
         />
 

--- a/assets/javascripts/kitten/components/popovers/simple-popover/test.js
+++ b/assets/javascripts/kitten/components/popovers/simple-popover/test.js
@@ -26,7 +26,7 @@ describe('<SimplePopover />', () => {
             titleId="popover-title"
             closeButtonLabel="Close"
             title="This popover has a title"
-            content="Maecenas sed diam eget risus varius blandit sit amet non magna. Donec id elit non mi porta gravida at eget metus. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. "
+            text="Maecenas sed diam eget risus varius blandit sit amet non magna. Donec id elit non mi porta gravida at eget metus. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. "
             illustration={<p>illus</p>}
             buttons={[
               {

--- a/assets/javascripts/kitten/components/popovers/simple-popover/test.js
+++ b/assets/javascripts/kitten/components/popovers/simple-popover/test.js
@@ -25,10 +25,10 @@ describe('<SimplePopover />', () => {
             onCloseClick={() => {}}
             titleId="popover-title"
             closeButtonLabel="Close"
-            popoverTitle="This popover has a title"
-            popoverContent="Maecenas sed diam eget risus varius blandit sit amet non magna. Donec id elit non mi porta gravida at eget metus. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. "
-            popoverIllustration={<p>illus</p>}
-            popoverButtons={[
+            title="This popover has a title"
+            content="Maecenas sed diam eget risus varius blandit sit amet non magna. Donec id elit non mi porta gravida at eget metus. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. "
+            illustration={<p>illus</p>}
+            buttons={[
               {
                 label: 'J’ai compris',
                 modifier: 'hydrogen',

--- a/assets/javascripts/kitten/components/popovers/simple-popover/test.js
+++ b/assets/javascripts/kitten/components/popovers/simple-popover/test.js
@@ -1,0 +1,56 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import 'jest-styled-components'
+import { SimplePopover } from './index'
+
+describe('<SimplePopover />', () => {
+  let component
+
+  describe('simple SimplePopover ', () => {
+    beforeEach(() => {
+      component = renderer.create(<SimplePopover />).toJSON()
+    })
+
+    it('matches with snapshot', () => {
+      expect(component).toMatchSnapshot()
+    })
+  })
+
+  describe('SimplePopover with multiple props', () => {
+    beforeEach(() => {
+      component = renderer
+        .create(
+          <SimplePopover
+            isVisible={true}
+            onCloseClick={() => {}}
+            titleId="popover-title"
+            closeButtonLabel="Close"
+            popoverTitle="This popover has a title"
+            popoverContent="Maecenas sed diam eget risus varius blandit sit amet non magna. Donec id elit non mi porta gravida at eget metus. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. "
+            popoverIllustration={<p>illus</p>}
+            popoverButtons={[
+              {
+                label: 'J’ai compris',
+                modifier: 'hydrogen',
+                tiny: true,
+                clickOptions: {
+                  closeOnClick: true,
+                },
+              },
+              {
+                label: 'Mes préférences',
+                modifier: 'helium',
+                tiny: true,
+                onClick: () => {},
+              },
+            ]}
+          />,
+        )
+        .toJSON()
+    })
+
+    it('matches with snapshot', () => {
+      expect(component).toMatchSnapshot()
+    })
+  })
+})

--- a/assets/javascripts/kitten/components/tours/highlight-halo/stories.js
+++ b/assets/javascripts/kitten/components/tours/highlight-halo/stories.js
@@ -14,7 +14,7 @@ const StoryContainer = ({ children }) => (
   </Container>
 )
 
-storiesOf('Tour/HighlightHalo', module)
+storiesOf('Popovers & Tours/HighlightHalo', module)
   .addDecorator(withKnobs)
   .add('default', () => {
     return (

--- a/assets/javascripts/kitten/index.js
+++ b/assets/javascripts/kitten/index.js
@@ -200,6 +200,7 @@ export {
   CallToActionPopover,
 } from './components/popovers/call-to-action-popover'
 export { Popover } from './components/popovers/popover'
+export { SimplePopover } from './components/popovers/simple-popover'
 
 // Search
 export { SearchInput } from './components/search/search-input'

--- a/src/components/cards/crowdfunding-card/components/title.js
+++ b/src/components/cards/crowdfunding-card/components/title.js
@@ -157,8 +157,8 @@ TitleComponent.propTypes = {
   titleTruncate: _propTypes.default.bool,
   loading: _propTypes.default.bool,
   widgetTitle: _propTypes.default.string,
-  dayCounter: _propTypes.default.string,
-  stateDay: _propTypes.default.element,
+  dayCounter: _propTypes.default.element,
+  stateDay: _propTypes.default.string,
   titleProps: _propTypes.default.shape()
 };
 TitleComponent.defaultProps = {
@@ -166,7 +166,7 @@ TitleComponent.defaultProps = {
   titleTruncate: true,
   loading: false,
   widgetTitle: '',
-  dayCounter: '',
+  dayCounter: null,
   stateDay: '',
   titleProps: {}
 };


### PR DESCRIPTION
Closes #.

All the open/close mechanics are left for the parent component.
Most of the styling code has been done by @camilledel, thanks 🎉

Screenshot:

![image](https://user-images.githubusercontent.com/1781070/68472216-46e76400-0220-11ea-802a-d95c2edf6e81.png)

TODO:

- [X] Tests
- [x] Changelog
- [X] A11Y
- [X] Stories
- [ ] BrowserStack
