### PR TITLE
[Carousel] Expose `goToPage` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Feature: Expose `goToPage` method in `Carousel`.
+
 ## [2.58.0] - 2020-03-11
 
 Feature:

--- a/assets/javascripts/kitten/components/carousel/carousel/carousel.js
+++ b/assets/javascripts/kitten/components/carousel/carousel/carousel.js
@@ -454,4 +454,5 @@ const PageDot = styled.div`
 export const Carousel = withMediaQueries({
   viewportIsXSOrLess: true,
   viewportIsMOrLess: true,
+  exposedMethods: ['goToPage'],
 })(CarouselBase)


### PR DESCRIPTION
## Ce qui a été fait

- Expose la méthode `goToPage` qui permet de se rendre sur n'importe quelle page en dehors du composant