### PR TITLE
Fix dropdown undefined value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
+- Fix `DropdownPhoneSelect` when phone number is empty.
 
 ## [2.100.1] - 2020-11-26
 

--- a/assets/javascripts/kitten/components/form/dropdown-phone-select/dropdown-phone-select.stories.js
+++ b/assets/javascripts/kitten/components/form/dropdown-phone-select/dropdown-phone-select.stories.js
@@ -54,3 +54,39 @@ export const Default = () => {
     </Grid>
   )
 }
+
+export const WithoutValues = () => {
+  return (
+    <Grid>
+      <GridCol offset-l="1" col-l="8">
+        <DropdownPhoneSelect
+          id={text('id', 'dropdown-select')}
+          error={boolean('error', false)}
+          valid={boolean('valid', false)}
+          disabled={boolean('disabled', false)}
+          hideLabel={boolean('hide label?', false)}
+          labelText={text('LabelText', 'label')}
+          resetOnBackspace
+          highlightOptionBox
+          placeholder={text('placeholder', 'Téléphone')}
+          phoneProps={{
+            preferredCountries: [
+              'fr',
+              'be',
+              'lu',
+              're',
+              'gp',
+              'mq',
+              'pf',
+              'nc',
+              'gf',
+              'yt',
+            ],
+          }}
+          locale={select('locale', ['fr', 'en', 'nl'], 'fr')}
+          flagsUrl={flagFile}
+        />
+      </GridCol>
+    </Grid>
+  )
+}

--- a/assets/javascripts/kitten/components/form/dropdown-phone-select/index.js
+++ b/assets/javascripts/kitten/components/form/dropdown-phone-select/index.js
@@ -178,7 +178,7 @@ export const DropdownPhoneSelect = ({
   const [getCaretPosition, setCaretPosition] = useState(0)
   const [getInputPlaceholder, setInputPlaceholder] = useState(placeholder)
   const [getDefaultSelectedValue, setDefaultSelectedValue] = useState(null)
-  const [getInputNumber, setInputNumber] = useState(null)
+  const [getInputNumber, setInputNumber] = useState('')
   const getPreviousFormattedNumber = usePrevious(getFormattedNumber)
 
   const phoneProps = {


### PR DESCRIPTION
Quand il n'y avait pas de `value` définie sur le composant, le `getInputNumber` était `null` et faisait planter le premier passage dans le `handleInput`.
