### PR TITLE
[RewardCard] Return `className` prop transmission to `RewardCard`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
-- Fix: Return ability to add `className` to `RewardCard`.
+- Feature: Add `className` prop propagation to `RewardCard`.
 
 ## [2.108.0] - 2020-01-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Return ability to add `className` to `RewardCard`.
+
 ## [2.108.0] - 2020-01-11
 
 Features:

--- a/assets/javascripts/kitten/components/cards/reward-card/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/cards/reward-card/__snapshots__/test.js.snap
@@ -93,7 +93,7 @@ exports[`<RewardCard /> with DiamondBadge matches with snapshot 1`] = `
 
 exports[`<RewardCard /> with all props matches with snapshot 1`] = `
 <div
-  className="sc-bZQynM htIJZx k-RewardCard"
+  className="sc-bZQynM htIJZx k-RewardCard customClassName"
 >
   <div
     className="k-RewardCard__cardRow"

--- a/assets/javascripts/kitten/components/cards/reward-card/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/cards/reward-card/__snapshots__/test.js.snap
@@ -258,7 +258,7 @@ exports[`<RewardCard /> with all props matches with snapshot 1`] = `
 
 exports[`<RewardCard /> with legacy props matches with snapshot 1`] = `
 <div
-  className="sc-bwzfXH bCeqqR k-LegacyRewardCard"
+  className="sc-bwzfXH bCeqqR k-LegacyRewardCard customClassName"
   disabled={false}
 >
   <div

--- a/assets/javascripts/kitten/components/cards/reward-card/index.js
+++ b/assets/javascripts/kitten/components/cards/reward-card/index.js
@@ -19,12 +19,13 @@ export const RewardCard = ({
   children,
   withoutBorder,
   disabled,
+  className,
   ...others
 }) => (
   <>
     {children ? (
       <StyledRewardCard
-        className={classNames('k-RewardCard', {
+        className={classNames('k-RewardCard', className, {
           'k-rewardCard--withoutBorder': withoutBorder,
           'k-RewardCard--isDisabled': disabled,
         })}

--- a/assets/javascripts/kitten/components/cards/reward-card/index.js
+++ b/assets/javascripts/kitten/components/cards/reward-card/index.js
@@ -19,17 +19,16 @@ export const RewardCard = ({
   children,
   withoutBorder,
   disabled,
-  className,
   ...others
 }) => (
   <>
     {children ? (
       <StyledRewardCard
-        className={classNames('k-RewardCard', className, {
+        {...others}
+        className={classNames('k-RewardCard', others.className, {
           'k-rewardCard--withoutBorder': withoutBorder,
           'k-RewardCard--isDisabled': disabled,
         })}
-        {...others}
       >
         {children}
       </StyledRewardCard>

--- a/assets/javascripts/kitten/components/cards/reward-card/legacy/reward-card-container.js
+++ b/assets/javascripts/kitten/components/cards/reward-card/legacy/reward-card-container.js
@@ -113,12 +113,12 @@ class LegacyRewardCardContainerBase extends Component {
     return (
       <Deprecated warningMessage="Please use RewardCard sub-component to make your composition. You can check some examples on https://kisskissbankbank.github.io/../../../">
         <StyledLegacyRewardCard
+          {...others}
           className={classNames('k-LegacyRewardCard', this.props.className, {
             'k-LegacyRewardCard--tinyVersion': this.isTinyVersion(),
             'k-LegacyRewardCard--sOrLessVersion': this.isSOrLessVersion(),
             'k-LegacyRewardCard--isDisabled': isDisabled,
           })}
-          {...others}
         >
           <Marger
             bottom={this.isSOrLessVersion() ? 0 : 4}

--- a/assets/javascripts/kitten/components/cards/reward-card/test.js
+++ b/assets/javascripts/kitten/components/cards/reward-card/test.js
@@ -195,6 +195,7 @@ describe('<RewardCard />', () => {
       const component = renderer
         .create(
           <RewardCard
+            className="customClassName"
             titleAmount="Custom title amount"
             imageProps={{
               src: '#image',

--- a/assets/javascripts/kitten/components/cards/reward-card/test.js
+++ b/assets/javascripts/kitten/components/cards/reward-card/test.js
@@ -49,7 +49,7 @@ describe('<RewardCard />', () => {
       window.matchMedia = createMockMediaMatcher(false)
       const component = renderer
         .create(
-          <RewardCard>
+          <RewardCard className="customClassName">
             <RewardCard.Row>
               <RewardCard.RowContent>
                 <RewardCard.StarredBadge>


### PR DESCRIPTION
Closes #.

Screenshot:


TODO:

- [x] Tests
- [x] Changelog
- [x] A11Y
- [x] Stories / Docs
- [x] BrowserStack
- [ ] New component added to `assets/javascripts/kitten/index.js`
