### PR TITLE
[Toggletip] New component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Feature: Add `Toggletip` component.
+
 ## [2.119.0] - 2020-02-10
 
 Feature:

--- a/assets/javascripts/kitten/components/atoms/tag/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/atoms/tag/__snapshots__/test.js.snap
@@ -2,13 +2,13 @@
 
 exports[`<Tag /> should match its empty snapshot 1`] = `
 <span
-  className="sc-bdVaJa foXQah k-Tag k-Tag--info"
+  className="sc-bdVaJa lajXQg k-Tag k-Tag--info"
 />
 `;
 
 exports[`<Tag /> should match its snapshot with props 1`] = `
 <span
-  className="sc-bdVaJa foXQah k-Tag k-Tag--info"
+  className="sc-bdVaJa lajXQg k-Tag k-Tag--info"
 >
   <strong>
     5

--- a/assets/javascripts/kitten/components/cards/backing-card/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/cards/backing-card/__snapshots__/test.js.snap
@@ -36,7 +36,7 @@ exports[`<BackingCard /> with some props matches with snapshot 1`] = `
     className="k-BackingCard__gridWrapper"
   >
     <span
-      className="sc-EHOje hGIGkH k-Tag k-BackingCard__headingTag k-BackingCard__drawer k-Tag--info"
+      className="sc-EHOje ckZRuJ k-Tag k-BackingCard__headingTag k-BackingCard__drawer k-Tag--info"
     >
       <svg
         fill="#222"
@@ -128,7 +128,7 @@ exports[`<BackingCard /> with some props matches with snapshot 1`] = `
       className="k-BackingCard__tagList k-BackingCard__drawer"
     >
       <li
-        className="sc-EHOje hGIGkH k-Tag k-Tag--info"
+        className="sc-EHOje ckZRuJ k-Tag k-Tag--info"
       >
         <strong
           className="k-u-weight-regular"
@@ -138,7 +138,7 @@ exports[`<BackingCard /> with some props matches with snapshot 1`] = `
          contributeurs
       </li>
       <li
-        className="sc-EHOje hGIGkH k-Tag k-Tag--info"
+        className="sc-EHOje ckZRuJ k-Tag k-Tag--info"
       >
         <strong
           className="k-u-weight-regular"

--- a/assets/javascripts/kitten/components/tooltips/toggletip/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/tooltips/toggletip/__snapshots__/test.js.snap
@@ -8,8 +8,8 @@ exports[`<Toggletip /> Default matches with snapshot 1`] = `
   onMouseLeave={[Function]}
   style={
     Object {
-      "--toggletipAction-left": "NaNrem",
-      "--toggletipAction-top": "NaNrem",
+      "--toggletipAction-left": undefined,
+      "--toggletipAction-top": undefined,
     }
   }
 >
@@ -52,8 +52,8 @@ exports[`<Toggletip /> With props matches with snapshot 1`] = `
   onMouseLeave={[Function]}
   style={
     Object {
-      "--toggletipAction-left": "NaNrem",
-      "--toggletipAction-top": "NaNrem",
+      "--toggletipAction-left": undefined,
+      "--toggletipAction-top": undefined,
     }
   }
 >

--- a/assets/javascripts/kitten/components/tooltips/toggletip/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/tooltips/toggletip/__snapshots__/test.js.snap
@@ -2,7 +2,8 @@
 
 exports[`<Toggletip /> Default matches with snapshot 1`] = `
 <span
-  className="sc-bdVaJa hSsYpi k-Toggletip k-Toggletip--info"
+  className="sc-bdVaJa imDtDI k-Toggletip k-Toggletip--info"
+  id="Toggletip-demo"
   style={
     Object {
       "--toggletipAction-left": "NaNrem",
@@ -39,7 +40,8 @@ exports[`<Toggletip /> Default matches with snapshot 1`] = `
 
 exports[`<Toggletip /> With props matches with snapshot 1`] = `
 <span
-  className="sc-bdVaJa hSsYpi k-Toggletip k-Toggletip--warning"
+  className="sc-bdVaJa imDtDI k-Toggletip k-Toggletip--warning"
+  id="Toggletip-demo"
   style={
     Object {
       "--toggletipAction-left": "NaNrem",

--- a/assets/javascripts/kitten/components/tooltips/toggletip/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/tooltips/toggletip/__snapshots__/test.js.snap
@@ -1,0 +1,75 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Toggletip /> Default matches with snapshot 1`] = `
+<span
+  className="sc-bdVaJa hSsYpi k-Toggletip k-Toggletip--info"
+  style={
+    Object {
+      "--toggletipAction-left": "NaNrem",
+      "--toggletipAction-top": "NaNrem",
+      "style": undefined,
+    }
+  }
+>
+  <button
+    aria-label="Sample label"
+    className="k-Toggletip__action k-u-reset-button"
+    onBlur={[Function]}
+    onClick={[Function]}
+    type="button"
+  >
+    <svg
+      fill="#fff"
+      height={10}
+      viewBox="0 0 6 10"
+      width={6}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      
+      <path
+        d="M1.98 8.486c0 .468.372.852.852.852a.858.858 0 1 0 0-1.716.85.85 0 0 0-.852.864zM3.552 5.63c1.32-.264 2.208-1.2 2.208-2.46C5.76 1.682 4.584.662 2.988.662c-1.2 0-2.16.624-2.748 1.488l.912.996C1.62 2.306 2.232 1.97 3 1.97c.708 0 1.332.432 1.332 1.176 0 .9-.876 1.332-1.8 1.332h-.396v2.196h1.416V5.63z"
+      />
+    </svg>
+  </button>
+  <span
+    role="status"
+  />
+</span>
+`;
+
+exports[`<Toggletip /> With props matches with snapshot 1`] = `
+<span
+  className="sc-bdVaJa hSsYpi k-Toggletip k-Toggletip--warning"
+  style={
+    Object {
+      "--toggletipAction-left": "NaNrem",
+      "--toggletipAction-top": "NaNrem",
+      "style": undefined,
+    }
+  }
+>
+  <button
+    aria-label="Sample label"
+    className="k-Toggletip__action k-u-reset-button customClassName"
+    onBlur={[Function]}
+    onClick={[Function]}
+    type="button"
+  >
+    <svg
+      height={10}
+      width={2}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      
+      <path
+        d="M1.82 6.86H.168V0H1.82v6.86zM0 8.96c0-.28.098-.518.294-.714a.972.972 0 0 1 .714-.294c.28 0 .518.098.714.294a.972.972 0 0 1 .294.714c0 .27-.098.504-.294.7a.972.972 0 0 1-.714.294.972.972 0 0 1-.714-.294.956.956 0 0 1-.294-.7z"
+        fill="#fff"
+        fillRule="evenodd"
+      />
+    </svg>
+  </button>
+  <span
+    role="status"
+  />
+</span>
+`;

--- a/assets/javascripts/kitten/components/tooltips/toggletip/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/tooltips/toggletip/__snapshots__/test.js.snap
@@ -10,7 +10,6 @@ exports[`<Toggletip /> Default matches with snapshot 1`] = `
     Object {
       "--toggletipAction-left": "NaNrem",
       "--toggletipAction-top": "NaNrem",
-      "style": undefined,
     }
   }
 >
@@ -55,7 +54,6 @@ exports[`<Toggletip /> With props matches with snapshot 1`] = `
     Object {
       "--toggletipAction-left": "NaNrem",
       "--toggletipAction-top": "NaNrem",
-      "style": undefined,
     }
   }
 >

--- a/assets/javascripts/kitten/components/tooltips/toggletip/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/tooltips/toggletip/__snapshots__/test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<Toggletip /> Default matches with snapshot 1`] = `
 <span
-  className="sc-bdVaJa cBUNev k-Toggletip k-Toggletip--info"
+  className="sc-bdVaJa tSArF k-Toggletip k-Toggletip--info"
   id="Toggletip-demo"
   style={
     Object {
@@ -45,7 +45,7 @@ exports[`<Toggletip /> Default matches with snapshot 1`] = `
 
 exports[`<Toggletip /> With props matches with snapshot 1`] = `
 <span
-  className="sc-bdVaJa cBUNev k-Toggletip k-Toggletip--warning"
+  className="sc-bdVaJa tSArF k-Toggletip k-Toggletip--warning"
   id="Toggletip-demo"
   style={
     Object {

--- a/assets/javascripts/kitten/components/tooltips/toggletip/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/tooltips/toggletip/__snapshots__/test.js.snap
@@ -4,6 +4,8 @@ exports[`<Toggletip /> Default matches with snapshot 1`] = `
 <span
   className="sc-bdVaJa tSArF k-Toggletip k-Toggletip--info"
   id="Toggletip-demo"
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
   style={
     Object {
       "--toggletipAction-left": "NaNrem",
@@ -47,6 +49,8 @@ exports[`<Toggletip /> With props matches with snapshot 1`] = `
 <span
   className="sc-bdVaJa tSArF k-Toggletip k-Toggletip--warning"
   id="Toggletip-demo"
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
   style={
     Object {
       "--toggletipAction-left": "NaNrem",

--- a/assets/javascripts/kitten/components/tooltips/toggletip/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/tooltips/toggletip/__snapshots__/test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<Toggletip /> Default matches with snapshot 1`] = `
 <span
-  className="sc-bdVaJa imDtDI k-Toggletip k-Toggletip--info"
+  className="sc-bdVaJa cBUNev k-Toggletip k-Toggletip--info"
   id="Toggletip-demo"
   style={
     Object {
@@ -17,6 +17,11 @@ exports[`<Toggletip /> Default matches with snapshot 1`] = `
     className="k-Toggletip__action k-u-reset-button"
     onBlur={[Function]}
     onClick={[Function]}
+    style={
+      Object {
+        "--toggletipAction-color": null,
+      }
+    }
     type="button"
   >
     <svg
@@ -40,7 +45,7 @@ exports[`<Toggletip /> Default matches with snapshot 1`] = `
 
 exports[`<Toggletip /> With props matches with snapshot 1`] = `
 <span
-  className="sc-bdVaJa imDtDI k-Toggletip k-Toggletip--warning"
+  className="sc-bdVaJa cBUNev k-Toggletip k-Toggletip--warning"
   id="Toggletip-demo"
   style={
     Object {
@@ -55,6 +60,11 @@ exports[`<Toggletip /> With props matches with snapshot 1`] = `
     className="k-Toggletip__action k-u-reset-button customClassName"
     onBlur={[Function]}
     onClick={[Function]}
+    style={
+      Object {
+        "--toggletipAction-color": null,
+      }
+    }
     type="button"
   >
     <svg

--- a/assets/javascripts/kitten/components/tooltips/toggletip/index.js
+++ b/assets/javascripts/kitten/components/tooltips/toggletip/index.js
@@ -269,7 +269,6 @@ export const Toggletip = ({
               'k-u-line-height-1-3',
               bubbleProps.className,
               {
-                '--toggletipBubble-zIndex': bubbleProps.zIndex || 1,
                 'k-Toggletip__bubble--left': bubbleOnLeftSide,
                 'k-Toggletip__bubble--lowTop': bubbleLowTop,
                 'k-Toggletip__bubble--rightLimit':
@@ -277,6 +276,7 @@ export const Toggletip = ({
               },
             )}
             style={{
+              '--toggletipBubble-zIndex': bubbleProps.zIndex || 1,
               '--toggletipBubble-color': bubbleProps.color || null,
               ...bubbleProps.style,
             }}

--- a/assets/javascripts/kitten/components/tooltips/toggletip/index.js
+++ b/assets/javascripts/kitten/components/tooltips/toggletip/index.js
@@ -254,8 +254,12 @@ export const Toggletip = ({
         `k-Toggletip--${modifier}`,
       )}
       style={{
-        '--toggletipAction-top': pxToRem(actionPosition.top),
-        '--toggletipAction-left': pxToRem(actionPosition.left),
+        '--toggletipAction-top': actionPosition.top
+          ? pxToRem(actionPosition.top)
+          : undefined,
+        '--toggletipAction-left': actionPosition.left
+          ? pxToRem(actionPosition.left)
+          : undefined,
         ...style,
       }}
       onMouseEnter={() => setHoverState(true)}

--- a/assets/javascripts/kitten/components/tooltips/toggletip/index.js
+++ b/assets/javascripts/kitten/components/tooltips/toggletip/index.js
@@ -250,9 +250,9 @@ export const Toggletip = ({
         `k-Toggletip--${modifier}`,
       )}
       style={{
-        style,
         '--toggletipAction-top': pxToRem(actionPosition.top),
         '--toggletipAction-left': pxToRem(actionPosition.left),
+        ...style,
       }}
       onMouseEnter={() => setHoverState(true)}
       onMouseLeave={() => setHoverState(false)}

--- a/assets/javascripts/kitten/components/tooltips/toggletip/index.js
+++ b/assets/javascripts/kitten/components/tooltips/toggletip/index.js
@@ -49,7 +49,7 @@ const StyledWrapper = styled.span`
   .k-Toggletip__bubble {
     --toggletipBubble-arrowMainPosition: ${pxToRem(-2 * 10)};
 
-    z-index: 1;
+    z-index: var(--toggletipBubble-zIndex);
     box-sizing: border-box;
     padding: ${pxToRem(12)};
     background-color: var(--toggletipBubble-color);
@@ -269,6 +269,7 @@ export const Toggletip = ({
               'k-u-line-height-1-3',
               bubbleProps.className,
               {
+                '--toggletipBubble-zIndex': bubbleProps.zIndex || 1,
                 'k-Toggletip__bubble--left': bubbleOnLeftSide,
                 'k-Toggletip__bubble--lowTop': bubbleLowTop,
                 'k-Toggletip__bubble--rightLimit':

--- a/assets/javascripts/kitten/components/tooltips/toggletip/index.js
+++ b/assets/javascripts/kitten/components/tooltips/toggletip/index.js
@@ -1,0 +1,259 @@
+import React, { useState, useEffect, useRef } from 'react'
+import PropTypes from 'prop-types'
+import classNames from 'classnames'
+import throttle from 'lodash/throttle'
+import styled from 'styled-components'
+import { pxToRem } from '../../../helpers/utils/typography'
+import { ScreenConfig } from '../../../constants/screen-config'
+import COLORS from '../../../constants/colors-config'
+import { CONTAINER_PADDING_THIN } from '../../../constants/grid-config'
+import { QuestionMarkIcon } from '../../../components/icons/question-mark-icon'
+import { WarningIcon } from '../../../components/icons/warning-icon'
+
+const StyledWrapper = styled.span`
+  --toggletipAction-size: ${pxToRem(24)};
+
+  position: relative;
+  display: inline-block;
+
+  &,
+  &.k-Toggletip--info {
+    --toggletipAction-color: ${COLORS.primary1};
+    --toggletipBubble-color: ${COLORS.primary4};
+  }
+  &.k-Toggletip--warning {
+    --toggletipAction-color: ${COLORS.orange};
+    --toggletipBubble-color: ${COLORS.orange1};
+  }
+  &.k-Toggletip--error {
+    --toggletipAction-color: ${COLORS.error};
+    --toggletipBubble-color: ${COLORS.error2};
+  }
+  &.k-Toggletip--success {
+    --toggletipAction-color: ${COLORS.valid};
+    --toggletipBubble-color: ${COLORS.valid1};
+  }
+  &.k-Toggletip--disabled {
+    --toggletipAction-color: ${COLORS.font2};
+    --toggletipBubble-color: ${COLORS.line1};
+  }
+
+  .k-Toggletip__action {
+    position: relative;
+    background-color: var(--toggletipAction-color);
+    width: var(--toggletipAction-size);
+    height: var(--toggletipAction-size);
+    border-radius: 50%;
+  }
+
+  .k-Toggletip__bubble {
+    --toggletipBubble-arrowMainPosition: ${pxToRem(-2 * 10)};
+
+    z-index: 1;
+    box-sizing: border-box;
+    padding: ${pxToRem(12)};
+    background-color: var(--toggletipBubble-color);
+    text-align: left;
+
+    &:after {
+      content: '';
+      position: absolute;
+      display: block;
+      width: 0;
+      height: 0;
+      border: ${pxToRem(10)} solid transparent;
+    }
+
+    @media (max-width: ${pxToRem(ScreenConfig.XS.max)}) {
+      border-radius: ${pxToRem(6)};
+      position: fixed;
+      top: calc(
+        var(--toggletipAction-top) + var(--toggletipAction-size) +
+          ${pxToRem(20)}
+      );
+      left: ${pxToRem(CONTAINER_PADDING_THIN)};
+      right: ${pxToRem(CONTAINER_PADDING_THIN)};
+
+      &:after {
+        top: var(--toggletipBubble-arrowMainPosition);
+        left: calc(
+          var(--toggletipAction-left) - ${pxToRem(CONTAINER_PADDING_THIN)} -
+            ${pxToRem(10)} + (var(--toggletipAction-size) / 2)
+        );
+        border-bottom-color: var(--toggletipBubble-color);
+      }
+    }
+
+    @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
+      border-radius: ${pxToRem(8)};
+      position: absolute;
+      top: calc(var(--toggletipAction-size) / 2);
+      left: calc(100% + ${pxToRem(20)});
+      transform: translateY(-50%);
+      min-width: ${pxToRem(220)};
+      max-width: ${pxToRem(440)};
+
+      &:after {
+        left: var(--toggletipBubble-arrowMainPosition);
+        top: calc(50% - ${pxToRem(10)});
+        border-right-color: var(--toggletipBubble-color);
+      }
+
+      &.k-Toggletip__bubble--left {
+        left: initial;
+        right: calc(100% + ${pxToRem(20)});
+
+        &:after {
+          left: initial;
+          right: var(--toggletipBubble-arrowMainPosition);
+          border-right-color: transparent;
+          border-left-color: var(--toggletipBubble-color);
+        }
+      }
+    }
+  }
+`
+
+const ButtonIcon = ({ modifier }) => {
+  if (modifier === 'info') {
+    return <QuestionMarkIcon width={6} height={10} color={COLORS.background1} />
+  }
+
+  return <WarningIcon width={2} height={10} color={COLORS.background1} />
+}
+
+export const Toggletip = ({
+  modifier,
+  style,
+  className,
+  children,
+  actionLabel,
+  actionProps,
+  bubbleProps,
+  ...props
+}) => {
+  const [isOpen, setOpen] = useState(false)
+  const [actionPosition, setActionPosition] = useState({})
+  const [bubbleOnLeftSide, setBubbleOnLeftSide] = useState(false)
+  const actionElement = useRef(null)
+
+  useEffect(() => {
+    document.addEventListener('click', handleOutsideClick)
+    document.addEventListener('keydown', handleKeydownEscape)
+    window.addEventListener('resize', throttle(updateCoordinates, 50))
+
+    return () => {
+      document.removeEventListener('click', handleOutsideClick)
+      document.removeEventListener('keydown', handleKeydownEscape)
+      window.removeEventListener('resize', throttle(updateCoordinates, 50))
+    }
+  }, [isOpen])
+
+  useEffect(() => {
+    updateCoordinates()
+  }, [actionElement])
+
+  const updateCoordinates = () => {
+    if (!actionElement.current) return
+
+    const actionElementCoords = actionElement.current?.getBoundingClientRect()
+
+    setActionPosition({
+      top: actionElementCoords.top,
+      left: actionElementCoords.left,
+    })
+
+    const bubblePlusMargins = 220 + 20 + CONTAINER_PADDING_THIN
+    const shouldDisplayOnLeftSide =
+      document.body.clientWidth < actionElementCoords.right + bubblePlusMargins
+    setBubbleOnLeftSide(shouldDisplayOnLeftSide)
+  }
+
+  const handleOutsideClick = event => {
+    if (actionElement.current !== event.target) {
+      setOpen(false)
+    }
+  }
+  const handleKeydownEscape = event => {
+    if (event.key === 'Escape') {
+      setOpen(false)
+    }
+  }
+
+  const handleClick = event => {
+    event.preventDefault()
+    setOpen(false)
+
+    window.setTimeout(() => setOpen(true), 100)
+  }
+
+  return (
+    <StyledWrapper
+      className={classNames(
+        'k-Toggletip',
+        className,
+        `k-Toggletip--${modifier}`,
+      )}
+      style={{
+        style,
+        '--toggletipAction-top': pxToRem(actionPosition.top),
+        '--toggletipAction-left': pxToRem(actionPosition.left),
+      }}
+      {...props}
+    >
+      <button
+        {...actionProps}
+        className={classNames(
+          'k-Toggletip__action',
+          'k-u-reset-button',
+          actionProps.className,
+        )}
+        type="button"
+        aria-label={actionLabel}
+        onClick={handleClick}
+        onBlur={() => setOpen(false)}
+        ref={actionElement}
+      >
+        <ButtonIcon modifier={modifier} />
+      </button>
+      <span role="status">
+        {isOpen && (
+          <span
+            {...bubbleProps}
+            className={classNames(
+              'k-Toggletip__bubble',
+              'k-u-weight-light',
+              'k-u-size-tiny',
+              'k-u-line-height-1-3',
+              bubbleProps.className,
+              {
+                'k-Toggletip__bubble--left': bubbleOnLeftSide,
+              },
+            )}
+          >
+            {children}
+          </span>
+        )}
+      </span>
+    </StyledWrapper>
+  )
+}
+
+Toggletip.defaultProps = {
+  modifier: 'info',
+  actionProps: {},
+  bubbleProps: {},
+}
+
+Toggletip.propTypes = {
+  modifier: PropTypes.oneOf([
+    'info',
+    'warning',
+    'error',
+    'success',
+    'disabled',
+  ]),
+  actionLabel: PropTypes.string.isRequired,
+  actionProps: PropTypes.object,
+  bubbleProps: PropTypes.object,
+}

--- a/assets/javascripts/kitten/components/tooltips/toggletip/index.js
+++ b/assets/javascripts/kitten/components/tooltips/toggletip/index.js
@@ -162,7 +162,7 @@ export const Toggletip = ({
     document.addEventListener('keydown', handleKeydownEscape)
     window.addEventListener('resize', throttle(updateCoordinates, 50))
 
-    const bubbleElement = actionElement.current.nextElementSibling?.children[0]
+    const bubbleElement = actionElement.current?.nextElementSibling?.children[0]
     const bubbleElementCoords = bubbleElement?.getBoundingClientRect() || {}
 
     const shouldDisplayBubbleLowTop =

--- a/assets/javascripts/kitten/components/tooltips/toggletip/index.js
+++ b/assets/javascripts/kitten/components/tooltips/toggletip/index.js
@@ -176,7 +176,7 @@ export const Toggletip = ({
   useEffect(() => {
     document.addEventListener('click', handleOutsideClick)
     document.addEventListener('keydown', handleKeydownEscape)
-    window.addEventListener('resize', throttle(updateCoordinates, 50))
+    window.addEventListener('resize', throttleUpdateCoordinates)
 
     const bubbleElement = actionElement.current?.nextElementSibling?.children[0]
     const bubbleElementCoords = bubbleElement?.getBoundingClientRect() || {}
@@ -188,13 +188,17 @@ export const Toggletip = ({
     return () => {
       document.removeEventListener('click', handleOutsideClick)
       document.removeEventListener('keydown', handleKeydownEscape)
-      window.removeEventListener('resize', throttle(updateCoordinates, 50))
+      window.removeEventListener('resize', throttleUpdateCoordinates)
     }
   }, [isOpen])
 
   useEffect(() => {
     updateCoordinates()
   }, [actionElement])
+
+  const throttleUpdateCoordinates = () => {
+    throttle(updateCoordinates, 50)
+  }
 
   const updateCoordinates = () => {
     if (!actionElement.current) return

--- a/assets/javascripts/kitten/components/tooltips/toggletip/index.js
+++ b/assets/javascripts/kitten/components/tooltips/toggletip/index.js
@@ -6,10 +6,7 @@ import styled from 'styled-components'
 import { pxToRem } from '../../../helpers/utils/typography'
 import { ScreenConfig } from '../../../constants/screen-config'
 import COLORS from '../../../constants/colors-config'
-import {
-  CONTAINER_PADDING,
-  CONTAINER_PADDING_THIN,
-} from '../../../constants/grid-config'
+import { CONTAINER_PADDING_THIN } from '../../../constants/grid-config'
 import { QuestionMarkIcon } from '../../../components/icons/question-mark-icon'
 import { WarningIcon } from '../../../components/icons/warning-icon'
 
@@ -69,13 +66,12 @@ const StyledWrapper = styled.span`
 
     @media (max-width: ${pxToRem(ScreenConfig.XS.max)}) {
       border-radius: ${pxToRem(6)};
-      position: fixed;
-      top: calc(
-        var(--toggletipAction-top) + var(--toggletipAction-size) +
-          ${pxToRem(20)}
+      position: absolute;
+      top: calc(var(--toggletipAction-size) + ${pxToRem(20)});
+      left: calc(
+        -1 * var(--toggletipAction-left) + ${pxToRem(CONTAINER_PADDING_THIN)}
       );
-      left: ${pxToRem(CONTAINER_PADDING_THIN)};
-      right: ${pxToRem(CONTAINER_PADDING_THIN)};
+      width: calc(100vw - ${pxToRem(CONTAINER_PADDING_THIN * 2)});
 
       &:after {
         top: var(--toggletipBubble-arrowMainPosition);
@@ -89,16 +85,21 @@ const StyledWrapper = styled.span`
 
     @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
       border-radius: ${pxToRem(8)};
-      position: fixed;
-      top: calc(var(--toggletipAction-top) + var(--toggletipAction-size) / 2);
-      left: calc(
-        var(--toggletipAction-left) + var(--toggletipAction-size) +
-          ${pxToRem(20)}
-      );
-      right: ${pxToRem(CONTAINER_PADDING)};
+      position: absolute;
+      top: calc(var(--toggletipAction-size) / 2);
+      left: calc(100% + ${pxToRem(20)});
       transform: translateY(-50%);
       min-width: ${pxToRem(220)};
       max-width: ${pxToRem(440)};
+      width: max-content;
+
+      &.k-Toggletip__bubble--rightLimit {
+        max-width: calc(
+          100vw - var(--toggletipAction-left) -
+            ${pxToRem(CONTAINER_PADDING_THIN + 20)} -
+            var(--toggletipAction-size)
+        );
+      }
 
       &:after {
         left: var(--toggletipBubble-arrowMainPosition);
@@ -107,7 +108,9 @@ const StyledWrapper = styled.span`
       }
 
       &.k-Toggletip__bubble--lowTop {
-        top: ${pxToRem(CONTAINER_PADDING_THIN)};
+        top: calc(
+          -1 * var(--toggletipAction-top) + ${pxToRem(CONTAINER_PADDING_THIN)}
+        );
         transform: none;
 
         &:after {
@@ -120,7 +123,7 @@ const StyledWrapper = styled.span`
 
       &.k-Toggletip__bubble--left {
         left: initial;
-        right: calc(100vw - var(--toggletipAction-left) + ${pxToRem(20)});
+        right: calc(100% + ${pxToRem(20)});
 
         &:after {
           left: initial;
@@ -155,6 +158,7 @@ export const Toggletip = ({
   const [actionPosition, setActionPosition] = useState({})
   const [bubbleOnLeftSide, setBubbleOnLeftSide] = useState(false)
   const [bubbleLowTop, setBubbleLowTop] = useState(false)
+  const [bubbleRightLimit, setBubbleRightLimit] = useState(false)
   const actionElement = useRef(null)
 
   useEffect(() => {
@@ -194,6 +198,13 @@ export const Toggletip = ({
     const shouldDisplayOnLeftSide =
       document.body.clientWidth < actionElementCoords.right + bubblePlusMargins
     setBubbleOnLeftSide(shouldDisplayOnLeftSide)
+
+    const shouldDisplayBubbleRightLimit =
+      document.body.clientWidth -
+        (actionElementCoords.right + CONTAINER_PADDING_THIN + 20) <
+      440
+
+    setBubbleRightLimit(shouldDisplayBubbleRightLimit)
   }
 
   const handleOutsideClick = event => {
@@ -260,6 +271,8 @@ export const Toggletip = ({
               {
                 'k-Toggletip__bubble--left': bubbleOnLeftSide,
                 'k-Toggletip__bubble--lowTop': bubbleLowTop,
+                'k-Toggletip__bubble--rightLimit':
+                  !bubbleOnLeftSide && bubbleRightLimit,
               },
             )}
             style={{

--- a/assets/javascripts/kitten/components/tooltips/toggletip/index.js
+++ b/assets/javascripts/kitten/components/tooltips/toggletip/index.js
@@ -154,12 +154,24 @@ export const Toggletip = ({
   bubbleProps,
   ...props
 }) => {
+  const [isHover, setHoverState] = useState(false)
+  const [hasBeenClicked, setClickedState] = useState(false)
   const [isOpen, setOpen] = useState(false)
   const [actionPosition, setActionPosition] = useState({})
   const [bubbleOnLeftSide, setBubbleOnLeftSide] = useState(false)
   const [bubbleLowTop, setBubbleLowTop] = useState(false)
   const [bubbleRightLimit, setBubbleRightLimit] = useState(false)
   const actionElement = useRef(null)
+
+  useEffect(() => {
+    if (isHover) {
+      setOpen(true)
+    }
+
+    if (!isHover && !hasBeenClicked) {
+      setOpen(false)
+    }
+  }, [isHover, hasBeenClicked])
 
   useEffect(() => {
     document.addEventListener('click', handleOutsideClick)
@@ -209,11 +221,13 @@ export const Toggletip = ({
 
   const handleOutsideClick = event => {
     if (actionElement.current !== event.target) {
+      setClickedState(false)
       setOpen(false)
     }
   }
   const handleKeydownEscape = event => {
     if (event.key === 'Escape') {
+      setClickedState(false)
       setOpen(false)
     }
   }
@@ -222,7 +236,10 @@ export const Toggletip = ({
     event.preventDefault()
     setOpen(false)
 
-    window.setTimeout(() => setOpen(true), 100)
+    window.setTimeout(() => {
+      setOpen(true)
+      setClickedState(true)
+    }, 100)
   }
 
   return (
@@ -237,6 +254,8 @@ export const Toggletip = ({
         '--toggletipAction-top': pxToRem(actionPosition.top),
         '--toggletipAction-left': pxToRem(actionPosition.left),
       }}
+      onMouseEnter={() => setHoverState(true)}
+      onMouseLeave={() => setHoverState(false)}
       {...props}
     >
       <button

--- a/assets/javascripts/kitten/components/tooltips/toggletip/index.js
+++ b/assets/javascripts/kitten/components/tooltips/toggletip/index.js
@@ -6,7 +6,10 @@ import styled from 'styled-components'
 import { pxToRem } from '../../../helpers/utils/typography'
 import { ScreenConfig } from '../../../constants/screen-config'
 import COLORS from '../../../constants/colors-config'
-import { CONTAINER_PADDING_THIN } from '../../../constants/grid-config'
+import {
+  CONTAINER_PADDING,
+  CONTAINER_PADDING_THIN,
+} from '../../../constants/grid-config'
 import { QuestionMarkIcon } from '../../../components/icons/question-mark-icon'
 import { WarningIcon } from '../../../components/icons/warning-icon'
 
@@ -86,9 +89,13 @@ const StyledWrapper = styled.span`
 
     @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
       border-radius: ${pxToRem(8)};
-      position: absolute;
-      top: calc(var(--toggletipAction-size) / 2);
-      left: calc(100% + ${pxToRem(20)});
+      position: fixed;
+      top: calc(var(--toggletipAction-top) + var(--toggletipAction-size) / 2);
+      left: calc(
+        var(--toggletipAction-left) + var(--toggletipAction-size) +
+          ${pxToRem(20)}
+      );
+      right: ${pxToRem(CONTAINER_PADDING)};
       transform: translateY(-50%);
       min-width: ${pxToRem(220)};
       max-width: ${pxToRem(440)};
@@ -99,9 +106,21 @@ const StyledWrapper = styled.span`
         border-right-color: var(--toggletipBubble-color);
       }
 
+      &.k-Toggletip__bubble--lowTop {
+        top: ${pxToRem(CONTAINER_PADDING_THIN)};
+        transform: none;
+
+        &:after {
+          top: calc(
+            var(--toggletipAction-top) - ${pxToRem(CONTAINER_PADDING_THIN)} -
+              ${pxToRem(10)} + (var(--toggletipAction-size) / 2)
+          );
+        }
+      }
+
       &.k-Toggletip__bubble--left {
         left: initial;
-        right: calc(100% + ${pxToRem(20)});
+        right: calc(100vw - var(--toggletipAction-left) + ${pxToRem(20)});
 
         &:after {
           left: initial;
@@ -135,12 +154,21 @@ export const Toggletip = ({
   const [isOpen, setOpen] = useState(false)
   const [actionPosition, setActionPosition] = useState({})
   const [bubbleOnLeftSide, setBubbleOnLeftSide] = useState(false)
+  const [bubbleLowTop, setBubbleLowTop] = useState(false)
   const actionElement = useRef(null)
 
   useEffect(() => {
     document.addEventListener('click', handleOutsideClick)
     document.addEventListener('keydown', handleKeydownEscape)
     window.addEventListener('resize', throttle(updateCoordinates, 50))
+
+    const bubbleElementCoords =
+      actionElement.current.nextElementSibling?.children[0]?.getBoundingClientRect() ||
+      {}
+
+    const shouldDisplayBubbleLowTop =
+      actionPosition.top < bubbleElementCoords.height / 2
+    setBubbleLowTop(shouldDisplayBubbleLowTop)
 
     return () => {
       document.removeEventListener('click', handleOutsideClick)
@@ -156,7 +184,7 @@ export const Toggletip = ({
   const updateCoordinates = () => {
     if (!actionElement.current) return
 
-    const actionElementCoords = actionElement.current?.getBoundingClientRect()
+    const actionElementCoords = actionElement.current.getBoundingClientRect()
 
     setActionPosition({
       top: actionElementCoords.top,
@@ -213,6 +241,10 @@ export const Toggletip = ({
         onClick={handleClick}
         onBlur={() => setOpen(false)}
         ref={actionElement}
+        style={{
+          '--toggletipAction-color': actionProps.color || null,
+          ...actionProps.style,
+        }}
       >
         <ButtonIcon modifier={modifier} />
       </button>
@@ -228,8 +260,13 @@ export const Toggletip = ({
               bubbleProps.className,
               {
                 'k-Toggletip__bubble--left': bubbleOnLeftSide,
+                'k-Toggletip__bubble--lowTop': bubbleLowTop,
               },
             )}
+            style={{
+              '--toggletipBubble-color': bubbleProps.color || null,
+              ...bubbleProps.style,
+            }}
           >
             {children}
           </span>

--- a/assets/javascripts/kitten/components/tooltips/toggletip/index.js
+++ b/assets/javascripts/kitten/components/tooltips/toggletip/index.js
@@ -162,9 +162,8 @@ export const Toggletip = ({
     document.addEventListener('keydown', handleKeydownEscape)
     window.addEventListener('resize', throttle(updateCoordinates, 50))
 
-    const bubbleElementCoords =
-      actionElement.current.nextElementSibling?.children[0]?.getBoundingClientRect() ||
-      {}
+    const bubbleElement = actionElement.current.nextElementSibling?.children[0]
+    const bubbleElementCoords = bubbleElement?.getBoundingClientRect() || {}
 
     const shouldDisplayBubbleLowTop =
       actionPosition.top < bubbleElementCoords.height / 2

--- a/assets/javascripts/kitten/components/tooltips/toggletip/stories.js
+++ b/assets/javascripts/kitten/components/tooltips/toggletip/stories.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { text, select } from '@storybook/addon-knobs'
 import { Toggletip } from './index'
+import COLORS from '../../../constants/colors-config'
 
 export default {
   title: 'Tooltips/Toggletip',
@@ -31,16 +32,48 @@ export const MultipleToggletips = () => (
         actionLabel="Sample label"
         id="Toggletip-top"
         place="left"
-        children="First Toggletip"
-      />
+        bubbleProps={{
+          className: 'k-u-color-background1 k-u-weight-regular',
+          color: COLORS.primary1,
+        }}
+      >
+        First toggletip.
+        <br />
+        Cras mattis consectetur purus sit amet fermentum. Lorem ipsum dolor sit
+        amet, consectetur adipiscing elit. Fusce dapibus, tellus ac cursus
+        commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit
+        amet risus. Cras justo odio, dapibus ac facilisis in, egestas eget quam.
+        Donec ullamcorper nulla non metus auctor fringilla.
+      </Toggletip>
     </div>
-    <div className="k-u-margin-top-quadruple k-u-align-right">
-      <Toggletip actionLabel="Sample label" id="Toggletip-bottom" place="right">
+    <div className="k-u-margin-vertical-quadruple k-u-align-right">
+      <Toggletip
+        modifier="warning"
+        actionLabel="Sample label"
+        id="Toggletip-center"
+        place="right"
+      >
         This is a text{' '}
-        <a className="k-u-link k-u-link-primary1" href="#">
+        <a className="k-u-link k-u-link-font1" href="#">
           with a link
         </a>
         .
+      </Toggletip>
+    </div>
+    <div className="k-u-margin-top-quadruple k-u-align-center">
+      <Toggletip
+        modifier="disabled"
+        actionLabel="Sample label"
+        id="Toggletip-bottom"
+        place="right"
+      >
+        This is a text for the last toggletip.
+        <br />
+        Cras mattis consectetur purus sit amet fermentum. Lorem ipsum dolor sit
+        amet, consectetur adipiscing elit. Fusce dapibus, tellus ac cursus
+        commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit
+        amet risus. Cras justo odio, dapibus ac facilisis in, egestas eget quam.
+        Donec ullamcorper nulla non metus auctor fringilla.
       </Toggletip>
     </div>
   </div>

--- a/assets/javascripts/kitten/components/tooltips/toggletip/stories.js
+++ b/assets/javascripts/kitten/components/tooltips/toggletip/stories.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { text, select } from '@storybook/addon-knobs'
+import { text, select, boolean } from '@storybook/addon-knobs'
 import { Toggletip } from './index'
 import COLORS from '../../../constants/colors-config'
 
@@ -38,12 +38,17 @@ export const MultipleToggletips = () => (
         }}
       >
         First toggletip.
-        <br />
-        Cras mattis consectetur purus sit amet fermentum. Lorem ipsum dolor sit
-        amet, consectetur adipiscing elit. Fusce dapibus, tellus ac cursus
-        commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit
-        amet risus. Cras justo odio, dapibus ac facilisis in, egestas eget quam.
-        Donec ullamcorper nulla non metus auctor fringilla.
+        {boolean('Long Text', false) && (
+          <>
+            <br />
+            Cras mattis consectetur purus sit amet fermentum. Lorem ipsum dolor
+            sit amet, consectetur adipiscing elit. Fusce dapibus, tellus ac
+            cursus commodo, tortor mauris condimentum nibh, ut fermentum massa
+            justo sit amet risus. Cras justo odio, dapibus ac facilisis in,
+            egestas eget quam. Donec ullamcorper nulla non metus auctor
+            fringilla.
+          </>
+        )}
       </Toggletip>
     </div>
     <div className="k-u-margin-vertical-quadruple k-u-align-right">
@@ -60,6 +65,17 @@ export const MultipleToggletips = () => (
         <a className="k-u-link k-u-link-font1" href="#">
           with a link
         </a>
+        {boolean('Long Text', false) && (
+          <>
+            <br />
+            Cras mattis consectetur purus sit amet fermentum. Lorem ipsum dolor
+            sit amet, consectetur adipiscing elit. Fusce dapibus, tellus ac
+            cursus commodo, tortor mauris condimentum nibh, ut fermentum massa
+            justo sit amet risus. Cras justo odio, dapibus ac facilisis in,
+            egestas eget quam. Donec ullamcorper nulla non metus auctor
+            fringilla.
+          </>
+        )}
         .
       </Toggletip>
     </div>
@@ -71,12 +87,17 @@ export const MultipleToggletips = () => (
         place="right"
       >
         This is a text for the last toggletip.
-        <br />
-        Cras mattis consectetur purus sit amet fermentum. Lorem ipsum dolor sit
-        amet, consectetur adipiscing elit. Fusce dapibus, tellus ac cursus
-        commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit
-        amet risus. Cras justo odio, dapibus ac facilisis in, egestas eget quam.
-        Donec ullamcorper nulla non metus auctor fringilla.
+        {boolean('Long Text', false) && (
+          <>
+            <br />
+            Cras mattis consectetur purus sit amet fermentum. Lorem ipsum dolor
+            sit amet, consectetur adipiscing elit. Fusce dapibus, tellus ac
+            cursus commodo, tortor mauris condimentum nibh, ut fermentum massa
+            justo sit amet risus. Cras justo odio, dapibus ac facilisis in,
+            egestas eget quam. Donec ullamcorper nulla non metus auctor
+            fringilla.
+          </>
+        )}
       </Toggletip>
     </div>
   </div>

--- a/assets/javascripts/kitten/components/tooltips/toggletip/stories.js
+++ b/assets/javascripts/kitten/components/tooltips/toggletip/stories.js
@@ -52,6 +52,9 @@ export const MultipleToggletips = () => (
         actionLabel="Sample label"
         id="Toggletip-center"
         place="right"
+        bubbleProps={{
+          zIndex: 500,
+        }}
       >
         This is a text{' '}
         <a className="k-u-link k-u-link-font1" href="#">

--- a/assets/javascripts/kitten/components/tooltips/toggletip/stories.js
+++ b/assets/javascripts/kitten/components/tooltips/toggletip/stories.js
@@ -1,0 +1,47 @@
+import React from 'react'
+import { text, select } from '@storybook/addon-knobs'
+import { Toggletip } from './index'
+
+export default {
+  title: 'Tooltips/Toggletip',
+  component: Toggletip,
+}
+
+export const Default = () => {
+  return (
+    <div className="k-u-margin-vertical-octuple k-u-margin-horizontal-quadruple">
+      <Toggletip
+        actionLabel="Sample label"
+        id="Toggletip-demo"
+        modifier={select(
+          'Modifier',
+          ['info', 'warning', 'error', 'success', 'disabled'],
+          'info',
+        )}
+        children={text('Text', 'The text of my Toggletip.')}
+      />
+    </div>
+  )
+}
+
+export const MultipleToggletips = () => (
+  <div className="k-u-margin-vertical-quadruple k-u-margin-horizontal-quadruple">
+    <div className="k-u-margin-bottom-quadruple">
+      <Toggletip
+        actionLabel="Sample label"
+        id="Toggletip-top"
+        place="left"
+        children="First Toggletip"
+      />
+    </div>
+    <div className="k-u-margin-top-quadruple k-u-align-right">
+      <Toggletip actionLabel="Sample label" id="Toggletip-bottom" place="right">
+        This is a text{' '}
+        <a className="k-u-link k-u-link-primary1" href="#">
+          with a link
+        </a>
+        .
+      </Toggletip>
+    </div>
+  </div>
+)

--- a/assets/javascripts/kitten/components/tooltips/toggletip/test.js
+++ b/assets/javascripts/kitten/components/tooltips/toggletip/test.js
@@ -1,0 +1,49 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { Toggletip } from './index'
+
+describe('<Toggletip />', () => {
+  let component
+
+  describe('Default', () => {
+    beforeEach(() => {
+      component = renderer
+        .create(
+          <Toggletip actionLabel="Sample label" id="Toggletip-demo">
+            This is the content of the Toggletip
+          </Toggletip>,
+        )
+        .toJSON()
+    })
+
+    it('matches with snapshot', () => {
+      expect(component).toMatchSnapshot()
+    })
+  })
+
+  describe('With props', () => {
+    beforeEach(() => {
+      component = renderer
+        .create(
+          <Toggletip
+            actionLabel="Sample label"
+            id="Toggletip-demo"
+            modifier="warning"
+            bubbleProps={{
+              className: 'customClassName',
+            }}
+            actionProps={{
+              className: 'customClassName',
+            }}
+          >
+            <div>This is the custom content of the Toggletip</div>
+          </Toggletip>,
+        )
+        .toJSON()
+    })
+
+    it('matches with snapshot', () => {
+      expect(component).toMatchSnapshot()
+    })
+  })
+})

--- a/assets/javascripts/kitten/components/tooltips/toggletip/test.js
+++ b/assets/javascripts/kitten/components/tooltips/toggletip/test.js
@@ -31,6 +31,7 @@ describe('<Toggletip />', () => {
             modifier="warning"
             bubbleProps={{
               className: 'customClassName',
+              zIndex: 500,
             }}
             actionProps={{
               className: 'customClassName',

--- a/assets/javascripts/kitten/components/tooltips/tooltip/tooltip.stories.js
+++ b/assets/javascripts/kitten/components/tooltips/tooltip/tooltip.stories.js
@@ -10,7 +10,7 @@ const StoryContainer = ({ children }) => (
 )
 
 export default {
-  title: 'Tooltip/Tooltip',
+  title: 'Tooltips/Tooltip',
   component: Tooltip,
 }
 

--- a/assets/javascripts/kitten/constants/colors-config.js
+++ b/assets/javascripts/kitten/constants/colors-config.js
@@ -22,14 +22,14 @@ export default {
   tertiary2: '#cff0d6', // Semi Light Green
 
   valid: '#61d079', // Green
-  valid1: 'rgba(97, 208, 121, .1)', // Green Light
+  valid1: 'hsl(133, 54%, 94%)', // Green Light
 
   error: '#ff0046', // Red
   error2: '#ffe5ec', // Light Red
   error3: '#ffb2c7', // Semi Light Red
 
   orange: '#ff7800',
-  orange1: 'rgba(255, 130, 15, .1)', // Orange light
+  orange1: '#fff2e7', // Orange light
 
   warning: '#8a6d3b',
   warning2: '#fcf8e3',

--- a/assets/javascripts/kitten/index.js
+++ b/assets/javascripts/kitten/index.js
@@ -246,6 +246,7 @@ export { TextCopy } from './components/text-copy'
 // Tooltips
 export { QuestionMarkWithTooltip } from './components/tooltips/question-mark-with-tooltip'
 export { StaticTooltip } from './components/tooltips/static-tooltip'
+export { Toggletip } from './components/tooltips/toggletip'
 export { TooltipNew } from './components/tooltips/tooltip-new'
 export { Tooltip } from './components/tooltips/tooltip'
 


### PR DESCRIPTION
Closes #.

- Création du composant `Toggletip`
- prop `modifier` acceptant les valeurs **'info'**, 'warning', 'error', 'success', 'disabled'

Vercel link:

- https://kitten-git-tooltips-tooltip-next.kisskissbankbank.vercel.app/?path=/story/tooltips-toggletip--default
- https://kitten-git-tooltips-tooltip-next.kisskissbankbank.vercel.app/?path=/story/tooltips-toggletip--multiple-toggletips

Basé sur : https://inclusive-components.design/tooltips-toggletips/
TODO:

- [x] Tests
- [x] Changelog
- [x] A11Y
- [x] Stories / Docs
- [ ] BrowserStack (IE11, Chrome & Firefox on Windows 10)
- [x] New component added to `assets/javascripts/kitten/index.js`
