### PR TITLE
[HorizontalStroke] Allow `string` prop types on customSize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Feature: Allow string prop types for `customSize` on `HorizontalStroke`.
 - Fix: Define default color for `DropdownSelect` items.
 - Feature: Add CSS utilities `k-u-flex-alignSelf-*` and docs.
 

--- a/assets/javascripts/kitten/components/layout/horizontal-stroke/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/layout/horizontal-stroke/__snapshots__/test.js.snap
@@ -1521,6 +1521,158 @@ exports[`<HorizontalStroke /> with height via \`customSize\` matches with snapsh
 />
 `;
 
+exports[`<HorizontalStroke /> with string type width via \`customSize\` matches with snapshot 1`] = `
+.c0 {
+  border: none;
+  background: #222;
+}
+
+.c0.k-HorizontalStroke--size--micro {
+  width: 0.9375rem;
+  height: 0.125rem;
+}
+
+.c0.k-HorizontalStroke--size--tiny {
+  width: 1.25rem;
+  height: 0.125rem;
+}
+
+.c0.k-HorizontalStroke--size--default {
+  width: 1.875rem;
+  height: 0.25rem;
+}
+
+.c0.k-HorizontalStroke--size--big {
+  width: 3.125rem;
+  height: 0.25rem;
+}
+
+.c0.k-HorizontalStroke--size--huge {
+  width: 6.25rem;
+  height: 0.375rem;
+}
+
+.c0.k-HorizontalStroke--modifier--primary {
+  width: 2.5rem;
+  height: 0.375rem;
+}
+
+.c0.k-HorizontalStroke--modifier--secondary {
+  width: 1.875rem;
+  height: 0.25rem;
+}
+
+.c0.k-HorizontalStroke--modifier--tertiary {
+  width: 1.875rem;
+  height: 0.25rem;
+}
+
+.c0.k-HorizontalStroke--modifier--quaternary {
+  width: 1.875rem;
+  height: 0.25rem;
+}
+
+.c0.k-HorizontalStroke--modifier--quinary {
+  width: 1.875rem;
+  height: 0.25rem;
+}
+
+.c0.k-HorizontalStroke--modifier--senary {
+  width: 0;
+  height: 0;
+}
+
+.c0.k-HorizontalStroke--modifier--septenary {
+  width: 0;
+  height: 0;
+}
+
+@media (min-width:40rem) {
+  .c0.k-HorizontalStroke--modifier--primary {
+    width: 3.125rem;
+    height: 0.375rem;
+  }
+
+  .c0.k-HorizontalStroke--modifier--secondary {
+    width: 2.5rem;
+    height: 0.375rem;
+  }
+
+  .c0.k-HorizontalStroke--modifier--tertiary {
+    width: 1.875rem;
+    height: 0.25rem;
+  }
+
+  .c0.k-HorizontalStroke--modifier--quaternary {
+    width: 1.875rem;
+    height: 0.25rem;
+  }
+
+  .c0.k-HorizontalStroke--modifier--quinary {
+    width: 1.875rem;
+    height: 0.25rem;
+  }
+
+  .c0.k-HorizontalStroke--modifier--senary {
+    width: 0;
+    height: 0;
+  }
+
+  .c0.k-HorizontalStroke--modifier--septenary {
+    width: 0;
+    height: 0;
+  }
+}
+
+@media (min-width:67.5rem) {
+  .c0.k-HorizontalStroke--modifier--primary {
+    width: 3.125rem;
+    height: 0.375rem;
+  }
+
+  .c0.k-HorizontalStroke--modifier--secondary {
+    width: 3.125rem;
+    height: 0.375rem;
+  }
+
+  .c0.k-HorizontalStroke--modifier--tertiary {
+    width: 2.5rem;
+    height: 0.375rem;
+  }
+
+  .c0.k-HorizontalStroke--modifier--quaternary {
+    width: 1.875rem;
+    height: 0.25rem;
+  }
+
+  .c0.k-HorizontalStroke--modifier--quinary {
+    width: 0;
+    height: 0;
+  }
+
+  .c0.k-HorizontalStroke--modifier--senary {
+    width: 1.875rem;
+    height: 0.25rem;
+  }
+
+  .c0.k-HorizontalStroke--modifier--septenary {
+    width: 0;
+    height: 0;
+  }
+}
+
+<div
+  className="c0 k-HorizontalStroke k-HorizontalStroke--size--default"
+  color="#222"
+  style={
+    Object {
+      "height": undefined,
+      "width": "100%",
+    }
+  }
+/>
+`;
+
 exports[`<HorizontalStroke /> with width and height via \`customSize\` matches with snapshot 1`] = `
 .c0 {
   border: none;

--- a/assets/javascripts/kitten/components/layout/horizontal-stroke/index.js
+++ b/assets/javascripts/kitten/components/layout/horizontal-stroke/index.js
@@ -107,8 +107,8 @@ HorizontalStroke.propTypes = {
     'septenary',
   ]),
   customSize: PropTypes.shape({
-    width: PropTypes.number,
-    height: PropTypes.number,
+    width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   }),
   color: PropTypes.string,
 }

--- a/assets/javascripts/kitten/components/layout/horizontal-stroke/test.js
+++ b/assets/javascripts/kitten/components/layout/horizontal-stroke/test.js
@@ -94,6 +94,18 @@ describe('<HorizontalStroke />', () => {
     })
   })
 
+  describe('with string type width via `customSize`', () => {
+    beforeEach(() => {
+      component = renderer
+        .create(<HorizontalStroke customSize={{ width: '100%' }} />)
+        .toJSON()
+    })
+
+    it('matches with snapshot', () => {
+      expect(component).toMatchSnapshot()
+    })
+  })
+
   describe('with width and height via `customSize`', () => {
     beforeEach(() => {
       component = renderer


### PR DESCRIPTION
Closes #.

Screenshot:

TODO:

- [x] Tests
- [x] Changelog
- [x] A11Y
- [x] Stories / Docs
- [ ] BrowserStack
- [ ] New component added to `assets/javascripts/kitten/index.js`
