### PR TITLE
[Comments] Add id prop to comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
+
 - Feature: Make copy text message disapear after 3sec on `<TextCopy />`. 
+- Feature: Add `id` prop to `<Comment />`.
 - Fix: Update copy text message size of `<TextCopy />` to `micro`. 
 
 ## [2.50.0] - 2020-01-06

--- a/assets/javascripts/kitten/components/comments/comment/index.js
+++ b/assets/javascripts/kitten/components/comments/comment/index.js
@@ -109,7 +109,7 @@ export const Comment = ({
   bottomNotes,
   likeButtonProps,
   avatarBadge,
-  ...props
+  id,
 }) => {
   const likeButtonElement = useRef(null)
   const [likeButtonWidth, setLikeButtonWidth] = useState(0)
@@ -124,7 +124,7 @@ export const Comment = ({
   }, [])
 
   return (
-    <StyledGrid>
+    <StyledGrid id={id}>
       <CommentAvatar
         avatarImgProps={avatarImgProps}
         commentDate={commentDate}


### PR DESCRIPTION
Propage la prop `id` passée au composant `Comment` jusqu'au DOM. Lié à https://github.com/KissKissBankBank/kisskissbankbank/pull/8276