### PR TITLE
Making `parseHtml` to work with `<3`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
+- Fix: escape html entities with `parseHtml` 
 
 ## [2.78.0] - 2020-07-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
-- Fix: escape html entities with `parseHtml` 
+- Fix: escape `<3` with `parseHtml` 
 
 ## [2.78.0] - 2020-07-06
 

--- a/assets/javascripts/kitten/helpers/utils/parser.js
+++ b/assets/javascripts/kitten/helpers/utils/parser.js
@@ -4,5 +4,10 @@ import HtmlToReact from 'html-to-react'
 export const parseHtml = value => {
   if (!value) return
 
-  return new HtmlToReact.Parser().parse(`<span>${value}</span>`).props.children
+  const encodedValue = value.replace(/[\u00A0-\u9999<>\&]/gim, i => {
+    return '&#' + i.charCodeAt(0) + ';'
+  })
+
+  return new HtmlToReact.Parser().parse(`<span>${encodedValue}</span>`).props
+    .children
 }

--- a/assets/javascripts/kitten/helpers/utils/parser.js
+++ b/assets/javascripts/kitten/helpers/utils/parser.js
@@ -4,9 +4,10 @@ import HtmlToReact from 'html-to-react'
 export const parseHtml = value => {
   if (!value) return
 
-  const encodedValue = value.replace(/[\u00A0-\u9999<>\&]/gim, i => {
-    return '&#' + i.charCodeAt(0) + ';'
-  })
+  const encodedValue = value.replace(
+    /[\u00A0-\u9999<>\&]/gim,
+    i => `&#${i.charCodeAt(0)};`,
+  )
 
   return new HtmlToReact.Parser().parse(`<span>${encodedValue}</span>`).props
     .children

--- a/assets/javascripts/kitten/helpers/utils/parser.js
+++ b/assets/javascripts/kitten/helpers/utils/parser.js
@@ -4,10 +4,8 @@ import HtmlToReact from 'html-to-react'
 export const parseHtml = value => {
   if (!value) return
 
-  const encodedValue = value.replace(
-    /[\u00A0-\u9999<>\&]/gim,
-    i => `&#${i.charCodeAt(0)};`,
-  )
+  // We need to escape "<3" common emoji
+  const encodedValue = value.replace('<3', '&lt;3')
 
   return new HtmlToReact.Parser().parse(`<span>${encodedValue}</span>`).props
     .children

--- a/assets/javascripts/kitten/helpers/utils/parser.test.js
+++ b/assets/javascripts/kitten/helpers/utils/parser.test.js
@@ -3,17 +3,18 @@ import ReactDOMServer from 'react-dom/server'
 
 describe('parseHtml()', () => {
   it('converts HTML to React with HTML tags', () => {
-    const parsedHtml = parseHtml('<strong>Foo <br/>Bar</strong>')
-    const escapedHtml = '&lt;strong&gt;Foo &lt;br/&gt;Bar&lt;/strong&gt;'
+    const html = '<strong>Foo <br/>Bar</strong>'
+    const parsedHtml = parseHtml(html)
 
-    expect(ReactDOMServer.renderToStaticMarkup(parsedHtml)).toBe(escapedHtml)
+    expect(ReactDOMServer.renderToStaticMarkup(parsedHtml)).toBe(html)
   })
 
   it('converts HTML to React with &nbsp;', () => {
     const html = 'FooBar&nbsp;!'
     const parsedHtml = parseHtml(html)
+    const nbsp = '\xa0'
 
-    expect(parsedHtml).toBe(`FooBar&nbsp;!`)
+    expect(parsedHtml).toBe(`FooBar${nbsp}!`)
   })
 
   it('converts HTML to React with <3 // html entities', () => {

--- a/assets/javascripts/kitten/helpers/utils/parser.test.js
+++ b/assets/javascripts/kitten/helpers/utils/parser.test.js
@@ -3,18 +3,17 @@ import ReactDOMServer from 'react-dom/server'
 
 describe('parseHtml()', () => {
   it('converts HTML to React with HTML tags', () => {
-    const html = '<strong>Foo <br/>Bar</strong>'
-    const parsedHtml = parseHtml(html)
+    const parsedHtml = parseHtml('<strong>Foo <br/>Bar</strong>')
+    const escapedHtml = '&lt;strong&gt;Foo &lt;br/&gt;Bar&lt;/strong&gt;'
 
-    expect(ReactDOMServer.renderToStaticMarkup(parsedHtml)).toBe(html)
+    expect(ReactDOMServer.renderToStaticMarkup(parsedHtml)).toBe(escapedHtml)
   })
 
   it('converts HTML to React with &nbsp;', () => {
     const html = 'FooBar&nbsp;!'
     const parsedHtml = parseHtml(html)
-    const nbsp = '\xa0'
 
-    expect(parsedHtml).toBe(`FooBar${nbsp}!`)
+    expect(parsedHtml).toBe(`FooBar&nbsp;!`)
   })
 
   it('converts HTML to React with <3 // html entities', () => {

--- a/assets/javascripts/kitten/helpers/utils/parser.test.js
+++ b/assets/javascripts/kitten/helpers/utils/parser.test.js
@@ -16,4 +16,11 @@ describe('parseHtml()', () => {
 
     expect(parsedHtml).toBe(`FooBar${nbsp}!`)
   })
+
+  it('converts HTML to React with <3 // html entities', () => {
+    const html = 'FooBar <3'
+    const parsedHtml = parseHtml(html)
+
+    expect(parsedHtml).toBe('FooBar <3')
+  })
 })

--- a/src/helpers/utils/parser.js
+++ b/src/helpers/utils/parser.js
@@ -11,8 +11,10 @@ var _htmlToReact = _interopRequireDefault(require("html-to-react"));
 
 // We add a span to make parseHtml works with strings.
 var parseHtml = function parseHtml(value) {
-  if (!value) return;
-  return new _htmlToReact.default.Parser().parse("<span>".concat(value, "</span>")).props.children;
+  if (!value) return; // We need to escape "<3" common emoji
+
+  var encodedValue = value.replace('<3', '&lt;3');
+  return new _htmlToReact.default.Parser().parse("<span>".concat(encodedValue, "</span>")).props.children;
 };
 
 exports.parseHtml = parseHtml;


### PR DESCRIPTION
Permet de fixer le crash lorsqu'un `string` contient un `<3` (genre `Merci <3 !`)