### PR TITLE
[Combobox] Filter on label instead of value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [unreleased]
 
 - Fix: do not apply focus styles on `VerticalStepper` when `disabled`
+- Fix: `Combobox` filter on `label` (instead of `value`)
 
 ## [2.112.0] - 2020-01-18
 

--- a/assets/javascripts/kitten/components/form/dropdown-select/combobox.js
+++ b/assets/javascripts/kitten/components/form/dropdown-select/combobox.js
@@ -2,11 +2,11 @@ import React, { useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
 import { useCombobox } from 'downshift'
 import COLORS from '../../../constants/colors-config'
-import { Label } from '../../../components/form/label'
+import { Label } from '../label'
 import classNames from 'classnames'
-import { WarningCircleIcon } from '../../../components/icons/warning-circle-icon'
-import { CheckedCircleIcon } from '../../../components/icons/checked-circle-icon'
-import { ArrowIcon } from '../../../components/icons/arrow-icon'
+import { WarningCircleIcon } from '../../icons/warning-circle-icon'
+import { CheckedCircleIcon } from '../../icons/checked-circle-icon'
+import { ArrowIcon } from '../../icons/arrow-icon'
 import find from 'lodash/fp/find'
 import flow from 'lodash/fp/flow'
 import uniqBy from 'lodash/fp/uniqBy'
@@ -59,7 +59,7 @@ export const DropdownCombobox = ({
   const onInputValueChange = changes => {
     const newItemsList = flow(
       filter(item => {
-        return item.value
+        return item.label
           .toLowerCase()
           .startsWith(changes.inputValue.toLowerCase())
       }),

--- a/assets/javascripts/kitten/components/form/dropdown-select/combobox.js
+++ b/assets/javascripts/kitten/components/form/dropdown-select/combobox.js
@@ -12,6 +12,7 @@ import flow from 'lodash/fp/flow'
 import uniqBy from 'lodash/fp/uniqBy'
 import filter from 'lodash/fp/filter'
 import isEmpty from 'lodash/isEmpty'
+import isObject from 'lodash/fp/isObject'
 import { StyledDropdown } from './styles'
 
 export const DropdownCombobox = ({
@@ -59,9 +60,10 @@ export const DropdownCombobox = ({
   const onInputValueChange = changes => {
     const newItemsList = flow(
       filter(item => {
-        return item.label
-          .toLowerCase()
-          .startsWith(changes.inputValue.toLowerCase())
+        const label = isObject(item.label)
+          ? item.searchableLabel || ''
+          : item.label
+        return label.toLowerCase().startsWith(changes.inputValue.toLowerCase())
       }),
       !isEmpty(changes.inputValue) && uniqLabelOnSearch
         ? uniqBy('label')

--- a/assets/javascripts/kitten/components/form/dropdown-select/combobox.js
+++ b/assets/javascripts/kitten/components/form/dropdown-select/combobox.js
@@ -15,6 +15,12 @@ import isEmpty from 'lodash/isEmpty'
 import isObject from 'lodash/fp/isObject'
 import { StyledDropdown } from './styles'
 
+const getLabelToFilter = item => {
+  if (item.searchableLabel) return item.searchableLabel
+  if (isObject(item.label)) return item.searchableLabel || ''
+  return item.label
+}
+
 export const DropdownCombobox = ({
   labelText,
   comboboxButtonLabelText,
@@ -60,9 +66,7 @@ export const DropdownCombobox = ({
   const onInputValueChange = changes => {
     const newItemsList = flow(
       filter(item => {
-        const label = isObject(item.label)
-          ? item.searchableLabel || ''
-          : item.label
+        const label = getLabelToFilter(item)
         return label.toLowerCase().startsWith(changes.inputValue.toLowerCase())
       }),
       !isEmpty(changes.inputValue) && uniqLabelOnSearch

--- a/assets/javascripts/kitten/components/form/dropdown-select/combobox.js
+++ b/assets/javascripts/kitten/components/form/dropdown-select/combobox.js
@@ -16,8 +16,9 @@ import isObject from 'lodash/fp/isObject'
 import { StyledDropdown } from './styles'
 
 const getLabelToFilter = item => {
-  if (item.searchableLabel) return item.searchableLabel
-  if (isObject(item.label)) return item.searchableLabel || ''
+  if (item.searchableLabel || isObject(item.label)) {
+    return item.searchableLabel || ''
+  }
   return item.label || ''
 }
 

--- a/assets/javascripts/kitten/components/form/dropdown-select/combobox.js
+++ b/assets/javascripts/kitten/components/form/dropdown-select/combobox.js
@@ -18,7 +18,7 @@ import { StyledDropdown } from './styles'
 const getLabelToFilter = item => {
   if (item.searchableLabel) return item.searchableLabel
   if (isObject(item.label)) return item.searchableLabel || ''
-  return item.label
+  return item.label || ''
 }
 
 export const DropdownCombobox = ({

--- a/assets/javascripts/kitten/components/form/dropdown-select/dropdown-select.stories.js
+++ b/assets/javascripts/kitten/components/form/dropdown-select/dropdown-select.stories.js
@@ -2,6 +2,8 @@ import React, { useState } from 'react'
 import { text, boolean, select, number } from '@storybook/addon-knobs'
 import { DropdownSelect } from './index'
 import { Grid, GridCol } from '../../../components/grid/grid'
+import { ArrowIcon } from '../../icons/arrow-icon'
+import { Text } from '../../typography/text'
 
 export default {
   component: DropdownSelect,
@@ -98,6 +100,59 @@ export const WithDuplicateValue = () => {
             { value: 'france', label: 'France' },
             { value: 'france', label: 'France' },
             { value: 'irlande', label: 'Irlande' },
+          ]}
+          size={select(
+            'size',
+            ['tiny', 'normal', 'big', 'huge', 'giant'],
+            'normal',
+          )}
+          variant={select('variant', ['andromeda', 'orion'], 'andromeda')}
+          defaultSelectedValue="focus"
+          comboboxButtonLabelText={text('Buton aria-label', 'label')}
+          noResultText={text('No results text', 'No results')}
+          uniqLabelOnSearch={boolean('uniqLabelOnSearch', false)}
+          menuZIndex={number('menuZIndex', 1000)}
+        />
+      </GridCol>
+    </Grid>
+  )
+}
+
+export const WithComponentsForLabel = () => {
+  return (
+    <Grid>
+      <GridCol offset="1" col="8">
+        <DropdownSelect
+          id={text('id', 'dropdown-select')}
+          error={boolean('error', false)}
+          valid={boolean('valid', false)}
+          disabled={boolean('disabled', false)}
+          hideLabel={boolean('hide label?', false)}
+          combobox={true}
+          labelText={text('LabelText', 'label')}
+          options={[
+            {
+              value: 'France',
+              searchableLabel: 'France',
+              label: (
+                <>
+                  <ArrowIcon direction="left" />
+                  <Text weight="bold">Un titre de la France</Text>
+                  Une explication du label
+                </>
+              ),
+            },
+            {
+              value: 'Espagne',
+              searchableLabel: 'Espagne',
+              label: (
+                <>
+                  <ArrowIcon direction="left" />
+                  <Text weight="bold">Un titre de l'espagne</Text>
+                  Une explication du label
+                </>
+              ),
+            },
           ]}
           size={select(
             'size',

--- a/assets/javascripts/kitten/components/form/dropdown-select/dropdown-select.stories.js
+++ b/assets/javascripts/kitten/components/form/dropdown-select/dropdown-select.stories.js
@@ -148,7 +148,7 @@ export const WithComponentsForLabel = () => {
               label: (
                 <>
                   <ArrowIcon direction="left" />
-                  <Text weight="bold">Un titre de l'espagne</Text>
+                  <Text weight="bold">Un titre de l'Espagne</Text>
                   Une explication du label
                 </>
               ),


### PR DESCRIPTION
Je change le système de filtrage pour qu'on prenne en compte le `label` (visible par l'user) et non la `value` (utile pour l'API).
Ça provoquait un bug côté KissKiss pour les pays qui sont du format `{ value : 'FR', label: 'France'}`.
A partir du moment où l'on tapait 'Fra', on n'avait plus rien en résultat car `'FR'.startsWith('Fra')`renvoie `false`.

Je pense que c'est juste une petite erreur lors de la création du composant, sur les *stories* ça ne posait pas de problèmes car nos `values` === `label`.

Je ne vois pas dans quels cas d'usage on voudrait filtrer par les `values` mais je me trompe peut-être de diagnostique. @joachimesque, @LanF3usT vous en pensez quoi ?