### PR TITLE
[Storybook] Use sideEffect option

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -41,6 +41,7 @@ module.exports = {
           },
         },
       ],
+      sideEffects: true,
     })
     return alteredConfig
   },


### PR DESCRIPTION
## Pourquoi

Pour la version buildée de Storybook, le fichier des styles `scss` n'était pas pris en compte. Il devait y avoir conflit entre tous les Kitten (src/esm/es6…).