### PR TITLE
[RewardCardTitle] Replace `Title` component by `TitleWithStroke` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Remplace by `Title` by `TitleWithStroke` on `RewardCardTitle`.
+
 ## [2.76.0] - 2020-07-01
 
 Feature:

--- a/assets/javascripts/kitten/components/cards/reward-card/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/cards/reward-card/__snapshots__/test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<RewardCard /> by default matches with snapshot 1`] = `
 <div
-  className="sc-bZQynM hLZFaM k-RewardCard"
+  className="sc-bZQynM ccPRax k-RewardCard"
 >
   <div
     className="k-RewardCard__cardRow"
@@ -10,21 +10,18 @@ exports[`<RewardCard /> by default matches with snapshot 1`] = `
     <div
       className="k-RewardCard__rowContent"
     >
-      <h6
-        className="k-u-color-font1 k-u-style-italic k-u-weight-bold k-RewardCard__title"
-      >
-        Custom title mount
-      </h6>
       <div
-        className="sc-bxivhb gmqSjE k-HorizontalStroke k-u-margin-bottom-triple k-HorizontalStroke--size--default"
-        color={null}
-        style={
-          Object {
-            "height": null,
-            "width": null,
-          }
-        }
-      />
+        className="sc-gzVnrw jvphxe k-RewardCard__title k-u-color-font1 k-TitleWithStroke--align-left k-TitleWithStroke--italic"
+      >
+        <h6
+          className="k-TitleWithStroke__title k-TitleWithStroke__title--senary"
+        >
+          Custom title mount
+        </h6>
+        <span
+          className="k-TitleWithStroke__stroke k-TitleWithStroke__stroke--senary"
+        />
+      </div>
       <p
         className="k-Paragraph k-Paragraph--quaternary k-Paragraph--withoutMargin"
       >
@@ -37,7 +34,7 @@ exports[`<RewardCard /> by default matches with snapshot 1`] = `
 
 exports[`<RewardCard /> with DiamondBadge matches with snapshot 1`] = `
 <div
-  className="sc-bZQynM hLZFaM k-RewardCard"
+  className="sc-bZQynM ccPRax k-RewardCard"
 >
   <div
     className="k-RewardCard__cardRow"
@@ -86,21 +83,18 @@ exports[`<RewardCard /> with DiamondBadge matches with snapshot 1`] = `
           </span>
         </div>
       </div>
-      <h6
-        className="k-u-color-font1 k-u-style-italic k-u-weight-bold k-RewardCard__title"
-      >
-        Custom title mount
-      </h6>
       <div
-        className="sc-bxivhb gmqSjE k-HorizontalStroke k-u-margin-bottom-triple k-HorizontalStroke--size--default"
-        color={null}
-        style={
-          Object {
-            "height": null,
-            "width": null,
-          }
-        }
-      />
+        className="sc-gzVnrw jvphxe k-RewardCard__title k-u-color-font1 k-TitleWithStroke--align-left k-TitleWithStroke--italic"
+      >
+        <h6
+          className="k-TitleWithStroke__title k-TitleWithStroke__title--senary"
+        >
+          Custom title mount
+        </h6>
+        <span
+          className="k-TitleWithStroke__stroke k-TitleWithStroke__stroke--senary"
+        />
+      </div>
       <p
         className="k-Paragraph k-Paragraph--quaternary k-Paragraph--withoutMargin"
       >
@@ -113,7 +107,7 @@ exports[`<RewardCard /> with DiamondBadge matches with snapshot 1`] = `
 
 exports[`<RewardCard /> with all props matches with snapshot 1`] = `
 <div
-  className="sc-bZQynM hLZFaM k-RewardCard"
+  className="sc-bZQynM ccPRax k-RewardCard"
 >
   <div
     className="k-RewardCard__cardRow"
@@ -163,21 +157,18 @@ exports[`<RewardCard /> with all props matches with snapshot 1`] = `
           </span>
         </div>
       </div>
-      <h6
-        className="k-u-color-font1 k-u-style-italic k-u-weight-bold k-RewardCard__title"
-      >
-        100$
-      </h6>
       <div
-        className="sc-bxivhb gmqSjE k-HorizontalStroke k-u-margin-bottom-triple k-HorizontalStroke--size--default"
-        color={null}
-        style={
-          Object {
-            "height": null,
-            "width": null,
-          }
-        }
-      />
+        className="sc-gzVnrw jvphxe k-RewardCard__title k-u-color-font1 k-TitleWithStroke--align-left k-TitleWithStroke--italic"
+      >
+        <h6
+          className="k-TitleWithStroke__title k-TitleWithStroke__title--senary"
+        >
+          100$
+        </h6>
+        <span
+          className="k-TitleWithStroke__stroke k-TitleWithStroke__stroke--senary"
+        />
+      </div>
       <p
         className="k-u-color-font1 k-u-weight-bold"
       >
@@ -189,7 +180,7 @@ exports[`<RewardCard /> with all props matches with snapshot 1`] = `
         Superatis Tauri montis verticibus qui ad solis ortum sublimius attolluntur, Cilicia spatiis porrigitur late distentis dives bonis omnibus terra, eiusque lateri dextro adnexa Isauria, pari sorte uberi palmite viget et frugibus minutis, quam mediam navigabile flumen Calycadnus interscindit.
       </p>
       <ul
-        className="sc-dnqmqq bYuYzA k-List"
+        className="sc-iwsKbI iHewmE k-List"
       >
         <li>
           <span

--- a/assets/javascripts/kitten/components/cards/reward-card/components/title.js
+++ b/assets/javascripts/kitten/components/cards/reward-card/components/title.js
@@ -1,9 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
-import { Text } from '../../../../components/typography/text'
-import { HorizontalStroke } from '../../../../components/layout/horizontal-stroke'
-import COLORS from '../../../../constants/colors-config'
+import { TitleWithStroke } from '../../../../components/typography/title-with-stroke'
 
 export const RewardCardTitle = ({
   children,
@@ -12,25 +10,19 @@ export const RewardCardTitle = ({
   className,
   ...props
 }) => (
-  <>
-    <Text
-      {...props}
-      fontStyle="italic"
-      weight="bold"
-      tag={tagName}
-      color="font1"
-      className={classNames('k-RewardCard__title', className, {
-        'k-RewardCard__title--disabled': disabled,
-      })}
-    >
-      {children}
-    </Text>
-    <HorizontalStroke
-      size="default"
-      className="k-u-margin-bottom-triple"
-      color={disabled ? COLORS.font2 : null}
-    />
-  </>
+  <TitleWithStroke
+    {...props}
+    italic
+    margin={false}
+    tag={tagName}
+    modifier="senary"
+    className={classNames('k-RewardCard__title', className, 
+      {'k-RewardCard__title--disabled': disabled},
+      'k-u-color-font1',
+    )}
+  >
+    {children}
+  </TitleWithStroke>
 )
 
 RewardCardTitle.propTypes = {

--- a/assets/javascripts/kitten/components/cards/reward-card/styles.js
+++ b/assets/javascripts/kitten/components/cards/reward-card/styles.js
@@ -41,10 +41,6 @@ export const StyledRewardCard = styled.div`
   }
 
   .k-RewardCard__title {
-    font-size: ${pxToRem(24)};
-    line-height: ${pxToRem(34)};
-    margin: 0 0 ${pxToRem(15)} 0;
-
     &.k-RewardCard__title--disabled {
       color: ${COLORS.font2};
       cursor: not-allowed;


### PR DESCRIPTION
Closes #.

Screenshot:


TODO:

- [ ] Tests
- [ ] Changelog
- [ ] A11Y
- [ ] Stories / Docs
- [ ] BrowserStack
