### PR TITLE
[Progress] Allow `value` to be a `string`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Allow `Progress` prop `value` to be a `string`.
+
 ## [2.41.2] - 2019-11-26
 
 Fix:

--- a/assets/javascripts/kitten/components/meters/progress/index.js
+++ b/assets/javascripts/kitten/components/meters/progress/index.js
@@ -42,10 +42,11 @@ export const Progress = ({ color, value, rampProps, ...others }) => {
 
   useEffect(() => {
     let progress = 0
+    let valueAsNumber = parseInt(value, 10)
 
-    if (value < valueMin) progress = valueMin
-    else if (value > valueMax) progress = valueMax
-    else progress = value
+    if (valueAsNumber < valueMin) progress = valueMin
+    else if (valueAsNumber > valueMax) progress = valueMax
+    else progress = valueAsNumber
 
     setProgressValue(progress)
   }, [value])
@@ -75,6 +76,6 @@ Progress.defaultProps = {
 
 Progress.propTypes = {
   color: PropTypes.string,
-  value: PropTypes.number,
+  value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   rampProps: PropTypes.object,
 }


### PR DESCRIPTION
Closes #.

Screenshot:


TODO:

- [x] Tests
- [x] Changelog
- [ ] A11Y
- [ ] Stories
- [ ] BrowserStack
