### PR TITLE
[Typographie] New `setting` prop for `Text` component and new `lineHeight` options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Feature: New `setting` prop for `Text` component and new `lineHeight` options.
+
 ## [2.78.0] - 2020-07-06
 
 Feature:

--- a/assets/javascripts/kitten/components/avatar/avatar-with-text-and-badge/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/avatar/avatar-with-text-and-badge/__snapshots__/test.js.snap
@@ -26,6 +26,7 @@ exports[`<AvatarWithTextAndBadge /> without avatar should match with snapshot 1`
         decoration={null}
         fontStyle={null}
         lineHeight={null}
+        setting={null}
         size="micro"
         tag="span"
         transform={null}
@@ -43,6 +44,7 @@ exports[`<AvatarWithTextAndBadge /> without avatar should match with snapshot 1`
       decoration={null}
       fontStyle={null}
       lineHeight={null}
+      setting={null}
       size={null}
       tag="span"
       transform={null}
@@ -58,6 +60,7 @@ exports[`<AvatarWithTextAndBadge /> without avatar should match with snapshot 1`
       decoration={null}
       fontStyle={null}
       lineHeight="normal"
+      setting={null}
       size={null}
       tag="span"
       transform={null}

--- a/assets/javascripts/kitten/components/typography/text.js
+++ b/assets/javascripts/kitten/components/typography/text.js
@@ -9,6 +9,7 @@ export class Text extends Component {
       color,
       decoration,
       lineHeight,
+      setting,
       size,
       fontStyle,
       tag,

--- a/assets/javascripts/kitten/components/typography/text.js
+++ b/assets/javascripts/kitten/components/typography/text.js
@@ -35,6 +35,11 @@ export class Text extends Component {
 
         // Line height.
         'k-u-line-height-normal': lineHeight == 'normal',
+        'k-u-line-height-1': lineHeight == '1',
+        'k-u-line-height-1-3': lineHeight == '1.3',
+
+        // Setting.
+        'k-u-font-setting-tnum': setting == 'tnum', // Monospaced numbers.
 
         // Size.
         'k-u-size-huge': size == 'huge',
@@ -73,7 +78,8 @@ Text.propTypes = {
     'valid',
   ]),
   decoration: PropTypes.oneOf(['underline', 'none']),
-  lineHeight: PropTypes.oneOf(['normal']),
+  lineHeight: PropTypes.oneOf(['normal', '1', '1.3']),
+  setting: PropTypes.oneOf(['tnum']),
   size: PropTypes.oneOf(['huge', 'big', 'default', 'tiny', 'micro', 'nano']),
   fontStyle: PropTypes.oneOf(['normal', 'italic']),
   transform: PropTypes.oneOf(['uppercase']),
@@ -85,6 +91,7 @@ Text.defaultProps = {
   color: null,
   decoration: null,
   lineHeight: null,
+  setting: null,
   size: null,
   fontStyle: null,
   tag: 'span',

--- a/assets/javascripts/kitten/components/typography/text.test.js
+++ b/assets/javascripts/kitten/components/typography/text.test.js
@@ -89,4 +89,12 @@ describe('<Text />', () => {
       expect(component.hasClass('k-u-decoration-underline')).toBe(true)
     })
   })
+
+  describe('with settings prop', () => {
+    const component = shallow(<Text setting="tnum" />)
+
+    it('has a good utility class', () => {
+      expect(component.hasClass('k-u-font-setting-tnum')).toBe(true)
+    })
+  })
 })


### PR DESCRIPTION
Closes #.

Screenshot:


TODO:

- [ ] Tests
- [ ] Changelog
- [ ] A11Y
- [ ] Stories / Docs
- [ ] BrowserStack
