### PR TITLE
[parseHtml] Fix parseHtml error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+Fix: - Fix `parseHtml` returning encoded error when using `replace()` on a
+  non `string` component.
+
 ## [2.88.0] - 2020-08-27
 
 Features:

--- a/assets/javascripts/kitten/helpers/utils/parser.js
+++ b/assets/javascripts/kitten/helpers/utils/parser.js
@@ -5,7 +5,8 @@ export const parseHtml = value => {
   if (!value) return
 
   // We need to escape "<3" common emoji
-  const encodedValue = value.replace('<3', '&lt;3')
+  const encodedValue =
+    typeof value === 'string' ? value.replace('<3', '&lt;3') : value
 
   return new HtmlToReact.Parser().parse(`<span>${encodedValue}</span>`).props
     .children


### PR DESCRIPTION
Cette portion du code `value.replace('<3', '&lt;3')` casse la fonction `parseHtml` lorsque `value` n'est pas une `string`.