### PR TITLE
[Carousel] Fix spacing calculations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [unreleased]
 
 - Fix: Fix Carousel margin and padding calculations.
+- Feature: Add `pageClickText` prop to Carousel for page click action.
 
 ## [2.114.0] - 2020-01-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Fix Carousel margin and padding calculations.
+
 ## [2.114.0] - 2020-01-29
 
 Features:
@@ -26,8 +28,8 @@ Features:
 
 Fixes:
 
-- do not apply focus styles on `VerticalStepper` when `disabled`
-- `Combobox` filter on `label` (instead of `value`)
+- Stop applying focus styles on `VerticalStepper` when `disabled`.
+- `Combobox` filter on `label` (instead of `value`).
 
 ## [2.112.0] - 2020-01-18
 
@@ -51,7 +53,7 @@ Feature:
 Fixes:
 
 - Add button types on `Carousel` navigation.
-- Fix: Remove scrollbars on `Carousel` on Firefox.
+- Remove scrollbars on `Carousel` on Firefox.
 
 ## [2.110.0] - 2020-01-13
 

--- a/assets/javascripts/kitten/components/carousel/carousel/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/carousel/carousel/__snapshots__/test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<Carousel /> by default on desktop matches with snapshot 1`] = `
 <div
-  className="sc-htpNat dnzoib k-Carousel"
+  className="sc-htpNat hDttjx k-Carousel"
 >
   <div
     className="k-Carousel__inner"
@@ -13,7 +13,6 @@ exports[`<Carousel /> by default on desktop matches with snapshot 1`] = `
   >
     <div
       className="k-Carousel__inner__pageContainer k-Carousel__inner__pageContainer--isActivePage k-Carousel__inner__pageContainer--hasBeenViewed"
-      onClick={[Function]}
     >
       <div
         className="k-Carousel__page k-Carousel__page--isActivePage k-Carousel__page--hasBeenViewed"
@@ -78,7 +77,7 @@ exports[`<Carousel /> by default on desktop matches with snapshot 1`] = `
 
 exports[`<Carousel /> by default on mobile matches with snapshot 1`] = `
 <div
-  className="sc-htpNat dnzoib k-Carousel"
+  className="sc-htpNat hDttjx k-Carousel"
 >
   <div
     className="k-Carousel__inner"
@@ -89,7 +88,6 @@ exports[`<Carousel /> by default on mobile matches with snapshot 1`] = `
   >
     <div
       className="k-Carousel__inner__pageContainer custom-class k-Carousel__inner__pageContainer--isActivePage k-Carousel__inner__pageContainer--hasBeenViewed"
-      onClick={[Function]}
     >
       <div
         className="k-Carousel__page k-Carousel__page--isActivePage k-Carousel__page--hasBeenViewed"
@@ -156,7 +154,7 @@ exports[`<Carousel /> empty carousel matches with snapshot 1`] = `null`;
 
 exports[`<Carousel /> legacy carousel on desktop matches with snapshot 1`] = `
 <div
-  className="sc-htpNat iLKiCQ k-Carousel k-LegacyCarousel"
+  className="sc-htpNat SbxkW k-Carousel k-LegacyCarousel"
 >
   <div
     className="k-Grid"
@@ -173,7 +171,6 @@ exports[`<Carousel /> legacy carousel on desktop matches with snapshot 1`] = `
       >
         <div
           className="k-Carousel__inner__pageContainer k-Carousel__inner__pageContainer--isActivePage k-Carousel__inner__pageContainer--hasBeenViewed"
-          onClick={[Function]}
         >
           <div
             className="k-Carousel__page k-Carousel__page--isActivePage k-Carousel__page--hasBeenViewed"
@@ -243,7 +240,7 @@ exports[`<Carousel /> legacy carousel on desktop matches with snapshot 1`] = `
 
 exports[`<Carousel /> legacy carousel on desktop with withoutLeftOffset={true} matches with snapshot 1`] = `
 <div
-  className="sc-htpNat iLKiCQ k-Carousel k-LegacyCarousel"
+  className="sc-htpNat SbxkW k-Carousel k-LegacyCarousel"
 >
   <div
     className="k-Grid"
@@ -260,7 +257,6 @@ exports[`<Carousel /> legacy carousel on desktop with withoutLeftOffset={true} m
       >
         <div
           className="k-Carousel__inner__pageContainer k-Carousel__inner__pageContainer--isActivePage k-Carousel__inner__pageContainer--hasBeenViewed"
-          onClick={[Function]}
         >
           <div
             className="k-Carousel__page k-Carousel__page--isActivePage k-Carousel__page--hasBeenViewed"
@@ -330,7 +326,7 @@ exports[`<Carousel /> legacy carousel on desktop with withoutLeftOffset={true} m
 
 exports[`<Carousel /> legacy carousel on mobile matches with snapshot 1`] = `
 <div
-  className="sc-htpNat iLKiCQ k-Carousel k-LegacyCarousel"
+  className="sc-htpNat SbxkW k-Carousel k-LegacyCarousel"
 >
   <div
     className="k-Grid"
@@ -347,7 +343,6 @@ exports[`<Carousel /> legacy carousel on mobile matches with snapshot 1`] = `
       >
         <div
           className="k-Carousel__inner__pageContainer k-Carousel__inner__pageContainer--isActivePage k-Carousel__inner__pageContainer--hasBeenViewed"
-          onClick={[Function]}
         >
           <div
             className="k-Carousel__page k-Carousel__page--isActivePage k-Carousel__page--hasBeenViewed"
@@ -417,7 +412,7 @@ exports[`<Carousel /> legacy carousel on mobile matches with snapshot 1`] = `
 
 exports[`<Carousel /> with exportVisibilityProps prop matches with snapshot 1`] = `
 <div
-  className="sc-htpNat dnzoib k-Carousel"
+  className="sc-htpNat hDttjx k-Carousel"
 >
   <div
     className="k-Carousel__inner"
@@ -428,7 +423,6 @@ exports[`<Carousel /> with exportVisibilityProps prop matches with snapshot 1`] 
   >
     <div
       className="k-Carousel__inner__pageContainer k-Carousel__inner__pageContainer--isActivePage k-Carousel__inner__pageContainer--hasBeenViewed"
-      onClick={[Function]}
     >
       <div
         className="k-Carousel__page k-Carousel__page--isActivePage k-Carousel__page--hasBeenViewed"
@@ -493,7 +487,7 @@ exports[`<Carousel /> with exportVisibilityProps prop matches with snapshot 1`] 
 
 exports[`<Carousel /> with itemsPerPage prop matches with snapshot 1`] = `
 <div
-  className="sc-htpNat hPhwtq k-Carousel"
+  className="sc-htpNat vdKcn k-Carousel"
 >
   <div
     className="k-Carousel__inner"
@@ -504,7 +498,6 @@ exports[`<Carousel /> with itemsPerPage prop matches with snapshot 1`] = `
   >
     <div
       className="k-Carousel__inner__pageContainer k-Carousel__inner__pageContainer--isActivePage k-Carousel__inner__pageContainer--hasBeenViewed"
-      onClick={[Function]}
     >
       <div
         className="k-Carousel__page k-Carousel__page--isActivePage k-Carousel__page--hasBeenViewed"
@@ -575,7 +568,7 @@ exports[`<Carousel /> with itemsPerPage prop matches with snapshot 1`] = `
 
 exports[`<Carousel /> with loop prop on desktop matches with snapshot 1`] = `
 <div
-  className="sc-htpNat dnzoib k-Carousel"
+  className="sc-htpNat hDttjx k-Carousel"
 >
   <div
     className="k-Carousel__inner"
@@ -586,7 +579,6 @@ exports[`<Carousel /> with loop prop on desktop matches with snapshot 1`] = `
   >
     <div
       className="k-Carousel__inner__pageContainer k-Carousel__inner__pageContainer--isActivePage k-Carousel__inner__pageContainer--hasBeenViewed"
-      onClick={[Function]}
     >
       <div
         className="k-Carousel__page k-Carousel__page--isActivePage k-Carousel__page--hasBeenViewed"

--- a/assets/javascripts/kitten/components/carousel/carousel/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/carousel/carousel/__snapshots__/test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<Carousel /> by default on desktop matches with snapshot 1`] = `
 <div
-  className="sc-htpNat hDttjx k-Carousel"
+  className="sc-htpNat ifYxKX k-Carousel"
 >
   <div
     className="k-Carousel__inner"
@@ -12,7 +12,10 @@ exports[`<Carousel /> by default on desktop matches with snapshot 1`] = `
     onTouchStart={[Function]}
   >
     <div
+      aria-label="Page 1"
       className="k-Carousel__inner__pageContainer k-Carousel__inner__pageContainer--isActivePage k-Carousel__inner__pageContainer--hasBeenViewed"
+      onClick={[Function]}
+      role="button"
     >
       <div
         className="k-Carousel__page k-Carousel__page--isActivePage k-Carousel__page--hasBeenViewed"
@@ -77,7 +80,7 @@ exports[`<Carousel /> by default on desktop matches with snapshot 1`] = `
 
 exports[`<Carousel /> by default on mobile matches with snapshot 1`] = `
 <div
-  className="sc-htpNat hDttjx k-Carousel"
+  className="sc-htpNat ifYxKX k-Carousel"
 >
   <div
     className="k-Carousel__inner"
@@ -87,7 +90,10 @@ exports[`<Carousel /> by default on mobile matches with snapshot 1`] = `
     onTouchStart={[Function]}
   >
     <div
+      aria-label="Page 1"
       className="k-Carousel__inner__pageContainer custom-class k-Carousel__inner__pageContainer--isActivePage k-Carousel__inner__pageContainer--hasBeenViewed"
+      onClick={[Function]}
+      role="button"
     >
       <div
         className="k-Carousel__page k-Carousel__page--isActivePage k-Carousel__page--hasBeenViewed"
@@ -154,7 +160,7 @@ exports[`<Carousel /> empty carousel matches with snapshot 1`] = `null`;
 
 exports[`<Carousel /> legacy carousel on desktop matches with snapshot 1`] = `
 <div
-  className="sc-htpNat SbxkW k-Carousel k-LegacyCarousel"
+  className="sc-htpNat bYZvvZ k-Carousel k-LegacyCarousel"
 >
   <div
     className="k-Grid"
@@ -170,7 +176,10 @@ exports[`<Carousel /> legacy carousel on desktop matches with snapshot 1`] = `
         onTouchStart={[Function]}
       >
         <div
+          aria-label="Page 1"
           className="k-Carousel__inner__pageContainer k-Carousel__inner__pageContainer--isActivePage k-Carousel__inner__pageContainer--hasBeenViewed"
+          onClick={[Function]}
+          role="button"
         >
           <div
             className="k-Carousel__page k-Carousel__page--isActivePage k-Carousel__page--hasBeenViewed"
@@ -240,7 +249,7 @@ exports[`<Carousel /> legacy carousel on desktop matches with snapshot 1`] = `
 
 exports[`<Carousel /> legacy carousel on desktop with withoutLeftOffset={true} matches with snapshot 1`] = `
 <div
-  className="sc-htpNat SbxkW k-Carousel k-LegacyCarousel"
+  className="sc-htpNat bYZvvZ k-Carousel k-LegacyCarousel"
 >
   <div
     className="k-Grid"
@@ -256,7 +265,10 @@ exports[`<Carousel /> legacy carousel on desktop with withoutLeftOffset={true} m
         onTouchStart={[Function]}
       >
         <div
+          aria-label="Page 1"
           className="k-Carousel__inner__pageContainer k-Carousel__inner__pageContainer--isActivePage k-Carousel__inner__pageContainer--hasBeenViewed"
+          onClick={[Function]}
+          role="button"
         >
           <div
             className="k-Carousel__page k-Carousel__page--isActivePage k-Carousel__page--hasBeenViewed"
@@ -326,7 +338,7 @@ exports[`<Carousel /> legacy carousel on desktop with withoutLeftOffset={true} m
 
 exports[`<Carousel /> legacy carousel on mobile matches with snapshot 1`] = `
 <div
-  className="sc-htpNat SbxkW k-Carousel k-LegacyCarousel"
+  className="sc-htpNat bYZvvZ k-Carousel k-LegacyCarousel"
 >
   <div
     className="k-Grid"
@@ -342,7 +354,10 @@ exports[`<Carousel /> legacy carousel on mobile matches with snapshot 1`] = `
         onTouchStart={[Function]}
       >
         <div
+          aria-label="Page 1"
           className="k-Carousel__inner__pageContainer k-Carousel__inner__pageContainer--isActivePage k-Carousel__inner__pageContainer--hasBeenViewed"
+          onClick={[Function]}
+          role="button"
         >
           <div
             className="k-Carousel__page k-Carousel__page--isActivePage k-Carousel__page--hasBeenViewed"
@@ -412,7 +427,7 @@ exports[`<Carousel /> legacy carousel on mobile matches with snapshot 1`] = `
 
 exports[`<Carousel /> with exportVisibilityProps prop matches with snapshot 1`] = `
 <div
-  className="sc-htpNat hDttjx k-Carousel"
+  className="sc-htpNat ifYxKX k-Carousel"
 >
   <div
     className="k-Carousel__inner"
@@ -422,7 +437,10 @@ exports[`<Carousel /> with exportVisibilityProps prop matches with snapshot 1`] 
     onTouchStart={[Function]}
   >
     <div
+      aria-label="Page 1"
       className="k-Carousel__inner__pageContainer k-Carousel__inner__pageContainer--isActivePage k-Carousel__inner__pageContainer--hasBeenViewed"
+      onClick={[Function]}
+      role="button"
     >
       <div
         className="k-Carousel__page k-Carousel__page--isActivePage k-Carousel__page--hasBeenViewed"
@@ -487,7 +505,7 @@ exports[`<Carousel /> with exportVisibilityProps prop matches with snapshot 1`] 
 
 exports[`<Carousel /> with itemsPerPage prop matches with snapshot 1`] = `
 <div
-  className="sc-htpNat vdKcn k-Carousel"
+  className="sc-htpNat kVDNzB k-Carousel"
 >
   <div
     className="k-Carousel__inner"
@@ -497,7 +515,10 @@ exports[`<Carousel /> with itemsPerPage prop matches with snapshot 1`] = `
     onTouchStart={[Function]}
   >
     <div
+      aria-label="Page 1"
       className="k-Carousel__inner__pageContainer k-Carousel__inner__pageContainer--isActivePage k-Carousel__inner__pageContainer--hasBeenViewed"
+      onClick={[Function]}
+      role="button"
     >
       <div
         className="k-Carousel__page k-Carousel__page--isActivePage k-Carousel__page--hasBeenViewed"
@@ -568,7 +589,7 @@ exports[`<Carousel /> with itemsPerPage prop matches with snapshot 1`] = `
 
 exports[`<Carousel /> with loop prop on desktop matches with snapshot 1`] = `
 <div
-  className="sc-htpNat hDttjx k-Carousel"
+  className="sc-htpNat ifYxKX k-Carousel"
 >
   <div
     className="k-Carousel__inner"
@@ -578,7 +599,10 @@ exports[`<Carousel /> with loop prop on desktop matches with snapshot 1`] = `
     onTouchStart={[Function]}
   >
     <div
+      aria-label="Page 1"
       className="k-Carousel__inner__pageContainer k-Carousel__inner__pageContainer--isActivePage k-Carousel__inner__pageContainer--hasBeenViewed"
+      onClick={[Function]}
+      role="button"
     >
       <div
         className="k-Carousel__page k-Carousel__page--isActivePage k-Carousel__page--hasBeenViewed"

--- a/assets/javascripts/kitten/components/carousel/carousel/components/carousel-inner.js
+++ b/assets/javascripts/kitten/components/carousel/carousel/components/carousel-inner.js
@@ -66,7 +66,7 @@ export const CarouselInner = ({
   const carouselInner = useRef(null)
   const previousIndexPageVisible = usePrevious(currentPageIndex)
 
-  let observer
+  let resizeObserver
 
   const onResizeObserve = ([entry]) => {
     const innerWidth = entry.contentRect.width
@@ -74,13 +74,13 @@ export const CarouselInner = ({
   }
 
   useEffect(() => {
-    observer = new ResizeObserver(onResizeObserve)
+    resizeObserver = new ResizeObserver(onResizeObserve)
 
-    return () => observer.disconnect()
+    return () => resizeObserver.disconnect()
   }, [])
 
   useEffect(() => {
-    carouselInner.current && observer.observe(carouselInner.current)
+    carouselInner.current && resizeObserver.observe(carouselInner.current)
   }, [carouselInner])
 
   useEffect(() => {
@@ -133,14 +133,6 @@ export const CarouselInner = ({
     }
   }
 
-  const handlePageClick = index => e => {
-    if (index === currentPageIndex) return
-
-    e.preventDefault()
-    scrollToPage(index)
-    document.activeElement.blur()
-  }
-
   const handleKeyDown = e => {
     if (e.key === 'ArrowRight') {
       goToPage(currentPageIndex + 1)
@@ -165,7 +157,6 @@ export const CarouselInner = ({
         return (
           <div
             key={index}
-            onClick={handlePageClick(index)}
             className={classNames(
               'k-Carousel__inner__pageContainer',
               pagesClassName,

--- a/assets/javascripts/kitten/components/carousel/carousel/components/carousel-inner.js
+++ b/assets/javascripts/kitten/components/carousel/carousel/components/carousel-inner.js
@@ -61,6 +61,7 @@ export const CarouselInner = ({
   onResizeInner,
   pagesClassName,
   viewedPages,
+  pageClickText,
 }) => {
   const [isTouched, setTouchState] = useState(false)
   const carouselInner = useRef(null)
@@ -133,6 +134,14 @@ export const CarouselInner = ({
     }
   }
 
+  const handlePageClick = index => e => {
+    if (index === currentPageIndex) return
+
+    e.preventDefault()
+    scrollToPage(index)
+    document.activeElement.blur()
+  }
+
   const handleKeyDown = e => {
     if (e.key === 'ArrowRight') {
       goToPage(currentPageIndex + 1)
@@ -157,6 +166,9 @@ export const CarouselInner = ({
         return (
           <div
             key={index}
+            role="button"
+            aria-label={pageClickText(index + 1)}
+            onClick={handlePageClick(index)}
             className={classNames(
               'k-Carousel__inner__pageContainer',
               pagesClassName,

--- a/assets/javascripts/kitten/components/carousel/carousel/index.js
+++ b/assets/javascripts/kitten/components/carousel/carousel/index.js
@@ -178,6 +178,7 @@ class CarouselBase extends Component {
       viewportIsMOrLess,
       pagesClassName,
       exportVisibilityProps,
+      pageClickText,
     } = this.props
 
     const { currentPageIndex, numberOfItemsPerPage, numberOfPages } = this.state
@@ -208,6 +209,7 @@ class CarouselBase extends Component {
         onResizeInner={this.onResizeInner}
         pagesClassName={pagesClassName}
         viewedPages={this.viewedPages}
+        pageClickText={pageClickText}
       />
     )
   }
@@ -386,6 +388,9 @@ CarouselBase.defaultProps = {
   },
   prevButtonText: 'Previous items',
   nextButtonText: 'Next items',
+  pageClickText: page => {
+    return `Page ${page}`
+  },
   firstButtonText: 'First items',
   lastButtonText: 'Last items',
   showPageSquares: false,
@@ -417,6 +422,7 @@ CarouselBase.propTypes = {
   }),
   prevButtonText: PropTypes.string,
   nextButtonText: PropTypes.string,
+  pageClickText: PropTypes.func,
   tinyButtons: PropTypes.bool,
   firstButtonText: PropTypes.string,
   lastButtonText: PropTypes.string,

--- a/assets/javascripts/kitten/components/carousel/carousel/index.js
+++ b/assets/javascripts/kitten/components/carousel/carousel/index.js
@@ -14,7 +14,7 @@ import { VisuallyHidden } from '../../../components/accessibility/visually-hidde
 import classNames from 'classnames'
 import { Grid, GridCol } from '../../../components/grid/grid'
 
-import { StyledCarouselContainer } from './styles'
+import { StyledCarouselContainer, OUTLINE_PLUS_OFFSET } from './styles'
 
 const getDataLength = ({ data, children }) => {
   if (!!data) return data.length
@@ -72,10 +72,11 @@ const getMarginBetweenAccordingToViewport = (
   viewportIsXSOrLess,
   viewportIsMOrLess,
 ) => {
-  if (viewportIsXSOrLess) return CONTAINER_PADDING_MOBILE / 2
-  if (viewportIsMOrLess) return CONTAINER_PADDING / 2
+  if (viewportIsXSOrLess)
+    return CONTAINER_PADDING_MOBILE / 2 - OUTLINE_PLUS_OFFSET * 2
+  if (viewportIsMOrLess) return CONTAINER_PADDING / 2 - OUTLINE_PLUS_OFFSET * 2
 
-  return baseItemMarginBetween
+  return baseItemMarginBetween - OUTLINE_PLUS_OFFSET * 2
 }
 
 class CarouselBase extends Component {

--- a/assets/javascripts/kitten/components/carousel/carousel/project-carousel.stories.js
+++ b/assets/javascripts/kitten/components/carousel/carousel/project-carousel.stories.js
@@ -120,6 +120,13 @@ export const Default = () => (
       paginationPosition={object('paginationPosition', paginationPosition)}
       showPageSquares={boolean('showPageSquares', false)}
       loop={boolean('loop', false)}
+      hidePaginationOnMobile={boolean('hidePaginationOnMobile', false)}
+      hidePagination={boolean('hidePagination', false)}
+      showOtherPages={boolean('showOtherPages', false)}
+      preferCompletePaginationOnMobile={boolean(
+        'preferCompletePaginationOnMobile',
+        false,
+      )}
     >
       {data.map(item => (
         <CrowdfundingCard
@@ -161,6 +168,13 @@ export const WithSpecificColNumber = () => (
       paginationPosition={object('paginationPosition', paginationPosition)}
       showPageSquares={boolean('showPageSquares', false)}
       loop={boolean('loop', false)}
+      hidePaginationOnMobile={boolean('hidePaginationOnMobile', false)}
+      hidePagination={boolean('hidePagination', false)}
+      showOtherPages={boolean('showOtherPages', false)}
+      preferCompletePaginationOnMobile={boolean(
+        'preferCompletePaginationOnMobile',
+        false,
+      )}
     >
       {data.map(item => (
         <CrowdfundingCard

--- a/assets/javascripts/kitten/components/carousel/carousel/styles.js
+++ b/assets/javascripts/kitten/components/carousel/carousel/styles.js
@@ -8,6 +8,8 @@ import {
 } from '../../../constants/grid-config'
 import ColorsConfig from '../../../constants/colors-config'
 
+export const OUTLINE_PLUS_OFFSET = 4
+
 // STYLE HELPERS
 
 const flexContainerdirectionStyle = mediaQuery => ({ paginationPosition }) => {
@@ -326,15 +328,17 @@ export const StyledCarouselContainer = styled.div`
     grid-template-columns: repeat(${({ numberOfPages }) =>
       numberOfPages}, 100%);
 
-    grid-gap: ${pxToRem(CONTAINER_PADDING_MOBILE / 2)};
+    grid-gap: ${pxToRem(
+      CONTAINER_PADDING_MOBILE / 2 - OUTLINE_PLUS_OFFSET * 2,
+    )};
 
     @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
-      grid-gap: ${pxToRem(CONTAINER_PADDING / 2)};
+      grid-gap: ${pxToRem(CONTAINER_PADDING / 2 - OUTLINE_PLUS_OFFSET * 2)};
     }
 
     @media (min-width: ${pxToRem(ScreenConfig.L.min)}) {
       grid-gap: ${({ baseItemMarginBetween }) =>
-        pxToRem(baseItemMarginBetween)};
+        pxToRem(baseItemMarginBetween - OUTLINE_PLUS_OFFSET * 2)};
     }
 
     /* Fix bug IE11 ResizeObserver, to trigger a first resize */
@@ -346,7 +350,7 @@ export const StyledCarouselContainer = styled.div`
     -ms-over-flow-style: none;
     /* mandatory to combine scroll with this property on iOS */
     -webkit-overflow-scrolling: touch;
-    scroll-snap-type: mandatory;
+    scroll-snap-type: x mandatory;
     /* Hide scrollbar on Firefox. */
     scrollbar-width: none;
     /* hide scrollbar on Chrome and Safari */
@@ -356,7 +360,7 @@ export const StyledCarouselContainer = styled.div`
 
     .k-Carousel__inner__pageContainer {
       width: 100%;
-      scroll-snap-align: center;
+      scroll-snap-align: start;
 
       &:not(.k-Carousel__inner__pageContainer--isActivePage) {
         cursor: pointer;
@@ -394,20 +398,23 @@ export const StyledCarouselContainer = styled.div`
   }
 
   &.k-Carousel--showOtherPages .k-Carousel__inner {
-    padding: 0 ${pxToRem(CONTAINER_PADDING_MOBILE)};
-    scroll-padding: ${pxToRem(CONTAINER_PADDING_MOBILE)};
+    margin: 0 !important;
+    padding: 0 ${pxToRem(CONTAINER_PADDING_MOBILE - OUTLINE_PLUS_OFFSET)};
+    scroll-padding: ${pxToRem(CONTAINER_PADDING_MOBILE - OUTLINE_PLUS_OFFSET)};
 
     @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
-      padding: 0 ${pxToRem(CONTAINER_PADDING)};
-      scroll-padding: ${pxToRem(CONTAINER_PADDING)};
+      padding: 0 ${pxToRem(CONTAINER_PADDING - OUTLINE_PLUS_OFFSET)};
+      scroll-padding: ${pxToRem(CONTAINER_PADDING - OUTLINE_PLUS_OFFSET)};
     }
 
     .k-Carousel__inner__pageContainer {
       &:last-child {
-        padding-right: ${pxToRem(CONTAINER_PADDING_MOBILE)};
+        padding-right: ${pxToRem(
+          CONTAINER_PADDING_MOBILE - OUTLINE_PLUS_OFFSET,
+        )};
 
         @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
-          padding-right: ${pxToRem(CONTAINER_PADDING)};
+          padding-right: ${pxToRem(CONTAINER_PADDING - OUTLINE_PLUS_OFFSET)};
         }
       }
     }
@@ -420,19 +427,21 @@ export const StyledCarouselContainer = styled.div`
     display: grid;
     grid-template-columns: repeat(${({ numberOfItemsPerPage }) =>
       numberOfItemsPerPage}, 1fr);
-    grid-gap: ${pxToRem(CONTAINER_PADDING_MOBILE / 2)};
+    grid-gap: ${pxToRem(
+      CONTAINER_PADDING_MOBILE / 2 - OUTLINE_PLUS_OFFSET * 2,
+    )};
 
     @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
-      grid-gap: ${pxToRem(CONTAINER_PADDING / 2)};
+      grid-gap: ${pxToRem(CONTAINER_PADDING / 2 - OUTLINE_PLUS_OFFSET * 2)};
     }
     @media (min-width: ${pxToRem(ScreenConfig.L.min)}) {
       grid-gap: ${({ baseItemMarginBetween }) =>
-        pxToRem(baseItemMarginBetween)};
+        pxToRem(baseItemMarginBetween - OUTLINE_PLUS_OFFSET * 2)};
     }
 
     .k-Carousel__page__item {
       overflow: hidden;
-      padding: ${pxToRem(4)};
+      padding: ${pxToRem(OUTLINE_PLUS_OFFSET)};
     }
     .k-Carousel__page__item > a {
       &:focus {

--- a/assets/javascripts/kitten/components/carousel/carousel/styles.js
+++ b/assets/javascripts/kitten/components/carousel/carousel/styles.js
@@ -364,6 +364,10 @@ export const StyledCarouselContainer = styled.div`
 
       &:not(.k-Carousel__inner__pageContainer--isActivePage) {
         cursor: pointer;
+
+        .k-Carousel__page__item > * {
+          pointer-events: none;
+        }
       }
     }
 


### PR DESCRIPTION
Lors de l'ajout d'un `outline` et d'un `outline-offset` à valeur positive sur les cards, il a fallu compenser au niveau des pages (padding positif) et du conteneur intérieur (margins négatifs). Tous les calculs n'avaient pas été bien faits sur les gouttières, ce qui faisait une mauvaise dimension calculée par le JS, et un bug dans Safari Mobile dans certains cas.

Closes #.

Vercel link:

- https://kitten-git-carousel-fix-margin-calculations.kisskissbankbank.vercel.app/?path=/story/carousels-carousel-projectcarousel--default

Screenshot:


TODO:

- [x] Tests
- [x] Changelog
- [x] A11Y
- [x] Stories / Docs
- [ ] BrowserStack (IE11, Chrome & Firefox on Windows 10)
- [ ] New component added to `assets/javascripts/kitten/index.js`
