### PR TITLE
[Modal] Remove Margin on `Modal__close` button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Feature: Make copy text message disappear after 3sec on `<TextCopy />`.
 - Feature: Add `id` prop to `<Comment />`.
 - Fix: Update copy text message size of `<TextCopy />` to `micro`.
+- Fix: Remove Margin on `Modal__close` button on `Modal`.
 
 ## [2.50.0] - 2020-01-06
 

--- a/assets/javascripts/kitten/components/modals/modal/index.js
+++ b/assets/javascripts/kitten/components/modals/modal/index.js
@@ -39,6 +39,10 @@ const GlobalStyle = createGlobalStyle`
     position: absolute;
     top: 0;
     right: ${pxToRem(50)};
+
+    button {
+      margin: 0;
+    }
   }
 
   .k-Modal__close--fixed {

--- a/assets/stylesheets/kitten/components/modals/modal.scss
+++ b/assets/stylesheets/kitten/components/modals/modal.scss
@@ -50,6 +50,10 @@
     position: absolute;
     top: 0;
     right: k-px-to-rem(50px);
+
+    button {
+      margin: 0;
+    }
   }
 
   .k-Modal__close--fixed {


### PR DESCRIPTION
Closes #.

Screenshot:


TODO:

- [ ] Tests
- [x] Changelog
- [ ] A11Y
- [ ] Stories
- [ ] BrowserStack
