### PR TITLE
[Header] Remove console error from `Centered` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Remove console error from `Header` component `Centered`.
+
 ## [2.86.0] - 2020-08-17
 
 Feature:

--- a/assets/javascripts/kitten/components/navigation/header-nav/components/centered.js
+++ b/assets/javascripts/kitten/components/navigation/header-nav/components/centered.js
@@ -17,7 +17,7 @@ export const Centered = ({ children, className, display, ...props }) => {
 }
 
 Centered.propTypes = {
-  display: PropTypes.oneOf['column'],
+  display: PropTypes.oneOf(['column']),
 }
 
 Centered.defaultProps = {


### PR DESCRIPTION
Closes #.

Screenshot:


TODO:

- [x] Tests
- [x] Changelog
- [ ] A11Y
- [ ] Stories / Docs
- [ ] BrowserStack
