### PR TITLE
Update `bin/release`

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,11 +184,12 @@ $ npm login
 - Run this command:
 
 ```sh
-bin/release NEW_VERSION
+bin/release
 ```
 
 - Follow the link to create the pull request on Github.
-- Announce the release on KissKissBankBank's #kit-ui Slack channel with the
+- Announce the release on KissKissBankBank's
+  [#kit-ui Slack channel](slack://channel?id=C1C04G41Y&team=T03M237SF) with the
   related CHANGELOG.
 
 ### Release!

--- a/bin/publish
+++ b/bin/publish
@@ -16,7 +16,7 @@ git push origin ${REALEASE_TAG}
 npm publish
 
 echo "Done! kitten v$PACKAGE_VERSION is published! 🚀"
-echo "I can use it alteady with npm install @kisskissbankbank/kitten"
+echo "I can use it already with npm install @kisskissbankbank/kitten"
 
 npm run deploy-storybook
 

--- a/bin/publish
+++ b/bin/publish
@@ -16,7 +16,7 @@ git push origin ${REALEASE_TAG}
 npm publish
 
 echo "Done! kitten v$PACKAGE_VERSION is published! 🚀"
-echo "I can use it already with npm install @kisskissbankbank/kitten"
+echo "Use it now with npm install @kisskissbankbank/kitten"
 
 npm run deploy-storybook
 

--- a/bin/release
+++ b/bin/release
@@ -1,19 +1,22 @@
 #!/usr/bin/env bash
-if [ -z "$1" ]
-  then
-    echo "You need to supply version (patch|minor|major or specific tag)"
-    exit
-fi
-echo "You're about to release the next version of kitten (${1})"
+
+PACKAGE_VERSION=$(cat package.json \
+  | grep version \
+  | head -1 \
+  | awk -F: '{ print $2 }' \
+  | sed 's/[",]//g' \
+  | tr -d '[[:space:]]')
+
+echo "You're about to release the next version of kitten $PACKAGE_VERSION"
 bin/install
 npm test
-git checkout -b release/v$1
+git checkout -b release/v${PACKAGE_VERSION}
 npm run build:js
 npm run build:utilities
 git add .
-git commit -m "add built js files for ${1}"
-npm --no-git-tag-version version $1
+git commit -m "add built js files for $PACKAGE_VERSION"
+npm --no-git-tag-version version ${PACKAGE_VERSION}
 git add .
-git commit -m "bump kitten version to $1"
-git push origin release/v$1
-echo "Done! You can now create a release PR: https://github.com/KissKissBankBank/kitten/compare/release/v${1}?expand=1 😸"
+git commit -m "bump kitten version to $PACKAGE_VERSION"
+git push origin release/v${PACKAGE_VERSION}
+echo "Done! You can now create a release PR: https://github.com/KissKissBankBank/kitten/compare/release/v${PACKAGE_VERSION}?expand=1 😸"

--- a/bin/release
+++ b/bin/release
@@ -14,9 +14,9 @@ git checkout -b release/v${PACKAGE_VERSION}
 npm run build:js
 npm run build:utilities
 git add .
-git commit -m "add built js files for $PACKAGE_VERSION"
+git commit -m "Add built js files for $PACKAGE_VERSION"
 npm --no-git-tag-version version ${PACKAGE_VERSION}
 git add .
-git commit -m "bump kitten version to $PACKAGE_VERSION"
+git commit -m "Bump kitten version to $PACKAGE_VERSION"
 git push origin release/v${PACKAGE_VERSION}
 echo "Done! You can now create a release PR: https://github.com/KissKissBankBank/kitten/compare/release/v${PACKAGE_VERSION}?expand=1 😸"


### PR DESCRIPTION
- Permet de lancer `bin/release` sans avoir à taper le numéro de version
- Met à jour le `README.md`
  - sur la commande `bin/release`
  - inclus le lien de l'app slack pour rediriger directement sur le channel `#kit-ui`