### PR TITLE
[VerticalStepper] Update `error` props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Update `error` props on `VerticalStepper` with `variant="orion"`. 
+
 ## [2.101.0] - 2020-11-30
 
 Features:

--- a/assets/javascripts/kitten/components/steppers/vertical-stepper/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/steppers/vertical-stepper/__snapshots__/test.js.snap
@@ -85,6 +85,11 @@ exports[`<VerticalStepper /> with all sub-components matches with snapshot 1`] =
   border-color: #eee;
 }
 
+.c3 .k-Steppers--VerticalStepper__status.k-Steppers--VerticalStepper__status--orion.k-Steppers--VerticalStepper__status--error {
+  color: #ff0046;
+  border-color: #ff0046;
+}
+
 .c3 .k-Steppers--VerticalStepper__status.k-Steppers--VerticalStepper__status--orion.k-Steppers--VerticalStepper__status--disabled {
   background-color: #fff;
   border-color: #eee;
@@ -345,7 +350,6 @@ exports[`<VerticalStepper /> with all sub-components matches with snapshot 1`] =
         </div>
         <div
           className="VerticalStepper__step k-Steppers--VerticalStepper__step--link--content"
-          error={false}
         >
           <p
             className="c4 k-Stepepers-VerticalStepper__title--andromeda"
@@ -392,7 +396,6 @@ exports[`<VerticalStepper /> with all sub-components matches with snapshot 1`] =
         </div>
         <div
           className="VerticalStepper__step k-Steppers--VerticalStepper__step--link--content"
-          error={false}
         >
           <p
             className="c4 k-Stepepers-VerticalStepper__title--andromeda"
@@ -458,7 +461,6 @@ exports[`<VerticalStepper /> with all sub-components matches with snapshot 1`] =
         </div>
         <div
           className="VerticalStepper__step k-Steppers--VerticalStepper__step--link--content"
-          error={true}
         >
           <p
             className="c4 k-Stepepers-VerticalStepper__title--andromeda"
@@ -522,7 +524,6 @@ exports[`<VerticalStepper /> with all sub-components matches with snapshot 1`] =
         </div>
         <div
           className="VerticalStepper__step k-Steppers--VerticalStepper__step--link--content"
-          error={false}
         >
           <p
             className="c4 k-Stepepers-VerticalStepper__title--andromeda"
@@ -569,7 +570,6 @@ exports[`<VerticalStepper /> with all sub-components matches with snapshot 1`] =
         </div>
         <div
           className="VerticalStepper__step k-Steppers--VerticalStepper__step--link--content"
-          error={false}
         >
           <p
             className="c4 k-Stepepers-VerticalStepper__title--andromeda"
@@ -675,6 +675,11 @@ exports[`<VerticalStepper /> with orion variant matches with snapshot 1`] = `
 .c3 .k-Steppers--VerticalStepper__status.k-Steppers--VerticalStepper__status--orion.k-Steppers--VerticalStepper__status--waiting {
   background-color: #fff;
   border-color: #eee;
+}
+
+.c3 .k-Steppers--VerticalStepper__status.k-Steppers--VerticalStepper__status--orion.k-Steppers--VerticalStepper__status--error {
+  color: #ff0046;
+  border-color: #ff0046;
 }
 
 .c3 .k-Steppers--VerticalStepper__status.k-Steppers--VerticalStepper__status--orion.k-Steppers--VerticalStepper__status--disabled {
@@ -908,7 +913,6 @@ exports[`<VerticalStepper /> with orion variant matches with snapshot 1`] = `
         </div>
         <div
           className="VerticalStepper__step k-Steppers--VerticalStepper__step--link--content"
-          error={false}
         >
           <p
             className="c4 k-Stepepers-VerticalStepper__title--orion"
@@ -957,7 +961,6 @@ exports[`<VerticalStepper /> with orion variant matches with snapshot 1`] = `
         </div>
         <div
           className="VerticalStepper__step k-Steppers--VerticalStepper__step--link--content"
-          error={false}
         >
           <p
             className="c4 k-Stepepers-VerticalStepper__title--orion"
@@ -995,7 +998,6 @@ exports[`<VerticalStepper /> with orion variant matches with snapshot 1`] = `
         </div>
         <div
           className="VerticalStepper__step k-Steppers--VerticalStepper__step--link--content"
-          error={true}
         >
           <p
             className="c4 k-Stepepers-VerticalStepper__title--orion"
@@ -1021,7 +1023,6 @@ exports[`<VerticalStepper /> with orion variant matches with snapshot 1`] = `
         </div>
         <div
           className="VerticalStepper__step k-Steppers--VerticalStepper__step--link--content"
-          error={false}
         >
           <p
             className="c4 k-Stepepers-VerticalStepper__title--orion"
@@ -1047,7 +1048,6 @@ exports[`<VerticalStepper /> with orion variant matches with snapshot 1`] = `
         </div>
         <div
           className="VerticalStepper__step k-Steppers--VerticalStepper__step--link--content"
-          error={false}
         >
           <p
             className="c4 k-Stepepers-VerticalStepper__title--orion"

--- a/assets/javascripts/kitten/components/steppers/vertical-stepper/components/status.js
+++ b/assets/javascripts/kitten/components/steppers/vertical-stepper/components/status.js
@@ -148,6 +148,10 @@ const StyledContainerStatus = styled.div`
         background-color: ${COLORS.background1};
         border-color: ${COLORS.line1};
       }
+      &.k-Steppers--VerticalStepper__status--error {
+        color: ${COLORS.error};
+        border-color: ${COLORS.error};
+      }
       &.k-Steppers--VerticalStepper__status--disabled {
         background-color: ${COLORS.background1};
         border-color: ${COLORS.line1};

--- a/assets/javascripts/kitten/components/steppers/vertical-stepper/components/step.js
+++ b/assets/javascripts/kitten/components/steppers/vertical-stepper/components/step.js
@@ -39,7 +39,6 @@ export const Step = ({
         />
 
         <div
-          error={error}
           className={classNames(
             STEP_CLASSNAME,
             'k-Steppers--VerticalStepper__step--link--content',

--- a/assets/javascripts/kitten/components/steppers/vertical-stepper/stories.js
+++ b/assets/javascripts/kitten/components/steppers/vertical-stepper/stories.js
@@ -51,7 +51,7 @@ export const WithOrionVariant = () => {
         <VerticalStepper.Step variant="orion" bridge />
 
         <VerticalStepper.Step
-          waiting
+          error
           statusProps={{ title: 'Étape à commencer' }}
           variant="orion"
         >


### PR DESCRIPTION
### Description
- Mise à jour de la props `error` quand on utilise `variant="orion".

Screenshot:


TODO:

- [x] Tests
- [x] Changelog
- [ ] A11Y
- [x] Stories / Docs
- [ ] BrowserStack
- [ ] New component added to `assets/javascripts/kitten/index.js`
