### PR TITLE
Create modal full size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
+- Feature : add `fullSize` and `fullSizeTitle` props to `next/Modal`
 
 ## [2.81.2] - 2020-07-21
 

--- a/assets/javascripts/kitten/components/modals/next/Modal.stories.js
+++ b/assets/javascripts/kitten/components/modals/next/Modal.stories.js
@@ -154,7 +154,31 @@ export const WithoutButton = () => (
     {() => (
       <>
         <Modal.Title>Lorem ipsum dolor sit consectetuer</Modal.Title>
-        <Modal.Paragraph withoutMargin>{text('content', paragraphContainer)}</Modal.Paragraph>
+        <Modal.Paragraph withoutMargin>
+          {text('content', paragraphContainer)}
+        </Modal.Paragraph>
+      </>
+    )}
+  </Modal>
+)
+
+export const FullSize = () => (
+  <Modal
+    trigger={<Button modifier="helium">Open</Button>}
+    hasCloseButton={boolean('Has close button', true)}
+    zIndex={number('Overlay z-index', 110)}
+    fullSizeTitle="Lorem ipsum dolor sit consectetuer"
+    fullSize={boolean('Has full size', true)}
+  >
+    {() => (
+      <>
+        <Modal.Title>Lorem ipsum dolor sit consectetuer</Modal.Title>
+        <Modal.Paragraph>
+          {text('content', `${paragraphContainer} ${paragraphContainer}`)}
+        </Modal.Paragraph>
+        <Modal.Actions>
+          <Modal.Button modifier="helium">Action 1 Button</Modal.Button>
+        </Modal.Actions>
       </>
     )}
   </Modal>

--- a/assets/javascripts/kitten/components/modals/next/index.js
+++ b/assets/javascripts/kitten/components/modals/next/index.js
@@ -6,6 +6,7 @@ import ReactModal from 'react-modal'
 import { CloseButton } from '../../../components/buttons/close-button'
 import { Button } from '../../../components/buttons/button/button'
 import { Paragraph } from '../../../components/typography/paragraph'
+import { Text } from '../../../components/typography/text'
 import styled, { createGlobalStyle, css } from 'styled-components'
 import { pxToRem } from '../../../helpers/utils/typography'
 import { ScreenConfig } from '../../../constants/screen-config'
@@ -22,6 +23,10 @@ const paddingPlusGutters = 2 * CONTAINER_PADDING + 11 * GUTTER
 const oneGridCol = `calc((100vw - ${pxToRem(
   paddingPlusGutters,
 )}) / 12 + ${pxToRem(GUTTER)})`
+
+const negativeOneGridCol = `calc(0px - ((100vw - ${pxToRem(
+  paddingPlusGutters,
+)}) / 12 + ${pxToRem(GUTTER)}))`
 
 const StyledParagraph = styled(Paragraph)`
   font-size: ${pxToRem(12)};
@@ -46,6 +51,13 @@ const GlobalStyle = createGlobalStyle`
     margin-left: ${pxToRem(20)};
     padding: ${pxToRem(50)} ${pxToRem(30)};
     width: calc(100vw ${pxToRem(20)});
+    ${props =>
+      props.fullSize &&
+      css`
+        padding-top: 0 !important;
+        min-width: 100vw !important;
+        margin: 0 !important;
+      `};
   
     @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
       margin: auto;
@@ -109,6 +121,11 @@ const GlobalStyle = createGlobalStyle`
       @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
         min-height: ${pxToRem(100)};
       }
+      ${props =>
+        props.fullSize &&
+        css`
+          min-height: 0 !important;
+        `}
     }
     ${props =>
       css`
@@ -134,6 +151,25 @@ const GlobalStyle = createGlobalStyle`
     transform: scale(1.06);
     opacity: 0;
   }
+  
+  .k-ModalNext__title--fullSize {
+    position: sticky;
+    top:0;
+    width: 100vw;
+    text-align: center;
+    margin-left: ${negativeOneGridCol};
+    box-sizing: border-box;
+    background-color: ${COLORS.background1};
+    padding: ${pxToRem(20)} ${oneGridCol};
+    border-bottom: ${pxToRem(2)} solid ${COLORS.line1};
+    margin-bottom: ${pxToRem(50)};
+  }
+  
+  .k-ModalNext__closeButton--fullSize {
+  position: absolute;
+  left: ${pxToRem(20)}
+  top: ${pxToRem(12)}
+  } 
 `
 
 const ModalTitle = ({ children }) => (
@@ -254,6 +290,8 @@ const InnerModal = ({
   huge,
   isOpen,
   zIndex,
+  fullSize,
+  fullSizeTitle,
   ...others
 }) => {
   const [{ show }, dispatch] = useContext(ModalContext)
@@ -276,7 +314,7 @@ const InnerModal = ({
 
   const ModalPortal = ReactDOM.createPortal(
     <>
-      <GlobalStyle cols={colsOnDesktop} zIndex={zIndex} />
+      <GlobalStyle cols={colsOnDesktop} zIndex={zIndex} fullSize={fullSize} />
       <ReactModal
         closeTimeoutMS={500}
         role="dialog"
@@ -305,11 +343,25 @@ const InnerModal = ({
         {...modalProps}
       >
         <>
+          {fullSize && Title && (
+            <div className="k-ModalNext__title--fullSize">
+              <CloseButton
+                className="k-ModalNext__closeButton--fullSize"
+                modifier="hydrogen"
+                onClick={close}
+                size="tiny"
+                closeButtonLabel={closeButtonLabel}
+              />
+              <Text size="tiny" color="font1" weight="regular">
+                {fullSizeTitle}
+              </Text>
+            </div>
+          )}
           {children({
             open: () => dispatch(updateState(true)),
             close: () => dispatch(updateState(false)),
           })}
-          {hasCloseButton && (
+          {hasCloseButton && !fullSize && (
             <div className="k-ModalNext__close">
               <CloseButton
                 style={{ position: 'fixed' }}
@@ -357,12 +409,14 @@ Modal.propTypes = {
   labelledby: PropTypes.string,
   describedby: PropTypes.string,
   closeButtonLabel: PropTypes.string,
+  fullSize: PropTypes.bool,
   modalProps: PropTypes.object,
   hasCloseButton: PropTypes.bool,
   big: PropTypes.bool,
   huge: PropTypes.bool,
   isOpen: PropTypes.bool,
   zIndex: PropTypes.number,
+  fullSizeTitle: PropTypes.string,
 }
 
 Modal.defaultProps = {
@@ -370,12 +424,14 @@ Modal.defaultProps = {
   labelledby: '',
   describedby: '',
   closeButtonLabel: 'Fermer',
+  fullSize: false,
   modalProps: {},
   hasCloseButton: true,
   big: false,
   huge: false,
   isOpen: false,
   zIndex: 110,
+  fullSizeTitle: '',
 }
 
 Modal.Title = ModalTitle

--- a/assets/javascripts/kitten/components/modals/next/index.js
+++ b/assets/javascripts/kitten/components/modals/next/index.js
@@ -166,9 +166,9 @@ const GlobalStyle = createGlobalStyle`
   }
   
   .k-ModalNext__closeButton--fullSize {
-  position: absolute;
-  left: ${pxToRem(20)}
-  top: ${pxToRem(12)}
+    position: absolute;
+    left: ${pxToRem(20)}
+    top: ${pxToRem(12)}
   } 
 `
 


### PR DESCRIPTION
Gestion `fullSize` de la modale `next` en se basant sur l'exemple ici : https://app.abstract.com/projects/6e9b6c3e-f67d-4831-b5ba-66caa5a524fe/branches/1a560145-95e1-4812-8ff3-364c87d4caed/commits/76563444fc3d308816441767681c07cb33aa498c/files/60B214CA-457A-4EF6-A64E-D419824C4C66/layers/39CAA2E4-15D3-4C5E-91F2-C0374450F6BC?mode=build&selected=root-FC0F05B2-E0D2-421D-92B9-E4A9BE18A71E

<img width="470" alt="Capture d’écran 2020-07-16 à 10 20 02" src="https://user-images.githubusercontent.com/804738/87646108-aa7e4580-c74e-11ea-8c8e-df35d88065db.png">

closes #2098
