### PR TITLE
[TextInput] Propagate `name` argument when `TextInput` is a textarea

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Propagate `name` argument when `TextInput` is a textarea.
 - Feature: Add `variant` prop to `ProgressRing`, defaults to `andromeda`.
 - Feature: Add `animationSpeed` prop to `ProgressRing`.
 

--- a/assets/javascripts/kitten/components/form/text-input/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/form/text-input/__snapshots__/test.js.snap
@@ -69,6 +69,21 @@ exports[`<TextInput /> with \`tag\` prop matches with snapshot 1`] = `
 />
 `;
 
+exports[`<TextInput /> with \`textarea\` tag matches with snapshot 1`] = `
+<div
+  className="sc-bwzfXH bEnvnC k-Form-TextInput__textareaContainer k-Form-TextInput__textareaContainer--andromeda"
+>
+  <textarea
+    className="sc-bdVaJa gvIinf k-Form-TextInput k-Form-TextInput--andromeda"
+    disabled={false}
+    name="message"
+  />
+  <div
+    className="k-Form-TextInput__textareaGradient"
+  />
+</div>
+`;
+
 exports[`<TextInput /> with \`tiny\` prop matches with snapshot 1`] = `
 <input
   className="sc-bdVaJa gvIinf k-Form-TextInput k-Form-TextInput--andromeda k-Form-TextInput--tiny"

--- a/assets/javascripts/kitten/components/form/text-input/index.js
+++ b/assets/javascripts/kitten/components/form/text-input/index.js
@@ -280,6 +280,7 @@ export class TextInput extends PureComponent {
             ref={input => (this.input = input)}
             as="textarea"
             disabled={disabled}
+            name={name}
             className={classNames(
               'k-Form-TextInput',
               className,

--- a/assets/javascripts/kitten/components/form/text-input/test.js
+++ b/assets/javascripts/kitten/components/form/text-input/test.js
@@ -104,4 +104,16 @@ describe('<TextInput />', () => {
       expect(component).toMatchSnapshot()
     })
   })
+
+  describe('with `textarea` tag', () => {
+    beforeEach(() => {
+      component = renderer
+        .create(<TextInput tag="textarea" name="message" />)
+        .toJSON()
+    })
+
+    it('matches with snapshot', () => {
+      expect(component).toMatchSnapshot()
+    })
+  })
 })


### PR DESCRIPTION
## Pourquoi

Quand on est en mode `tag="textarea"` le `name` n'était pas propagé dans le DOM. Sans conséquence car Formik n'en a pas forcement besoin mais en terme de validité HTML, on est pas bon.