### PR TITLE
[DropDown] Add `uniqLabelOnSearch` prop on `Dropdown`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fix: Fix className and refacto.
 - Fix: Fix `DropdownSelect` item line height and alignment.
 - Fix: `ProgressBar` wasn’t passing class names.
-- Feature: Add `uniqLabelOnSearch` prop on `Dropdown`
+- Feature: Add `uniqLabelOnSearch` prop on `DropdownSelect`.
 
 ## [2.104.1] - 2020-12-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fix: Fix className and refacto.
 - Fix: Fix `DropdownSelect` item line height and alignment.
 - Fix: `ProgressBar` wasn’t passing class names.
+- Feature: Add `uniqLabelOnSearch` prop on `Dropdown`
 
 ## [2.104.1] - 2020-12-14
 

--- a/assets/javascripts/kitten/components/form/dropdown-select/combobox.js
+++ b/assets/javascripts/kitten/components/form/dropdown-select/combobox.js
@@ -8,6 +8,10 @@ import { WarningCircleIcon } from '../../../components/icons/warning-circle-icon
 import { CheckedCircleIcon } from '../../../components/icons/checked-circle-icon'
 import { ArrowIcon } from '../../../components/icons/arrow-icon'
 import find from 'lodash/fp/find'
+import flow from 'lodash/fp/flow'
+import uniqBy from 'lodash/fp/uniqBy'
+import filter from 'lodash/fp/filter'
+import isEmpty from 'lodash/isEmpty'
 import { StyledDropdown } from './styles'
 
 export const DropdownCombobox = ({
@@ -33,6 +37,7 @@ export const DropdownCombobox = ({
   onMenuClose,
   onMenuOpen,
   openOnLoad,
+  uniqLabelOnSearch,
 }) => {
   const [flattenedOptions, setFlattenedOptions] = useState([])
   const [filteredOptions, setFilteredOptions] = useState([])
@@ -51,11 +56,16 @@ export const DropdownCombobox = ({
   }
 
   const onInputValueChange = changes => {
-    const newItemsList = flattenedOptions.filter(item => {
-      return item.value
-        .toLowerCase()
-        .startsWith(changes.inputValue.toLowerCase())
-    })
+    const newItemsList = flow(
+      filter(item => {
+        return item.value
+          .toLowerCase()
+          .startsWith(changes.inputValue.toLowerCase())
+      }),
+      !isEmpty(changes.inputValue) && uniqLabelOnSearch
+        ? uniqBy('label')
+        : item => item,
+    )(flattenedOptions)
 
     setFilteredOptions(newItemsList)
     onInputChange({ value: changes.inputValue, changes })

--- a/assets/javascripts/kitten/components/form/dropdown-select/dropdown-select.stories.js
+++ b/assets/javascripts/kitten/components/form/dropdown-select/dropdown-select.stories.js
@@ -80,3 +80,36 @@ export const Default = () => {
     </Grid>
   )
 }
+
+export const WithDoublon = () => {
+  return (
+    <Grid>
+      <GridCol offset="1" col="8">
+        <DropdownSelect
+          id={text('id', 'dropdown-select')}
+          error={boolean('error', false)}
+          valid={boolean('valid', false)}
+          disabled={boolean('disabled', false)}
+          hideLabel={boolean('hide label?', false)}
+          combobox={true}
+          labelText={text('LabelText', 'label')}
+          options={[
+            { value: 'france', label: 'France' },
+            { value: 'france', label: 'France' },
+            { value: 'irlande', label: 'Irlande' },
+          ]}
+          size={select(
+            'size',
+            ['tiny', 'normal', 'big', 'huge', 'giant'],
+            'normal',
+          )}
+          variant={select('variant', ['andromeda', 'orion'], 'andromeda')}
+          defaultSelectedValue="focus"
+          comboboxButtonLabelText={text('Buton aria-label', 'label')}
+          noResultText={text('No results text', 'No results')}
+          uniqLabelOnSearch={boolean('uniqLabelOnSearch', false)}
+        />
+      </GridCol>
+    </Grid>
+  )
+}

--- a/assets/javascripts/kitten/components/form/dropdown-select/dropdown-select.stories.js
+++ b/assets/javascripts/kitten/components/form/dropdown-select/dropdown-select.stories.js
@@ -81,7 +81,7 @@ export const Default = () => {
   )
 }
 
-export const WithDoublon = () => {
+export const WithDuplicateValue = () => {
   return (
     <Grid>
       <GridCol offset="1" col="8">

--- a/assets/javascripts/kitten/components/form/dropdown-select/index.js
+++ b/assets/javascripts/kitten/components/form/dropdown-select/index.js
@@ -204,6 +204,7 @@ DropdownSelect.defaultProps = {
   onMenuClose: () => {},
   onMenuOpen: () => {},
   openOnLoad: false,
+  uniqLabelOnSearch: false,
 }
 
 DropdownSelect.propTypes = {
@@ -224,4 +225,5 @@ DropdownSelect.propTypes = {
   onMenuClose: PropTypes.func,
   onMenuOpen: PropTypes.func,
   openOnLoad: PropTypes.bool,
+  uniqLabelOnSearch: PropTypes.bool,
 }


### PR DESCRIPTION
Ajout d'une prop qui permet de forcer l'affichage unique de chaque label.
Ça servirait pour les pays, on a deux fois la France dans la liste mais quand on fait la recherche on aimerait ne l'afficher qu'une seule fois.