### PR TITLE
[DropdownSelectWithInput] mobile style fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Feature: Add `hideIconOnMobile` prop on `DropdownSelectWithInput`.
+- Fix: `DropdownSelectWithInput` mobile style fixes.
+
 ## [2.111.0] - 2020-01-15
 
 Feature:

--- a/assets/javascripts/kitten/components/form/dropdown-phone-select/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/form/dropdown-phone-select/__snapshots__/test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<DropdownPhoneSelect /> should match its snapshot with props 1`] = `
 <div
-  className="sc-bdVaJa jLzFta k-Form-DropdownSelectWithInput k-Form-DropdownSelectWithInput--isOpen"
+  className="sc-bdVaJa ixOUWP k-Form-DropdownSelectWithInput k-Form-DropdownSelectWithInput--isOpen"
   style={
     Object {
       "--menu-z-index": 1000,

--- a/assets/javascripts/kitten/components/form/dropdown-select-with-input/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/form/dropdown-select-with-input/__snapshots__/test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<DropdownSelectWithInput /> should match its snapshot with props 1`] = `
 <div
-  className="sc-bdVaJa jLzFta k-Form-DropdownSelectWithInput k-Form-DropdownSelectWithInput--isOpen"
+  className="sc-bdVaJa ixOUWP k-Form-DropdownSelectWithInput k-Form-DropdownSelectWithInput--isOpen"
   style={
     Object {
       "--menu-z-index": 1000,

--- a/assets/javascripts/kitten/components/form/dropdown-select-with-input/dropdown-select.stories.js
+++ b/assets/javascripts/kitten/components/form/dropdown-select-with-input/dropdown-select.stories.js
@@ -70,6 +70,7 @@ export const Default = () => {
           }}
           resetOnBackspace={boolean('resetOnBackspace', false)}
           highlightOptionBox={boolean('highlightOptionBox', true)}
+          hideIconOnMobile={boolean('hideIconOnMobile', false)}
         />
         <p>
           Integer posuere erat a ante venenatis dapibus posuere velit aliquet.
@@ -109,6 +110,7 @@ export const DeactivatedDropdown = () => {
           deactivateDropdown
           className="k-u-margin-bottom-triple"
           menuZIndex={number('menuZIndex', 1000)}
+          hideIconOnMobile={boolean('hideIconOnMobile', false)}
         />
         <DropdownSelectWithInput
           id={text('id', 'dropdown-select')}
@@ -124,6 +126,7 @@ export const DeactivatedDropdown = () => {
           deactivateDropdown
           className="k-u-margin-bottom-triple"
           menuZIndex={number('menuZIndex', 1000)}
+          hideIconOnMobile={boolean('hideIconOnMobile', false)}
         />
         <DropdownSelectWithInput
           id={text('id', 'dropdown-select')}
@@ -139,6 +142,7 @@ export const DeactivatedDropdown = () => {
           deactivateDropdown
           className="k-u-margin-bottom-triple"
           menuZIndex={number('menuZIndex', 1000)}
+          hideIconOnMobile={boolean('hideIconOnMobile', false)}
         />
       </GridCol>
     </Grid>

--- a/assets/javascripts/kitten/components/form/dropdown-select-with-input/index.js
+++ b/assets/javascripts/kitten/components/form/dropdown-select-with-input/index.js
@@ -68,8 +68,10 @@ const StyledDropdownSelectWithInput = styled.div`
     ${TYPOGRAPHY.fontStyles.light}
     color: ${COLORS.font1};
     margin: 0 ${pxToRem(15)} 0 ${pxToRem(40)};
+    font-size: ${pxToRem(-2)};
 
     @media (min-width: ${ScreenConfig.S.min}px) {
+      font-size: ${pxToRem(-1)};
       margin-left: ${pxToRem(60)};
     }
   }
@@ -77,8 +79,13 @@ const StyledDropdownSelectWithInput = styled.div`
   .k-Form-DropdownSelectWithInput__content--selectedItem {
     background: ${COLORS.primary5};
     border-radius: ${pxToRem(4)};
-    padding: 0 ${pxToRem(15)};
-    height: ${pxToRem(46)};
+    padding: 0 ${pxToRem(10)};
+    height: ${pxToRem(40)};
+
+    @media (min-width: ${ScreenConfig.S.min}px) {
+      padding: 0 ${pxToRem(15)};
+      height: ${pxToRem(46)};
+    }
   }
 
   .k-Form-DropdownSelectWithInput__placeholder {
@@ -87,7 +94,7 @@ const StyledDropdownSelectWithInput = styled.div`
   }
 
   .k-Form-DropdownSelectWithInput__content__icon {
-    margin-right: ${pxToRem(15)};
+    margin-right: ${pxToRem(10)};
     display: flex;
     align-items: center;
 
@@ -103,7 +110,20 @@ const StyledDropdownSelectWithInput = styled.div`
     svg[stroke], svg [stroke] {
       stroke: currentColor;
     }
+
+    @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
+      margin-right: ${pxToRem(15)};
+    }
   }
+
+  &.k-Form-DropdownSelectWithInput--hideIconOnMobile {
+    @media (max-width: ${pxToRem(ScreenConfig.XS.max)}) {
+      .k-Form-DropdownSelectWithInput__content__icon {
+        display: none;
+      }
+    }
+  }
+
 
   .k-Form-DropdownSelectWithInput__button__arrowBox {
     position: absolute;
@@ -144,12 +164,16 @@ const StyledDropdownSelectWithInput = styled.div`
   .k-Form-DropdownSelectWithInput__input {
     display: none;
     ${TYPOGRAPHY.fontStyles.light}
+    font-size: ${stepToRem(-1)};
     color: ${COLORS.font1};
-    font-size: ${stepToRem(0)};
     appearance: none;
     padding: 0;
     border: none;
     background-color: transparent;
+
+    @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
+      font-size: ${stepToRem(0)};
+    }
   }
 
   .k-Form-DropdownSelectWithInput__list {
@@ -210,7 +234,7 @@ const StyledDropdownSelectWithInput = styled.div`
   }
 
   .k-Form-DropdownSelectWithInput__item__icon {
-    margin-right: ${pxToRem(20)};
+    margin-right: ${pxToRem(10)};
     min-width: ${pxToRem(20)};
     display: flex;
     align-items: center;
@@ -219,6 +243,10 @@ const StyledDropdownSelectWithInput = styled.div`
     svg {
       display: block;
       max-width:100%;
+    }
+
+    @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
+      margin-right: ${pxToRem(20)};
     }
   }
 
@@ -328,6 +356,7 @@ export const DropdownSelectWithInput = ({
   deactivateDropdown,
   className,
   menuZIndex,
+  hideIconOnMobile,
 }) => {
   const getA11ySelectionMessage = ({ itemToString, selectedItem }) => {
     return a11ySelectionMessageDisplayer(itemToString(selectedItem))
@@ -410,6 +439,7 @@ export const DropdownSelectWithInput = ({
         'k-Form-DropdownSelectWithInput--valid': valid,
         'k-Form-DropdownSelectWithInput--disabled': disabled,
         'k-Form-DropdownSelectWithInput--noDropdown': deactivateDropdown,
+        'k-Form-DropdownSelectWithInput--hideIconOnMobile': hideIconOnMobile,
       })}
       style={{ '--menu-z-index': menuZIndex }}
     >
@@ -560,6 +590,7 @@ DropdownSelectWithInput.defaultProps = {
   openOnLoad: false,
   deactivateDropdown: false,
   menuZIndex: 1000,
+  hideIconOnMobile: false,
 }
 
 DropdownSelectWithInput.propTypes = {
@@ -582,4 +613,5 @@ DropdownSelectWithInput.propTypes = {
   openOnLoad: PropTypes.bool,
   deactivateDropdown: PropTypes.bool,
   menuZIndex: PropTypes.number,
+  hideIconOnMobile: PropTypes.bool,
 }


### PR DESCRIPTION
Closes #.

Vercel link:

- https://kitten-git-dropdown-select-with-input-fix-modal-styles.kisskissbankbank.vercel.app/?path=/story/form-dropdownselectwithinput--default
- https://kitten-git-dropdown-select-with-input-fix-modal-styles.kisskissbankbank.vercel.app/?path=/story/form-dropdownselectwithinput--deactivated-dropdown

Screenshot:


TODO:

- [x] Tests
- [x] Changelog
- [x] A11Y
- [x] Stories / Docs
- [ ] BrowserStack (IE11, Chrome & Firefox on Windows 10)
- [ ] New component added to `assets/javascripts/kitten/index.js`
