### PR TITLE
[BackingCard] Add `hover` styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Feature: Add `hover` styles for `BackingCard`.
+- Feature: `line3` color for a light semi dark grey.
+
 ## [2.117.0] - 2020-02-08
 
 Feature:

--- a/assets/javascripts/kitten/components/cards/backing-card/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/cards/backing-card/__snapshots__/test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<BackingCard /> default matches with snapshot 1`] = `
 <article
-  className="sc-bdVaJa iaEUpv k-BackingCard k-BackingCard--hasBorder"
+  className="sc-bdVaJa fcXrzt k-BackingCard k-BackingCard--hasBorder"
 >
   <div
     className="k-BackingCard__gridWrapper"
@@ -22,13 +22,13 @@ exports[`<BackingCard /> default matches with snapshot 1`] = `
 
 exports[`<BackingCard /> with some props matches with snapshot 1`] = `
 <article
-  className="sc-bdVaJa iaEUpv k-BackingCard k-BackingCard--hasBorder"
+  className="sc-bdVaJa fcXrzt k-BackingCard k-BackingCard--hasBorder"
 >
   <div
     className="k-BackingCard__gridWrapper"
   >
     <article
-      className="sc-bdVaJa iaEUpv k-BackingCard k-BackingCard--disabled"
+      className="sc-bdVaJa fcXrzt k-BackingCard k-BackingCard--disabled"
     >
       <div
         className="k-BackingCard__imageWrapper"

--- a/assets/javascripts/kitten/components/cards/backing-card/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/cards/backing-card/__snapshots__/test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<BackingCard /> default matches with snapshot 1`] = `
 <article
-  className="sc-bdVaJa fOmeYC k-BackingCard k-BackingCard--hasBorder"
+  className="sc-bdVaJa hHGRuH k-BackingCard k-BackingCard--hasBorder"
 >
   <div
     className="k-BackingCard__gridWrapper"
@@ -22,7 +22,7 @@ exports[`<BackingCard /> default matches with snapshot 1`] = `
 
 exports[`<BackingCard /> with some props matches with snapshot 1`] = `
 <article
-  className="sc-bdVaJa fOmeYC k-BackingCard k-BackingCard--disabled"
+  className="sc-bdVaJa hHGRuH k-BackingCard k-BackingCard--disabled"
 >
   <div
     className="k-BackingCard__imageWrapper"
@@ -135,8 +135,7 @@ exports[`<BackingCard /> with some props matches with snapshot 1`] = `
         >
           5
         </strong>
-         
-        contributeurs
+         contributeurs
       </li>
       <li
         className="sc-EHOje hGIGkH k-Tag k-Tag--info"
@@ -146,8 +145,7 @@ exports[`<BackingCard /> with some props matches with snapshot 1`] = `
         >
           2/6
         </strong>
-         
-        disponibles
+         disponibles
       </li>
     </ul>
   </div>

--- a/assets/javascripts/kitten/components/cards/backing-card/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/cards/backing-card/__snapshots__/test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<BackingCard /> default matches with snapshot 1`] = `
 <article
-  className="sc-bdVaJa fcXrzt k-BackingCard k-BackingCard--hasBorder"
+  className="sc-bdVaJa dKQvEl k-BackingCard k-BackingCard--hasBorder"
 >
   <div
     className="k-BackingCard__gridWrapper"
@@ -22,13 +22,13 @@ exports[`<BackingCard /> default matches with snapshot 1`] = `
 
 exports[`<BackingCard /> with some props matches with snapshot 1`] = `
 <article
-  className="sc-bdVaJa fcXrzt k-BackingCard k-BackingCard--hasBorder"
+  className="sc-bdVaJa dKQvEl k-BackingCard k-BackingCard--hasBorder"
 >
   <div
     className="k-BackingCard__gridWrapper"
   >
     <article
-      className="sc-bdVaJa fcXrzt k-BackingCard k-BackingCard--disabled"
+      className="sc-bdVaJa dKQvEl k-BackingCard k-BackingCard--disabled"
     >
       <div
         className="k-BackingCard__imageWrapper"

--- a/assets/javascripts/kitten/components/cards/backing-card/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/cards/backing-card/__snapshots__/test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<BackingCard /> default matches with snapshot 1`] = `
 <article
-  className="sc-bdVaJa eeLavE k-BackingCard k-BackingCard--hasBorder"
+  className="sc-bdVaJa iaEUpv k-BackingCard k-BackingCard--hasBorder"
 >
   <div
     className="k-BackingCard__gridWrapper"
@@ -22,13 +22,13 @@ exports[`<BackingCard /> default matches with snapshot 1`] = `
 
 exports[`<BackingCard /> with some props matches with snapshot 1`] = `
 <article
-  className="sc-bdVaJa eeLavE k-BackingCard k-BackingCard--hasBorder"
+  className="sc-bdVaJa iaEUpv k-BackingCard k-BackingCard--hasBorder"
 >
   <div
     className="k-BackingCard__gridWrapper"
   >
     <article
-      className="sc-bdVaJa eeLavE k-BackingCard k-BackingCard--disabled"
+      className="sc-bdVaJa iaEUpv k-BackingCard k-BackingCard--disabled"
     >
       <div
         className="k-BackingCard__imageWrapper"

--- a/assets/javascripts/kitten/components/cards/backing-card/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/cards/backing-card/__snapshots__/test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<BackingCard /> default matches with snapshot 1`] = `
 <article
-  className="sc-bdVaJa dKQvEl k-BackingCard k-BackingCard--hasBorder"
+  className="sc-bdVaJa fOmeYC k-BackingCard k-BackingCard--hasBorder"
 >
   <div
     className="k-BackingCard__gridWrapper"
@@ -22,148 +22,140 @@ exports[`<BackingCard /> default matches with snapshot 1`] = `
 
 exports[`<BackingCard /> with some props matches with snapshot 1`] = `
 <article
-  className="sc-bdVaJa dKQvEl k-BackingCard k-BackingCard--hasBorder"
+  className="sc-bdVaJa fOmeYC k-BackingCard k-BackingCard--disabled"
 >
+  <div
+    className="k-BackingCard__imageWrapper"
+  >
+    <img
+      alt=""
+      src="/kitten.jpg"
+    />
+  </div>
   <div
     className="k-BackingCard__gridWrapper"
   >
-    <article
-      className="sc-bdVaJa dKQvEl k-BackingCard k-BackingCard--disabled"
+    <span
+      className="sc-EHOje hGIGkH k-Tag k-BackingCard__headingTag k-BackingCard__drawer k-Tag--info"
+    >
+      <svg
+        fill="#222"
+        height="13"
+        viewBox="0 0 18 16"
+        width="14"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        
+        <path
+          d="M8.999 0l1.93 5.974c.028.09.112.15.206.15l6.274-.013-5.084 3.68a.216.216 0 0 0-.079.242L14.198 16l-5.072-3.7a.216.216 0 0 0-.255 0L3.801 16l1.953-5.967a.216.216 0 0 0-.079-.243L.591 6.111l6.274.012c.094 0 .178-.06.207-.15L8.999 0z"
+        />
+      </svg>
+      Star reward
+    </span>
+    <div
+      className="k-BackingCard__titleWrapper k-BackingCard__drawer"
+    >
+      <h3
+        className="sc-bwzfXH uTxCW k-u-line-height-1 k-u-size-default k-u-weight-bold k-BackingCard__title k-u-margin-none"
+      >
+        Lorem ipsum dolor sit amet, consectetuer adipiscing eget dolor.
+      </h3>
+    </div>
+    <p
+      className="sc-bwzfXH uTxCW k-u-line-height-1 k-u-weight-bold k-BackingCard__amount k-BackingCard__drawer"
+    >
+      65 €
+    </p>
+    <p
+      className="k-BackingCard__info k-u-size-tiny k-u-line-height-normal k-BackingCard__halfDrawer"
+    >
+      <span
+        className="sc-bwzfXH uTxCW k-u-line-height-normal k-u-size-tiny k-u-weight-regular k-BackingCard__info__legend"
+      >
+        Prix de livraison :
+      </span>
+       
+      <span
+        className="sc-bwzfXH uTxCW k-u-line-height-normal k-u-size-tiny k-u-weight-light k-BackingCard__info__value"
+      >
+        5 € (en France)
+      </span>
+    </p>
+    <p
+      className="k-BackingCard__info k-u-size-tiny k-u-line-height-normal k-BackingCard__halfDrawer"
+    >
+      <span
+        className="sc-bwzfXH uTxCW k-u-line-height-normal k-u-size-tiny k-u-weight-regular k-BackingCard__info__legend"
+      >
+        Livraison estimée :
+      </span>
+       
+      <span
+        className="sc-bwzfXH uTxCW k-u-line-height-normal k-u-size-tiny k-u-weight-light k-BackingCard__info__value"
+      >
+        Janvier 2022
+      </span>
+    </p>
+    <div
+      className="k-BackingCard__descriptionWrapper k-BackingCard__drawer k-BackingCard__drawer--extensible k-BackingCard__descriptionWrapper--truncateText"
     >
       <div
-        className="k-BackingCard__imageWrapper"
+        className="k-BackingCard__description"
       >
-        <img
-          alt=""
-          src="/kitten.jpg"
-        />
+        <p
+          className="k-u-margin-none"
+        >
+          Maecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet adipiscing sem neque sed ipsum.
+        </p>
+        <p
+          className="k-u-margin-none"
+        >
+          Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tell
+        </p>
+        <p
+          className="k-u-margin-none"
+        >
+          Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tell
+        </p>
+        <p
+          className="k-u-margin-none"
+        >
+          Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tell
+        </p>
       </div>
-      <div
-        className="k-BackingCard__gridWrapper"
+    </div>
+    <ul
+      className="k-BackingCard__tagList k-BackingCard__drawer"
+    >
+      <li
+        className="sc-EHOje hGIGkH k-Tag k-Tag--info"
       >
-        <span
-          className="sc-EHOje hGIGkH k-Tag k-BackingCard__headingTag k-BackingCard__drawer k-Tag--info"
+        <strong
+          className="k-u-weight-regular"
         >
-          <svg
-            fill="#222"
-            height="13"
-            viewBox="0 0 18 16"
-            width="14"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            
-            <path
-              d="M8.999 0l1.93 5.974c.028.09.112.15.206.15l6.274-.013-5.084 3.68a.216.216 0 0 0-.079.242L14.198 16l-5.072-3.7a.216.216 0 0 0-.255 0L3.801 16l1.953-5.967a.216.216 0 0 0-.079-.243L.591 6.111l6.274.012c.094 0 .178-.06.207-.15L8.999 0z"
-            />
-          </svg>
-          Star reward
-        </span>
-        <div
-          className="k-BackingCard__titleWrapper k-BackingCard__drawer"
-        >
-          <h3
-            className="sc-bwzfXH uTxCW k-u-line-height-1 k-u-size-default k-u-weight-bold k-BackingCard__title k-u-margin-none"
-          >
-            Lorem ipsum dolor sit amet, consectetuer adipiscing eget dolor.
-          </h3>
-        </div>
-        <p
-          className="sc-bwzfXH uTxCW k-u-line-height-1 k-u-weight-bold k-BackingCard__amount k-BackingCard__drawer"
-        >
-          65 €
-        </p>
-        <p
-          className="k-BackingCard__info k-u-size-tiny k-u-line-height-normal k-BackingCard__halfDrawer"
-        >
-          <span
-            className="sc-bwzfXH uTxCW k-u-line-height-normal k-u-size-tiny k-u-weight-regular k-BackingCard__info__legend"
-          >
-            Prix de livraison :
-          </span>
-           
-          <span
-            className="sc-bwzfXH uTxCW k-u-line-height-normal k-u-size-tiny k-u-weight-light k-BackingCard__info__value"
-          >
-            5 € (en France)
-          </span>
-        </p>
-        <p
-          className="k-BackingCard__info k-u-size-tiny k-u-line-height-normal k-BackingCard__halfDrawer"
-        >
-          <span
-            className="sc-bwzfXH uTxCW k-u-line-height-normal k-u-size-tiny k-u-weight-regular k-BackingCard__info__legend"
-          >
-            Livraison estimée :
-          </span>
-           
-          <span
-            className="sc-bwzfXH uTxCW k-u-line-height-normal k-u-size-tiny k-u-weight-light k-BackingCard__info__value"
-          >
-            Janvier 2022
-          </span>
-        </p>
-        <div
-          className="k-BackingCard__descriptionWrapper k-BackingCard__drawer k-BackingCard__drawer--extensible k-BackingCard__descriptionWrapper--truncateText"
-        >
-          <div
-            className="k-BackingCard__description"
-          >
-            <p
-              className="k-u-margin-none"
-            >
-              Maecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet adipiscing sem neque sed ipsum.
-            </p>
-            <p
-              className="k-u-margin-none"
-            >
-              Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tell
-            </p>
-            <p
-              className="k-u-margin-none"
-            >
-              Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tell
-            </p>
-            <p
-              className="k-u-margin-none"
-            >
-              Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tell
-            </p>
-          </div>
-        </div>
-        <ul
-          className="k-BackingCard__tagList k-BackingCard__drawer"
-        >
-          <li
-            className="sc-EHOje hGIGkH k-Tag k-Tag--info"
-          >
-            <strong
-              className="k-u-weight-regular"
-            >
-              5
-            </strong>
-             
-            contributeurs
-          </li>
-          <li
-            className="sc-EHOje hGIGkH k-Tag k-Tag--info"
-          >
-            <strong
-              className="k-u-weight-regular"
-            >
-              2/6
-            </strong>
-             
-            disponibles
-          </li>
-        </ul>
-      </div>
-      <button
-        className="sc-bxivhb hYUqPP k-BackingCard__button k-BackingCard__drawer"
-        disabled={true}
+          5
+        </strong>
+         
+        contributeurs
+      </li>
+      <li
+        className="sc-EHOje hGIGkH k-Tag k-Tag--info"
       >
-        Je soutiens
-      </button>
-    </article>
+        <strong
+          className="k-u-weight-regular"
+        >
+          2/6
+        </strong>
+         
+        disponibles
+      </li>
+    </ul>
   </div>
+  <button
+    className="sc-bxivhb hYUqPP k-BackingCard__button k-BackingCard__drawer"
+    disabled={true}
+  >
+    Je soutiens
+  </button>
 </article>
 `;

--- a/assets/javascripts/kitten/components/cards/backing-card/stories.js
+++ b/assets/javascripts/kitten/components/cards/backing-card/stories.js
@@ -433,7 +433,7 @@ export const InACarouselComponent = () => {
           <BackingCard.Button>Je soutiens</BackingCard.Button>
         </BackingCard>
 
-        <BackingCard disabled as="button" className="k-u-reset-button">
+        <BackingCard disabled className="k-u-reset-button">
           <BackingCard.Image>
             <img src="/kitten.jpg" alt="" />
           </BackingCard.Image>
@@ -475,7 +475,7 @@ export const InACarouselComponent = () => {
           </BackingCard.TagList>
         </BackingCard>
 
-        <BackingCard disabled as="button" className="k-u-reset-button">
+        <BackingCard disabled className="k-u-reset-button">
           <BackingCard.HeadingTag icon="star" text="Star reward" />
           <BackingCard.Title>
             Lorem ipsum dolor sit amet, consectetuer adipiscing eget dolor.
@@ -514,7 +514,7 @@ export const InACarouselComponent = () => {
           </BackingCard.TagList>
         </BackingCard>
 
-        <BackingCard disabled as="button" className="k-u-reset-button">
+        <BackingCard disabled className="k-u-reset-button">
           <BackingCard.Image>
             <GifVideo poster="/kitten.jpg">
               <source
@@ -561,7 +561,7 @@ export const InACarouselComponent = () => {
           </BackingCard.TagList>
         </BackingCard>
 
-        <BackingCard disabled as="button" className="k-u-reset-button">
+        <BackingCard disabled className="k-u-reset-button">
           <BackingCard.Amount>65&nbsp;€</BackingCard.Amount>
           <BackingCard.Description moreButtonText="See more…" truncateText>
             <p className="k-u-margin-none">

--- a/assets/javascripts/kitten/components/cards/backing-card/styles.js
+++ b/assets/javascripts/kitten/components/cards/backing-card/styles.js
@@ -7,14 +7,16 @@ export const StyledBackingCard = styled.article`
   --backingCard--border-width: 0;
   --backingCard--border-radius: 0;
   --backingCard--grid-col: repeat(auto-fit, minmax(${pxToRem(120)}, 1fr));
+  --backingCard--border-color: ${COLORS.line1};
 
   /* CARD STYLE */
 
-  border: var(--backingCard--border-width) solid ${COLORS.line1};
+  border: var(--backingCard--border-width) solid var(--backingCard--border-color);
   border-radius: var(--backingCard--border-radius);
   display: flex;
   flex-direction: column;
   align-items: stretch;
+  transition: border-color .2s ease-in-out;
 
   &.k-BackingCard--hasBorder {
     --backingCard--border-width: ${pxToRem(2)};
@@ -83,6 +85,7 @@ export const StyledBackingCard = styled.article`
       object-position: center center;
       border-top-left-radius: var(--backingCard--border-radius);
       border-top-right-radius: var(--backingCard--border-radius);
+      transition: transform .2s ease-in-out;
     }
   }
 
@@ -184,6 +187,25 @@ export const StyledBackingCard = styled.article`
 
     .k-BackingCard__description__moreButton {
       color: ${COLORS.font2};
+    }
+  }
+
+  button&:hover,
+  a&:hover {
+    --backingCard--border-color: ${COLORS.font3};
+
+    cursor: pointer;
+
+    .k-BackingCard__imageWrapper {
+      img,
+      figure,
+      video {
+        transform: scale(1.05);
+      }
+    }
+    .k-BackingCard__button {
+      border-color: ${COLORS.primary2};
+      background-color: ${COLORS.primary2};
     }
   }
 `

--- a/assets/javascripts/kitten/components/cards/backing-card/styles.js
+++ b/assets/javascripts/kitten/components/cards/backing-card/styles.js
@@ -192,7 +192,7 @@ export const StyledBackingCard = styled.article`
 
   button&:hover,
   a&:hover {
-    --backingCard--border-color: ${COLORS.font3};
+    --backingCard--border-color: ${COLORS.line3};
 
     cursor: pointer;
 

--- a/assets/javascripts/kitten/components/cards/backing-card/styles.js
+++ b/assets/javascripts/kitten/components/cards/backing-card/styles.js
@@ -192,7 +192,7 @@ export const StyledBackingCard = styled.article`
 
   button&:hover,
   a&:hover {
-    --backingCard--border-color: ${COLORS.line3};
+    --backingCard--border-color: ${COLORS.line2};
 
     cursor: pointer;
 

--- a/assets/javascripts/kitten/components/cards/backing-card/styles.js
+++ b/assets/javascripts/kitten/components/cards/backing-card/styles.js
@@ -207,5 +207,8 @@ export const StyledBackingCard = styled.article`
       border-color: ${COLORS.primary2};
       background-color: ${COLORS.primary2};
     }
+    .k-BackingCard__description__moreButton {
+      color: ${COLORS.primary2};
+    }
   }
 `

--- a/assets/javascripts/kitten/components/cards/backing-card/styles.js
+++ b/assets/javascripts/kitten/components/cards/backing-card/styles.js
@@ -190,6 +190,7 @@ export const StyledBackingCard = styled.article`
     }
   }
 
+  &.k-BackingCard--hasHover:hover,
   button&:hover,
   a&:hover {
     --backingCard--border-color: ${COLORS.line2};

--- a/assets/javascripts/kitten/components/cards/backing-card/test.js
+++ b/assets/javascripts/kitten/components/cards/backing-card/test.js
@@ -24,57 +24,53 @@ describe('<BackingCard />', () => {
     beforeEach(() => {
       component = renderer
         .create(
-          <BackingCard>
-            <BackingCard disabled hasBorder={false}>
-              <BackingCard.Image>
-                <img src="/kitten.jpg" alt="" />
-              </BackingCard.Image>
-              <BackingCard.HeadingTag icon="star" text="Star reward" />
-              <BackingCard.Title>
-                Lorem ipsum dolor sit amet, consectetuer adipiscing eget dolor.
-              </BackingCard.Title>
-              <BackingCard.Amount>65&nbsp;€</BackingCard.Amount>
-              <BackingCard.Info
-                legend="Prix de livraison&nbsp;:"
-                value="5&nbsp;€ (en France)"
-              />
-              <BackingCard.Info
-                legend="Livraison estimée&nbsp;:"
-                value="Janvier 2022"
-              />
-              <BackingCard.Description moreButtonText="See more…" truncateText>
-                <p className="k-u-margin-none">
-                  Maecenas tempus, tellus eget condimentum rhoncus, sem quam
-                  semper libero, sit amet adipiscing sem neque sed ipsum.
-                </p>
-                <p className="k-u-margin-none">
-                  Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac,
-                  enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a,
-                  tell
-                </p>
-                <p className="k-u-margin-none">
-                  Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac,
-                  enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a,
-                  tell
-                </p>
-                <p className="k-u-margin-none">
-                  Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac,
-                  enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a,
-                  tell
-                </p>
-              </BackingCard.Description>
-              <BackingCard.TagList>
-                <Tag as="li">
-                  <strong className="k-u-weight-regular">5</strong>{' '}
-                  contributeurs
-                </Tag>
-                <Tag as="li">
-                  <strong className="k-u-weight-regular">2/6</strong>{' '}
-                  disponibles
-                </Tag>
-              </BackingCard.TagList>
-              <BackingCard.Button>Je soutiens</BackingCard.Button>
-            </BackingCard>
+          <BackingCard disabled hasBorder={false}>
+            <BackingCard.Image>
+              <img src="/kitten.jpg" alt="" />
+            </BackingCard.Image>
+            <BackingCard.HeadingTag icon="star" text="Star reward" />
+            <BackingCard.Title>
+              Lorem ipsum dolor sit amet, consectetuer adipiscing eget dolor.
+            </BackingCard.Title>
+            <BackingCard.Amount>65&nbsp;€</BackingCard.Amount>
+            <BackingCard.Info
+              legend="Prix de livraison&nbsp;:"
+              value="5&nbsp;€ (en France)"
+            />
+            <BackingCard.Info
+              legend="Livraison estimée&nbsp;:"
+              value="Janvier 2022"
+            />
+            <BackingCard.Description moreButtonText="See more…" truncateText>
+              <p className="k-u-margin-none">
+                Maecenas tempus, tellus eget condimentum rhoncus, sem quam
+                semper libero, sit amet adipiscing sem neque sed ipsum.
+              </p>
+              <p className="k-u-margin-none">
+                Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac,
+                enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a,
+                tell
+              </p>
+              <p className="k-u-margin-none">
+                Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac,
+                enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a,
+                tell
+              </p>
+              <p className="k-u-margin-none">
+                Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac,
+                enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a,
+                tell
+              </p>
+            </BackingCard.Description>
+            <BackingCard.TagList>
+              <Tag as="li">
+                <strong className="k-u-weight-regular">5</strong> contributeurs
+              </Tag>
+              <Tag as="li">
+                <strong className="k-u-weight-regular">2/6</strong> disponibles
+              </Tag>
+            </BackingCard.TagList>
+            <BackingCard.Button>Je soutiens</BackingCard.Button>
           </BackingCard>,
         )
         .toJSON()

--- a/assets/javascripts/kitten/constants/colors-config.js
+++ b/assets/javascripts/kitten/constants/colors-config.js
@@ -10,7 +10,6 @@ export default {
 
   line1: '#eee', // Semi Light Grey
   line2: '#d8d8d8', // Grey
-  line3: '#dbdbdb', // Semi Dark Grey Light
 
   primary1: '#19b4fa', // Primary
   primary2: '#05a8e6', // Semi Dark Primary

--- a/assets/javascripts/kitten/constants/colors-config.js
+++ b/assets/javascripts/kitten/constants/colors-config.js
@@ -10,6 +10,7 @@ export default {
 
   line1: '#eee', // Semi Light Grey
   line2: '#d8d8d8', // Grey
+  line3: '#dbdbdb', // Semi Dark Grey Light
 
   primary1: '#19b4fa', // Primary
   primary2: '#05a8e6', // Semi Dark Primary

--- a/doc/design/colors.js
+++ b/doc/design/colors.js
@@ -10,7 +10,6 @@ const sass = {
   'background-3': '#f6f6f6', // Light Grey
   'line-1': '#eee', // Semi Light Grey
   'line-2': '#d8d8d8', // Grey
-  'line-3': '#dbdbdb', // Grey
 
   'primary-1': '#19b4fa', // Primary
   'primary-2': '#05a8e6', // Semi Dark Primary

--- a/doc/design/colors.js
+++ b/doc/design/colors.js
@@ -10,6 +10,7 @@ const sass = {
   'background-3': '#f6f6f6', // Light Grey
   'line-1': '#eee', // Semi Light Grey
   'line-2': '#d8d8d8', // Grey
+  'line-3': '#dbdbdb', // Grey
 
   'primary-1': '#19b4fa', // Primary
   'primary-2': '#05a8e6', // Semi Dark Primary
@@ -30,10 +31,14 @@ const sass = {
   'tertiary-3': '#4ae191',
 
   'valid': '#61d079', // Green
+  'valid1': 'rgba(97, 208, 121, .1)', // Green Light
 
   'error': '#ff0046', // Red
   'error-2': '#ffe5ec', // Light Red
   'error-3': '#ffb2c7', // Semi Light Red
+
+  'orange': '#ff7800',
+  'orange1': 'rgba(255, 130, 15, .1)', // Orange light
 
   'red-light-mdc': '#ffebe0',
   'red-mdc': '#ff0000',


### PR DESCRIPTION
Closes #.

Vercel link:

- https://kitten-git-backing-card-add-hover-styles.kisskissbankbank.vercel.app/?path=/story/cards-backingcard--in-a-carousel-component

Screenshot:


TODO:

- [x] Tests
- [x] Changelog
- [x] A11Y
- [x] Stories / Docs
- [ ] BrowserStack (IE11, Chrome & Firefox on Windows 10)
- [ ] New component added to `assets/javascripts/kitten/index.js`
