### PR TITLE
[VerticalStepper] No onClick handler when disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: do not apply focus styles on `VerticalStepper` when `disabled`
+
 ## [2.112.0] - 2020-01-18
 
 Feature:

--- a/assets/javascripts/kitten/components/steppers/vertical-stepper/components/step.js
+++ b/assets/javascripts/kitten/components/steppers/vertical-stepper/components/step.js
@@ -18,6 +18,7 @@ export const Step = ({
   className,
   variant,
   bridge,
+  onClick,
   ...other
 }) => {
   return (
@@ -29,6 +30,7 @@ export const Step = ({
     >
       <StyledLink
         as={other.href && !disabled ? 'a' : 'span'}
+        onClick={disabled ? null : onClick}
         {...other}
         variant={variant}
       >


### PR DESCRIPTION
On ne propage la prop `onClick` si la step est `disabled`. Ça évite d'appliquer des styles non voulu.