### PR TITLE
Next Modal

### DIFF
--- a/.storybook/decorators/grid.js
+++ b/.storybook/decorators/grid.js
@@ -1,11 +1,11 @@
-import React, { Fragment } from 'react'
-import { DevGrid } from 'kitten/components/dev/dev-grid'
+import React from 'react'
+import { DevGrid } from '../../assets/javascripts/kitten/components/dev/dev-grid'
 
-const GridDecorator = (storyFn) => (
-  <Fragment>
-    { storyFn() }
+const GridDecorator = storyFn => (
+  <>
+    {storyFn()}
     <DevGrid />
-  </Fragment>
+  </>
 )
 
 export default GridDecorator

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -14,7 +14,6 @@ module.exports = {
       options: {
         configureJSX: true,
         babelOptions: {},
-        sourceLoaderOptions: null,
       },
     },
   ],

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,5 +1,3 @@
-const createCompiler = require('@storybook/addon-docs/mdx-compiler-plugin')
-
 module.exports = {
   stories: [
     '../assets/javascripts/kitten/**/stories.(js|mdx)',
@@ -11,26 +9,13 @@ module.exports = {
     '@storybook/addon-actions/register',
     '@storybook/addon-a11y/register',
     '@storybook/addon-viewport/register',
-    '@storybook/addon-docs/register',
+    {
+      name: '@storybook/addon-docs',
+      options: {
+        configureJSX: true,
+        babelOptions: {},
+        sourceLoaderOptions: null,
+      },
+    },
   ],
-  webpackFinal: async config => {
-    config.module.rules.push({
-      test: /stories.mdx$/,
-      use: [
-        {
-          loader: 'babel-loader',
-          options: {
-            plugins: ['@babel/plugin-transform-react-jsx'],
-          },
-        },
-        {
-          loader: '@mdx-js/loader',
-          options: {
-            compilers: [createCompiler({})],
-          },
-        },
-      ],
-    })
-    return config
-  },
 }

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -21,12 +21,14 @@ module.exports = {
     rules: [
       {
         test: /\.(svg|png|jpe?g)$/,
-        use: [{
-          loader: 'file-loader',
-          options: {
-            name: 'images/[name].[ext]',
+        use: [
+          {
+            loader: 'file-loader',
+            options: {
+              name: 'images/[name].[ext]',
+            },
           },
-        }],
+        ],
       },
       {
         test: /\.css$/,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [unreleased]
 
 - Fix: Remove `calc` on `ProgressRing`.
+- Add: New `<Modal />` component imported from `import { Modal } from '@kisskissbankbank/kitten/next`, (see usage on our Storybook, section named `NEXT`).
 
 ## [2.66.1] - 2020-04-27
 

--- a/assets/javascripts/kitten/components/modals/next/Modal.stories.js
+++ b/assets/javascripts/kitten/components/modals/next/Modal.stories.js
@@ -42,6 +42,7 @@ export default {
     Paragraph: Modal.Paragraph,
     Actions: Modal.Actions,
     Button: Modal.Button,
+    CloseButton: Modal.CloseButton,
   },
 }
 

--- a/assets/javascripts/kitten/components/modals/next/Modal.stories.js
+++ b/assets/javascripts/kitten/components/modals/next/Modal.stories.js
@@ -52,11 +52,15 @@ export const OneButton = () => (
     big={boolean('Big size', false)}
     huge={boolean('Huge size', false)}
   >
-    <Modal.Title>Lorem ipsum dolor sit consectetuer</Modal.Title>
-    <Modal.Paragraph>{text('content', paragraphContainer)}</Modal.Paragraph>
-    <Modal.Actions>
-      <Modal.Button modifier="helium">Action 1 Button</Modal.Button>
-    </Modal.Actions>
+    {() => (
+      <>
+        <Modal.Title>Lorem ipsum dolor sit consectetuer</Modal.Title>
+        <Modal.Paragraph>{text('content', paragraphContainer)}</Modal.Paragraph>
+        <Modal.Actions>
+          <Modal.Button modifier="helium">Action 1 Button</Modal.Button>
+        </Modal.Actions>
+      </>
+    )}
   </Modal>
 )
 
@@ -67,12 +71,16 @@ export const TwoButton = () => (
     big={boolean('Big size', true)}
     huge={boolean('Huge size', false)}
   >
-    <Modal.Title>Lorem ipsum dolor sit consectetuer</Modal.Title>
-    <Modal.Paragraph>{text('content', paragraphContainer)}</Modal.Paragraph>
-    <Modal.Actions>
-      <Modal.Button modifier="helium">Action 1 Button</Modal.Button>
-      <Modal.Button modifier="oxygen">Action 2 Button</Modal.Button>
-    </Modal.Actions>
+    {() => (
+      <>
+        <Modal.Title>Lorem ipsum dolor sit consectetuer</Modal.Title>
+        <Modal.Paragraph>{text('content', paragraphContainer)}</Modal.Paragraph>
+        <Modal.Actions>
+          <Modal.Button modifier="helium">Action 1 Button</Modal.Button>
+          <Modal.Button modifier="oxygen">Action 2 Button</Modal.Button>
+        </Modal.Actions>
+      </>
+    )}
   </Modal>
 )
 
@@ -90,11 +98,17 @@ export const WithState = () => {
         huge={boolean('Huge size', false)}
         onClose={() => updateModalState(false)}
       >
-        <Modal.Title>Lorem ipsum dolor sit consectetuer</Modal.Title>
-        <Modal.Paragraph>{text('content', paragraphContainer)}</Modal.Paragraph>
-        <Modal.Actions>
-          <Modal.Button modifier="helium">Action 1 Button</Modal.Button>
-        </Modal.Actions>
+        {() => (
+          <>
+            <Modal.Title>Lorem ipsum dolor sit consectetuer</Modal.Title>
+            <Modal.Paragraph>
+              {text('content', paragraphContainer)}
+            </Modal.Paragraph>
+            <Modal.Actions>
+              <Modal.Button modifier="helium">Action 1 Button</Modal.Button>
+            </Modal.Actions>
+          </>
+        )}
       </Modal>
     </>
   )
@@ -104,10 +118,10 @@ export const Multi = () => {
   return (
     <>
       <Modal trigger={<Button modifier="helium">Open 1</Button>}>
-        <Modal.Title>Modal 1</Modal.Title>
+        {() => <Modal.Title>Modal 1</Modal.Title>}
       </Modal>
       <Modal trigger={<Button modifier="helium">Open 2</Button>}>
-        <Modal.Title>Modal 2</Modal.Title>
+        {() => <Modal.Title>Modal 2</Modal.Title>}
       </Modal>
     </>
   )

--- a/assets/javascripts/kitten/components/modals/next/Modal.stories.js
+++ b/assets/javascripts/kitten/components/modals/next/Modal.stories.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { withKnobs, text, boolean } from '@storybook/addon-knobs'
 import { Modal } from './index'
 import { Button } from '../../../components/buttons/button/button'
@@ -37,6 +37,12 @@ export default {
   title: 'NEXT/Modal',
   decorators: [withKnobs],
   component: Modal,
+  subcomponents: {
+    Title: Modal.Title,
+    Paragraph: Modal.Paragraph,
+    Actions: Modal.Actions,
+    Button: Modal.Button,
+  },
 }
 
 export const OneButton = () => (
@@ -70,16 +76,39 @@ export const TwoButton = () => (
   </Modal>
 )
 
-export const LaunchOnMount = () => (
-  <Modal
-    hasCloseButton={boolean('Has close button', true)}
-    big={boolean('Big size', false)}
-    huge={boolean('Huge size', false)}
-  >
-    <Modal.Title>Lorem ipsum dolor sit consectetuer</Modal.Title>
-    <Modal.Paragraph>{text('content', paragraphContainer)}</Modal.Paragraph>
-    <Modal.Actions>
-      <Modal.Button modifier="helium">Action 1 Button</Modal.Button>
-    </Modal.Actions>
-  </Modal>
-)
+export const WithState = () => {
+  const [showModal, updateModalState] = useState(false)
+  return (
+    <>
+      <Button modifier="helium" onClick={() => updateModalState(!showModal)}>
+        Open
+      </Button>
+      <Modal
+        isOpen={showModal}
+        hasCloseButton={boolean('Has close button', true)}
+        big={boolean('Big size', false)}
+        huge={boolean('Huge size', false)}
+        onClose={() => updateModalState(false)}
+      >
+        <Modal.Title>Lorem ipsum dolor sit consectetuer</Modal.Title>
+        <Modal.Paragraph>{text('content', paragraphContainer)}</Modal.Paragraph>
+        <Modal.Actions>
+          <Modal.Button modifier="helium">Action 1 Button</Modal.Button>
+        </Modal.Actions>
+      </Modal>
+    </>
+  )
+}
+
+export const Multi = () => {
+  return (
+    <>
+      <Modal trigger={<Button modifier="helium">Open 1</Button>}>
+        <Modal.Title>Modal 1</Modal.Title>
+      </Modal>
+      <Modal trigger={<Button modifier="helium">Open 2</Button>}>
+        <Modal.Title>Modal 2</Modal.Title>
+      </Modal>
+    </>
+  )
+}

--- a/assets/javascripts/kitten/components/modals/next/Modal.stories.js
+++ b/assets/javascripts/kitten/components/modals/next/Modal.stories.js
@@ -114,6 +114,21 @@ export const WithState = () => {
   )
 }
 
+export const WithCloseButton = () => {
+  return (
+    <Modal trigger={<Button modifier="helium">Open</Button>}>
+      {() => (
+        <>
+          <Modal.Title>Modal</Modal.Title>
+          <Modal.Actions>
+            <Modal.CloseButton>Close it !</Modal.CloseButton>
+          </Modal.Actions>
+        </>
+      )}
+    </Modal>
+  )
+}
+
 export const Multi = () => {
   return (
     <>

--- a/assets/javascripts/kitten/components/modals/next/Modal.stories.js
+++ b/assets/javascripts/kitten/components/modals/next/Modal.stories.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { withKnobs, text, boolean } from '@storybook/addon-knobs'
+import { withKnobs, text, boolean, number } from '@storybook/addon-knobs'
 import { Modal } from './index'
 import { Button } from '../../../components/buttons/button/button'
 
@@ -51,6 +51,7 @@ export const OneButton = () => (
     hasCloseButton={boolean('Has close button', true)}
     big={boolean('Big size', false)}
     huge={boolean('Huge size', false)}
+    zIndex={number('Overlay z-index', 110)}
   >
     {() => (
       <>

--- a/assets/javascripts/kitten/components/modals/next/index.js
+++ b/assets/javascripts/kitten/components/modals/next/index.js
@@ -38,6 +38,7 @@ const GlobalStyle = createGlobalStyle`
     position: relative;
     background-color: ${COLORS.background1};
     box-sizing: border-box;
+    outline: none;
     margin: ${pxToRem(50)} ${pxToRem(20)};
     padding: ${pxToRem(50)} ${pxToRem(30)};
     width: calc(100vw ${pxToRem(20)});
@@ -135,16 +136,25 @@ const ModalTitle = ({ children }) => (
   </Title>
 )
 
-const ModalParagraph = ({ children }) => (
+const ModalParagraph = ({ children, align }) => (
   <StyledParagraph
     modifier="quaternary"
     margin={false}
+    style={{ textAlign: align }}
     tag="p"
     className="k-u-margin-bottom-triple k-u-margin-bottom-quadruple@s-up"
   >
     {children}
   </StyledParagraph>
 )
+
+ModalParagraph.propTypes = {
+  align: PropTypes.oneOf(['center', 'left', 'right', 'justify']),
+}
+
+ModalParagraph.defaultProps = {
+  align: 'center',
+}
 
 const Actions = styled.div`
   display: flex;

--- a/assets/javascripts/kitten/components/modals/next/index.js
+++ b/assets/javascripts/kitten/components/modals/next/index.js
@@ -230,6 +230,9 @@ export const Modal = ({
           beforeClose: 'k-Modal__overlay--beforeClose',
         }}
         isOpen={showModal}
+        onAfterOpen={({ overlayEl }) => {
+          overlayEl.scrollTop = 0
+        }}
         aria={{
           labelledby,
           describedby,

--- a/assets/javascripts/kitten/components/modals/next/index.js
+++ b/assets/javascripts/kitten/components/modals/next/index.js
@@ -172,7 +172,7 @@ const ModalButton = styled(props => <Button big fluid {...props} />)`
     :not(:last-child) {
       margin-bottom: 0;
     }
-    &:not(:first-child) {
+    :not(:first-child) {
       margin-left: ${pxToRem(GUTTER)};
     }
   }

--- a/assets/javascripts/kitten/components/modals/next/index.js
+++ b/assets/javascripts/kitten/components/modals/next/index.js
@@ -182,6 +182,7 @@ export const Modal = ({
   maxWidth,
   big,
   huge,
+  isOpen,
   ...others
 }) => {
   const [showModal, setShowModal] = useState(false)
@@ -197,6 +198,11 @@ export const Modal = ({
       setShowModal(true)
     }
   }, [])
+
+  useEffect(() => {
+    setShowModal(isOpen)
+  }, [isOpen])
+
   const ModalPortal = ReactDOM.createPortal(
     <>
       <GlobalStyle cols={colsOnDesktop} />
@@ -265,8 +271,9 @@ Modal.propTypes = {
   closeButtonLabel: PropTypes.string,
   modalProps: PropTypes.object,
   hasCloseButton: PropTypes.bool,
-  big: PropTypes.boolean,
-  huge: PropTypes.boolean,
+  big: PropTypes.bool,
+  huge: PropTypes.bool,
+  isOpen: PropTypes.bool,
 }
 
 Modal.defaultProps = {
@@ -278,6 +285,7 @@ Modal.defaultProps = {
   hasCloseButton: true,
   big: false,
   huge: false,
+  isOpen: false,
 }
 
 Modal.Title = ModalTitle

--- a/assets/javascripts/kitten/components/modals/next/index.js
+++ b/assets/javascripts/kitten/components/modals/next/index.js
@@ -78,7 +78,7 @@ const GlobalStyle = createGlobalStyle`
     top: 0;
     right: ${pxToRem(40)};
     @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
-     right: ${pxToRem(50)};
+      right: ${pxToRem(50)};
   }
 
     button {
@@ -243,7 +243,10 @@ export const Modal = ({
         {...modalProps}
       >
         <>
-          {children}
+          {children({
+            open: () => setShowModal(true),
+            close: () => setShowModal(false),
+          })}
           {hasCloseButton && (
             <div className="k-ModalNext__close">
               <CloseButton

--- a/assets/javascripts/kitten/components/modals/next/index.js
+++ b/assets/javascripts/kitten/components/modals/next/index.js
@@ -30,11 +30,11 @@ const StyledParagraph = styled(Paragraph)`
 `
 
 const GlobalStyle = createGlobalStyle`
-  body.k-Modal__body--open {
+  body.k-ModalNext__body--open {
     overflow: hidden;
   }
   
-  .k-Modal-content {
+  .k-ModalNext-content {
     position: relative;
     background-color: ${COLORS.background1};
     box-sizing: border-box;
@@ -73,7 +73,7 @@ const GlobalStyle = createGlobalStyle`
     }
   }
 
-  .k-Modal__close {
+  .k-ModalNext__close {
     position: absolute;
     top: 0;
     right: ${pxToRem(40)};
@@ -86,11 +86,11 @@ const GlobalStyle = createGlobalStyle`
     }
   }
   
-  .k-Modal-content {
+  .k-ModalNext-content {
     transform: scale(0.94);
   }
 
-  .k-Modal__overlay {
+  .k-ModalNext__overlay {
     position: fixed;
     z-index: 110;
     overflow: scroll;
@@ -105,20 +105,20 @@ const GlobalStyle = createGlobalStyle`
     background-color: rgba(34, 34, 34, .8);
   }
   
-  .k-Modal__overlay--afterOpen {
+  .k-ModalNext__overlay--afterOpen {
     transition: opacity .3s ease;
     opacity: 1;
   }
-  .k-Modal--afterOpen {
+  .k-ModalNext--afterOpen {
     transition: opacity .3s ease, transform .3s ease;
     transform: scale(1);
     opacity: 1;
   }
 
-  .k-Modal__overlay--beforeClose {
+  .k-ModalNext__overlay--beforeClose {
     opacity: 0;
   }
-  .k-Modal--beforeClose {
+  .k-ModalNext--beforeClose {
     transition: opacity .3s ease, transform .5s ease;
     transform: scale(1.06);
     opacity: 0;
@@ -165,13 +165,12 @@ const Actions = styled.div`
 `
 
 const ModalButton = styled(props => <Button big fluid {...props} />)`
-  :not(:last-child) {
-    margin-bottom: ${pxToRem(20)};
+  @media (max-width: ${pxToRem(ScreenConfig.XS.max)}) {
+    :not(:last-child) {
+      margin-bottom: ${pxToRem(20)};
+    }
   }
   @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
-    :not(:last-child) {
-      margin-bottom: 0;
-    }
     :not(:first-child) {
       margin-left: ${pxToRem(GUTTER)};
     }
@@ -220,14 +219,14 @@ export const Modal = ({
         closeTimeoutMS={500}
         role="dialog"
         className={{
-          base: 'k-Modal-content',
-          afterOpen: 'k-Modal--afterOpen',
-          beforeClose: 'k-Modal--beforeClose',
+          base: 'k-ModalNext-content',
+          afterOpen: 'k-ModalNext--afterOpen',
+          beforeClose: 'k-ModalNext--beforeClose',
         }}
         overlayClassName={{
-          base: 'k-Modal__overlay',
-          afterOpen: 'k-Modal__overlay--afterOpen',
-          beforeClose: 'k-Modal__overlay--beforeClose',
+          base: 'k-ModalNext__overlay',
+          afterOpen: 'k-ModalNext__overlay--afterOpen',
+          beforeClose: 'k-ModalNext__overlay--beforeClose',
         }}
         isOpen={showModal}
         onAfterOpen={({ overlayEl }) => {
@@ -240,13 +239,13 @@ export const Modal = ({
         ariaHideApp={false}
         onRequestClose={close}
         contentLabel={label}
-        bodyOpenClassName="k-Modal__body--open"
+        bodyOpenClassName="k-ModalNext__body--open"
         {...modalProps}
       >
         <>
           {children}
           {hasCloseButton && (
-            <div className="k-Modal__close">
+            <div className="k-ModalNext__close">
               <CloseButton
                 style={{ position: 'fixed' }}
                 className="k-u-hidden@s-up"

--- a/assets/javascripts/kitten/components/modals/next/index.js
+++ b/assets/javascripts/kitten/components/modals/next/index.js
@@ -330,7 +330,7 @@ const InnerModal = ({
     document.body,
   )
   return (
-    <div className={classNames('k-Modal', className)} {...others}>
+    <div className={classNames('k-ModalNext', className)} {...others}>
       {trigger && (
         <span onClick={() => dispatch(updateState(true))}>{trigger}</span>
       )}

--- a/assets/javascripts/kitten/components/modals/next/index.js
+++ b/assets/javascripts/kitten/components/modals/next/index.js
@@ -90,7 +90,6 @@ const GlobalStyle = createGlobalStyle`
   
   .k-ModalNext__overlay {
     position: fixed;
-    z-index: 110;
     overflow: scroll;
     display: flex;
     flex-direction: column;
@@ -110,6 +109,10 @@ const GlobalStyle = createGlobalStyle`
         min-height: ${pxToRem(100)};
       }
     }
+    ${props =>
+      css`
+        z-index: ${props.zIndex};
+      `}
   }
   
   .k-ModalNext__overlay--afterOpen {
@@ -246,6 +249,7 @@ const InnerModal = ({
   big,
   huge,
   isOpen,
+  zIndex,
   ...others
 }) => {
   const [{ show }, dispatch] = useContext(ModalContext)
@@ -268,7 +272,7 @@ const InnerModal = ({
 
   const ModalPortal = ReactDOM.createPortal(
     <>
-      <GlobalStyle cols={colsOnDesktop} />
+      <GlobalStyle cols={colsOnDesktop} zIndex={zIndex} />
       <ReactModal
         closeTimeoutMS={500}
         role="dialog"
@@ -353,6 +357,7 @@ Modal.propTypes = {
   big: PropTypes.bool,
   huge: PropTypes.bool,
   isOpen: PropTypes.bool,
+  zIndex: PropTypes.number,
 }
 
 Modal.defaultProps = {
@@ -365,6 +370,7 @@ Modal.defaultProps = {
   big: false,
   huge: false,
   isOpen: false,
+  zIndex: 110,
 }
 
 Modal.Title = ModalTitle

--- a/assets/javascripts/kitten/components/modals/next/index.js
+++ b/assets/javascripts/kitten/components/modals/next/index.js
@@ -1,0 +1,298 @@
+import React, { useState, useEffect } from 'react'
+import ReactDOM from 'react-dom'
+import PropTypes from 'prop-types'
+import classNames from 'classnames'
+import ReactModal from 'react-modal'
+import { CloseButton } from '../../../components/buttons/close-button'
+import { Button } from '../../../components/buttons/button/button'
+import { Paragraph } from '../../../components/typography/paragraph'
+import { Grid, GridCol } from '../../../components/grid/grid'
+import { Container } from '../../../components/grid/container'
+import styled, { createGlobalStyle } from 'styled-components'
+import { pxToRem } from '../../../helpers/utils/typography'
+import { ScreenConfig } from '../../../constants/screen-config'
+import { Title } from '../../typography/title'
+import COLORS from '../../../constants/colors-config'
+import {
+  CONTAINER_PADDING,
+  GUTTER,
+  CONTAINER_MAX_WIDTH,
+} from '../../../constants/grid-config'
+
+const paddingPlusGutters = 2 * CONTAINER_PADDING + 11 * GUTTER
+const oneGridCol = `calc((100vw - ${pxToRem(
+  paddingPlusGutters,
+)}) / 12 + ${pxToRem(GUTTER)})`
+const oneGridColXl = `${pxToRem(
+  (CONTAINER_MAX_WIDTH - paddingPlusGutters) / 12 + GUTTER,
+)}`
+
+const ModalLayout = styled.div`
+  position: relative;
+  background-color: ${COLORS.background1};
+  box-sizing: border-box;
+  margin: ${pxToRem(50)} ${pxToRem(20)};
+  padding: ${pxToRem(50)} ${pxToRem(30)};
+
+  @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
+    margin: ${pxToRem(100)} auto;
+    padding: ${pxToRem(80)} ${oneGridCol};
+  }
+
+  @media (min-width: ${pxToRem(ScreenConfig.XL.min)}) {
+    margin: ${pxToRem(100)} auto;
+    padding: ${pxToRem(80)} ${oneGridColXl};
+  }
+`
+
+const StyledParagraph = styled(Paragraph)`
+  font-size: ${pxToRem(12)};
+  @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
+    font-size: ${pxToRem(14)};
+  }
+`
+
+const GlobalStyle = createGlobalStyle`
+  body.k-Modal__body--open {
+    overflow: hidden;
+  }
+
+  .k-Modal__close {
+    position: absolute;
+    top: 0;
+    right: ${pxToRem(40)};
+    @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
+     right: ${pxToRem(50)};
+  }
+
+    button {
+      margin: 0;
+    }
+  }
+  
+  .k-Modal-content {
+    transform: scale(0.94);
+  }
+
+  .k-Modal__overlay {
+    position: fixed;
+    z-index: 110;
+    overflow: scroll;
+    display: block;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    opacity: 0;
+    justify-content: center;
+    align-items: center;
+    background-color: rgba(34, 34, 34, .8);
+  }
+  
+  .k-Modal__overlay--afterOpen {
+    transition: opacity .3s ease;
+    opacity: 1;
+  }
+  .k-Modal--afterOpen {
+    transition: opacity .3s ease, transform .3s ease;
+    transform: scale(1);
+    opacity: 1;
+  }
+
+  .k-Modal__overlay--beforeClose {
+    opacity: 0;
+  }
+  .k-Modal--beforeClose {
+    transition: opacity .3s ease, transform .5s ease;
+    transform: scale(1.06);
+    opacity: 0;
+  }
+`
+
+const ModalTitle = ({ children }) => (
+  <Title
+    modifier="quaternary"
+    margin={false}
+    tag="p"
+    className="k-u-margin-bottom-singleHalf--important k-u-align-center"
+  >
+    {children}
+  </Title>
+)
+
+const ModalParagraph = ({ children }) => (
+  <StyledParagraph
+    modifier="quaternary"
+    margin={false}
+    tag="p"
+    className="k-u-margin-bottom-triple k-u-margin-bottom-quadruple@s-up"
+  >
+    {children}
+  </StyledParagraph>
+)
+
+const Actions = styled.div`
+  display: flex;
+  flex-direction: column;
+  @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
+    flex-direction: row;
+  }
+`
+
+const ModalButton = styled(props => <Button big fluid {...props} />)`
+  :not(:last-child) {
+    margin-bottom: ${pxToRem(20)};
+  }
+  @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
+    :not(:last-child) {
+      margin-bottom: 0;
+    }
+    &:not(:first-child) {
+      margin-left: ${pxToRem(GUTTER)};
+    }
+  }
+`
+
+export const Modal = ({
+  trigger,
+  children,
+  label,
+  labelledby,
+  describedby,
+  className,
+  closeButtonLabel,
+  onClose,
+  modalProps,
+  hasCloseButton,
+  maxWidth,
+  big,
+  huge,
+  ...others
+}) => {
+  const [showModal, setShowModal] = useState(false)
+  const colsOnDesktop = huge ? 10 : big ? 8 : 6
+  const offsetOnDesktop = huge ? 1 : big ? 2 : 3
+  const close = () => {
+    setShowModal(false)
+    if (onClose) {
+      onClose()
+    }
+  }
+  useEffect(() => {
+    if (!trigger) {
+      setShowModal(true)
+    }
+  }, [])
+  const Layout = (
+    <ModalLayout>
+      {children}
+      {hasCloseButton && (
+        <div className="k-Modal__close">
+          <CloseButton
+            style={{ position: 'fixed' }}
+            className="k-u-hidden@s-up"
+            modifier="beryllium"
+            onClick={close}
+            size="tiny"
+            closeButtonLabel={closeButtonLabel}
+          />
+          <CloseButton
+            style={{ position: 'fixed' }}
+            className="k-u-hidden@xs-down"
+            modifier="beryllium"
+            onClick={close}
+            closeButtonLabel={closeButtonLabel}
+          />
+        </div>
+      )}
+    </ModalLayout>
+  )
+  const ModalPortal = ReactDOM.createPortal(
+    <div
+      id="modal-overlay"
+      onClick={e => {
+        if (
+          e.target.dataset.overlay ||
+          (e.target.className.indexOf &&
+            e.target.className.indexOf('k-Modal-content') !== -1)
+        ) {
+          close()
+        }
+      }}
+    >
+      <GlobalStyle />
+      <ReactModal
+        closeTimeoutMS={500}
+        role="dialog"
+        className={{
+          base: 'k-Modal-content',
+          afterOpen: 'k-Modal--afterOpen',
+          beforeClose: 'k-Modal--beforeClose',
+        }}
+        overlayClassName={{
+          base: 'k-Modal__overlay',
+          afterOpen: 'k-Modal__overlay--afterOpen',
+          beforeClose: 'k-Modal__overlay--beforeClose',
+        }}
+        isOpen={showModal}
+        aria={{
+          labelledby,
+          describedby,
+        }}
+        ariaHideApp={false}
+        onRequestClose={close}
+        contentLabel={label}
+        bodyOpenClassName="k-Modal__body--open"
+        {...modalProps}
+      >
+        <Container fullWidthBelowScreenSize="XS" data-overlay="container">
+          <Grid className="k-u-hidden@xs-down" data-overlay="grid">
+            <GridCol
+              col={12}
+              col-l={colsOnDesktop}
+              offset-l={offsetOnDesktop}
+              data-overlay="grid-col"
+            >
+              {Layout}
+            </GridCol>
+          </Grid>
+          <div className="k-u-hidden@s-up">{Layout}</div>
+        </Container>
+      </ReactModal>
+    </div>,
+    document.body,
+  )
+  return (
+    <div className={classNames('k-Modal', className)} {...others}>
+      {trigger && <span onClick={() => setShowModal(true)}>{trigger}</span>}
+      {ModalPortal}
+    </div>
+  )
+}
+
+Modal.propTypes = {
+  label: PropTypes.string,
+  labelledby: PropTypes.string,
+  describedby: PropTypes.string,
+  closeButtonLabel: PropTypes.string,
+  modalProps: PropTypes.object,
+  hasCloseButton: PropTypes.bool,
+  big: PropTypes.boolean,
+  huge: PropTypes.boolean,
+}
+
+Modal.defaultProps = {
+  label: 'Modal',
+  labelledby: '',
+  describedby: '',
+  closeButtonLabel: 'Fermer',
+  modalProps: {},
+  hasCloseButton: true,
+  big: false,
+  huge: false,
+}
+
+Modal.Title = ModalTitle
+Modal.Paragraph = ModalParagraph
+Modal.Actions = Actions
+Modal.Button = ModalButton

--- a/assets/javascripts/kitten/components/modals/next/index.js
+++ b/assets/javascripts/kitten/components/modals/next/index.js
@@ -30,21 +30,24 @@ const StyledParagraph = styled(Paragraph)`
 `
 
 const GlobalStyle = createGlobalStyle`
+
   body.k-ModalNext__body--open {
     overflow: hidden;
   }
   
-  .k-ModalNext-content {
+  .k-ModalNext__content {
     position: relative;
     background-color: ${COLORS.background1};
     box-sizing: border-box;
     outline: none;
-    margin: ${pxToRem(50)} ${pxToRem(20)};
+    transform: scale(0.94);
+    margin-right: ${pxToRem(20)};
+    margin-left: ${pxToRem(20)};
     padding: ${pxToRem(50)} ${pxToRem(30)};
     width: calc(100vw ${pxToRem(20)});
   
     @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
-      margin: ${pxToRem(100)} auto;
+      margin: auto;
       padding: ${pxToRem(80)} ${oneGridCol};
       width: calc((100vw - ${pxToRem(paddingPlusGutters)}) + (${pxToRem(
   GUTTER,
@@ -52,7 +55,6 @@ const GlobalStyle = createGlobalStyle`
     }
   
     @media (min-width: ${pxToRem(ScreenConfig.L.min)}) {
-      margin: ${pxToRem(100)} auto;
       padding: ${pxToRem(80)} ${oneGridCol};
       ${props => css`
         width: calc(
@@ -86,23 +88,28 @@ const GlobalStyle = createGlobalStyle`
     }
   }
   
-  .k-ModalNext-content {
-    transform: scale(0.94);
-  }
-
   .k-ModalNext__overlay {
     position: fixed;
     z-index: 110;
     overflow: scroll;
-    display: block;
+    display: flex;
+    flex-direction: column;
     top: 0;
     left: 0;
     right: 0;
     bottom: 0;
     opacity: 0;
-    justify-content: center;
-    align-items: center;
-    background-color: rgba(34, 34, 34, .8);
+    background-color: rgba(34, 34, 34, .8);    
+    &::before ,
+    &::after {
+      content:'';
+      flex:1;
+      min-height: ${pxToRem(50)};
+
+      @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
+        min-height: ${pxToRem(100)};
+      }
+    }
   }
   
   .k-ModalNext__overlay--afterOpen {
@@ -219,7 +226,7 @@ export const Modal = ({
         closeTimeoutMS={500}
         role="dialog"
         className={{
-          base: 'k-ModalNext-content',
+          base: 'k-ModalNext__content',
           afterOpen: 'k-ModalNext--afterOpen',
           beforeClose: 'k-ModalNext--beforeClose',
         }}

--- a/assets/javascripts/kitten/components/modals/next/index.js
+++ b/assets/javascripts/kitten/components/modals/next/index.js
@@ -6,9 +6,7 @@ import ReactModal from 'react-modal'
 import { CloseButton } from '../../../components/buttons/close-button'
 import { Button } from '../../../components/buttons/button/button'
 import { Paragraph } from '../../../components/typography/paragraph'
-import { Grid, GridCol } from '../../../components/grid/grid'
-import { Container } from '../../../components/grid/container'
-import styled, { createGlobalStyle } from 'styled-components'
+import styled, { createGlobalStyle, css } from 'styled-components'
 import { pxToRem } from '../../../helpers/utils/typography'
 import { ScreenConfig } from '../../../constants/screen-config'
 import { Title } from '../../typography/title'
@@ -23,27 +21,6 @@ const paddingPlusGutters = 2 * CONTAINER_PADDING + 11 * GUTTER
 const oneGridCol = `calc((100vw - ${pxToRem(
   paddingPlusGutters,
 )}) / 12 + ${pxToRem(GUTTER)})`
-const oneGridColXl = `${pxToRem(
-  (CONTAINER_MAX_WIDTH - paddingPlusGutters) / 12 + GUTTER,
-)}`
-
-const ModalLayout = styled.div`
-  position: relative;
-  background-color: ${COLORS.background1};
-  box-sizing: border-box;
-  margin: ${pxToRem(50)} ${pxToRem(20)};
-  padding: ${pxToRem(50)} ${pxToRem(30)};
-
-  @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
-    margin: ${pxToRem(100)} auto;
-    padding: ${pxToRem(80)} ${oneGridCol};
-  }
-
-  @media (min-width: ${pxToRem(ScreenConfig.XL.min)}) {
-    margin: ${pxToRem(100)} auto;
-    padding: ${pxToRem(80)} ${oneGridColXl};
-  }
-`
 
 const StyledParagraph = styled(Paragraph)`
   font-size: ${pxToRem(12)};
@@ -55,6 +32,44 @@ const StyledParagraph = styled(Paragraph)`
 const GlobalStyle = createGlobalStyle`
   body.k-Modal__body--open {
     overflow: hidden;
+  }
+  
+  .k-Modal-content {
+    position: relative;
+    background-color: ${COLORS.background1};
+    box-sizing: border-box;
+    margin: ${pxToRem(50)} ${pxToRem(20)};
+    padding: ${pxToRem(50)} ${pxToRem(30)};
+    width: calc(100vw ${pxToRem(20)});
+  
+    @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
+      margin: ${pxToRem(100)} auto;
+      padding: ${pxToRem(80)} ${oneGridCol};
+      width: calc((100vw - ${pxToRem(paddingPlusGutters)}) + (${pxToRem(
+  GUTTER,
+)} * 11))
+    }
+  
+    @media (min-width: ${pxToRem(ScreenConfig.L.min)}) {
+      margin: ${pxToRem(100)} auto;
+      padding: ${pxToRem(80)} ${oneGridCol};
+      ${props => css`
+        width: calc(
+          ((100vw - ${pxToRem(paddingPlusGutters)}) / 12 + ${pxToRem(GUTTER)}) *
+            ${props.cols} - ${pxToRem(GUTTER)}
+        );
+      `}
+    }
+    
+    @media (min-width: ${pxToRem(ScreenConfig.XL.min)}) {
+    ${props => css`
+      width: ${pxToRem(
+        ((CONTAINER_MAX_WIDTH - paddingPlusGutters) / 12 + GUTTER) *
+          props.cols -
+          GUTTER,
+      )};
+    `}
+    }
   }
 
   .k-Modal__close {
@@ -171,7 +186,6 @@ export const Modal = ({
 }) => {
   const [showModal, setShowModal] = useState(false)
   const colsOnDesktop = huge ? 10 : big ? 8 : 6
-  const offsetOnDesktop = huge ? 1 : big ? 2 : 3
   const close = () => {
     setShowModal(false)
     if (onClose) {
@@ -183,44 +197,9 @@ export const Modal = ({
       setShowModal(true)
     }
   }, [])
-  const Layout = (
-    <ModalLayout>
-      {children}
-      {hasCloseButton && (
-        <div className="k-Modal__close">
-          <CloseButton
-            style={{ position: 'fixed' }}
-            className="k-u-hidden@s-up"
-            modifier="beryllium"
-            onClick={close}
-            size="tiny"
-            closeButtonLabel={closeButtonLabel}
-          />
-          <CloseButton
-            style={{ position: 'fixed' }}
-            className="k-u-hidden@xs-down"
-            modifier="beryllium"
-            onClick={close}
-            closeButtonLabel={closeButtonLabel}
-          />
-        </div>
-      )}
-    </ModalLayout>
-  )
   const ModalPortal = ReactDOM.createPortal(
-    <div
-      id="modal-overlay"
-      onClick={e => {
-        if (
-          e.target.dataset.overlay ||
-          (e.target.className.indexOf &&
-            e.target.className.indexOf('k-Modal-content') !== -1)
-        ) {
-          close()
-        }
-      }}
-    >
-      <GlobalStyle />
+    <>
+      <GlobalStyle cols={colsOnDesktop} />
       <ReactModal
         closeTimeoutMS={500}
         role="dialog"
@@ -245,21 +224,30 @@ export const Modal = ({
         bodyOpenClassName="k-Modal__body--open"
         {...modalProps}
       >
-        <Container fullWidthBelowScreenSize="XS" data-overlay="container">
-          <Grid className="k-u-hidden@xs-down" data-overlay="grid">
-            <GridCol
-              col={12}
-              col-l={colsOnDesktop}
-              offset-l={offsetOnDesktop}
-              data-overlay="grid-col"
-            >
-              {Layout}
-            </GridCol>
-          </Grid>
-          <div className="k-u-hidden@s-up">{Layout}</div>
-        </Container>
+        <>
+          {children}
+          {hasCloseButton && (
+            <div className="k-Modal__close">
+              <CloseButton
+                style={{ position: 'fixed' }}
+                className="k-u-hidden@s-up"
+                modifier="beryllium"
+                onClick={close}
+                size="tiny"
+                closeButtonLabel={closeButtonLabel}
+              />
+              <CloseButton
+                style={{ position: 'fixed' }}
+                className="k-u-hidden@xs-down"
+                modifier="beryllium"
+                onClick={close}
+                closeButtonLabel={closeButtonLabel}
+              />
+            </div>
+          )}
+        </>
       </ReactModal>
-    </div>,
+    </>,
     document.body,
   )
   return (

--- a/assets/javascripts/kitten/components/modals/next/stories.js
+++ b/assets/javascripts/kitten/components/modals/next/stories.js
@@ -1,0 +1,85 @@
+import React from 'react'
+import { withKnobs, text, boolean } from '@storybook/addon-knobs'
+import { Modal } from './index'
+import { Button } from '../../../components/buttons/button/button'
+
+const paragraphContainer = `
+  Sed ut perspiciatis unde omnis iste natus error sit voluptatem
+  accusantium doloremque laudantium, totam rem aperiam, eaque ipsa
+  quae ab illo inventore veritatis et quasi architecto beatae vitae
+  dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit
+  aspernatur aut odit aut fugit, sed quia consequuntur magni dolores
+  eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est,
+  qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit,
+  sed quia non numquam eius modi tempora incidunt ut labore et dolore
+  magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis
+  nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut
+  aliquid ex ea commodi consequatur? Quis autem vel eum iure
+  reprehenderit qui in ea voluptate velit esse quam nihil molestiae
+  consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla
+  pariatur? Sed ut perspiciatis unde omnis iste natus error sit
+  voluptatem accusantium doloremque laudantium, totam rem aperiam,
+  eaque ipsa quae ab illo inventore veritatis et quasi architecto
+  beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia
+  voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur
+  magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro
+  quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur,
+  adipisci velit, sed quia non numquam eius modi tempora incidunt ut
+  labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad
+  minima veniam, quis nostrum exercitationem ullam corporis suscipit
+  laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem
+  vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil
+  molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas
+  nulla pariatur?
+`
+
+export default {
+  title: 'NEXT/Modal',
+  decorators: [withKnobs],
+  component: Modal,
+}
+
+export const OneButton = () => (
+  <Modal
+    trigger={<Button modifier="helium">Open</Button>}
+    hasCloseButton={boolean('Has close button', true)}
+    big={boolean('Big size', false)}
+    huge={boolean('Huge size', false)}
+  >
+    <Modal.Title>Lorem ipsum dolor sit consectetuer</Modal.Title>
+    <Modal.Paragraph>{text('content', paragraphContainer)}</Modal.Paragraph>
+    <Modal.Actions>
+      <Modal.Button modifier="helium">Action 1 Button</Modal.Button>
+    </Modal.Actions>
+  </Modal>
+)
+
+export const TwoButton = () => (
+  <Modal
+    trigger={<Button modifier="helium">Open</Button>}
+    hasCloseButton={boolean('Has close button', true)}
+    big={boolean('Big size', true)}
+    huge={boolean('Huge size', false)}
+  >
+    <Modal.Title>Lorem ipsum dolor sit consectetuer</Modal.Title>
+    <Modal.Paragraph>{text('content', paragraphContainer)}</Modal.Paragraph>
+    <Modal.Actions>
+      <Modal.Button modifier="helium">Action 1 Button</Modal.Button>
+      <Modal.Button modifier="oxygen">Action 2 Button</Modal.Button>
+    </Modal.Actions>
+  </Modal>
+)
+
+export const LaunchOnMount = () => (
+  <Modal
+    hasCloseButton={boolean('Has close button', true)}
+    big={boolean('Big size', false)}
+    huge={boolean('Huge size', false)}
+  >
+    <Modal.Title>Lorem ipsum dolor sit consectetuer</Modal.Title>
+    <Modal.Paragraph>{text('content', paragraphContainer)}</Modal.Paragraph>
+    <Modal.Actions>
+      <Modal.Button modifier="helium">Action 1 Button</Modal.Button>
+    </Modal.Actions>
+  </Modal>
+)

--- a/assets/javascripts/kitten/next/index.js
+++ b/assets/javascripts/kitten/next/index.js
@@ -1,3 +1,3 @@
 export { Modal } from '../components/modals/next'
-export { Button } from './components/buttons/button/button'
+export { Button } from '../components/buttons/button/button'
 export { Carousel } from '../components/carousel/carousel/carousel'

--- a/assets/javascripts/kitten/next/index.js
+++ b/assets/javascripts/kitten/next/index.js
@@ -1,0 +1,3 @@
+export { Modal } from '../components/modals/next'
+export { Button } from './components/buttons/button/button'
+export { Carousel } from '../components/carousel/carousel/carousel'

--- a/package-lock.json
+++ b/package-lock.json
@@ -21797,9 +21797,9 @@
       }
     },
     "react-modal": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.11.1.tgz",
-      "integrity": "sha512-8uN744Yq0X2lbfSLxsEEc2UV3RjSRb4yDVxRQ1aGzPo86QjNOwhQSukDb8U8kR+636TRTvfMren10fgOjAy9eA==",
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.11.2.tgz",
+      "integrity": "sha512-o8gvvCOFaG1T7W6JUvsYjRjMVToLZgLIsi5kdhFIQCtHxDkA47LznX62j+l6YQkpXDbvQegsDyxe/+JJsFQN7w==",
       "requires": {
         "exenv": "^1.2.0",
         "prop-types": "^15.5.10",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "react-dropzone": "3.13.1",
     "react-markdown": "2.5.1",
     "react-masonry-component": "6.2.1",
-    "react-modal": "3.11.1",
+    "react-modal": "3.11.2",
     "react-places-autocomplete": "5.4.3",
     "react-select": "1.0.0",
     "react-test-renderer": "16.8.6",


### PR DESCRIPTION
Création d'une "nouvelle" Popin répondant aux standards de la maquette 

https://app.abstract.com/projects/67e5bf40-6a62-11e9-ab92-01fc018ad3a7/branches/5dadd0c8-ffc2-4ba4-8a1c-a56ed3337c66/commits/e4842c2996f717c579575515361299fc489f335d/files/D681D1DD-7F19-4397-954C-78509DA47F6A/layers/DDABE5C6-17A7-4EF0-80F8-04BA9088FAC6

Avec une API restreinte qui laisse deux choix dans la gestion de celle-ci : 

Via un trigger.
Via la prop `isOpen`

J'ai l'impression que ça couvre tous les cas qu'on a.

J'ai mis la gestion du Portal directement dans la Modal. Du coup je ne peux pas faire de test facilement : https://github.com/facebook/react/issues/11565

La gestion du responsive est gérée en `grid`. Ça donne des calculs un peu exotiques. @joachimesque va se pencher sur des helpers.

J'ai fait un peu de modifs pour la gestion de la conf Storybook

Petit détails : Il faut nommer ses stories avec le nom du composant devant pour bien faire fonctionner la doc, notamment les snippets de code. 

<img width="1007" alt="Capture d’écran 2020-04-29 à 16 45 22" src="https://user-images.githubusercontent.com/804738/80609844-e1d73300-8a38-11ea-89fe-38b40fe934b3.png">
