### PR TITLE
[HeaderNav] Fix StickyContainer width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix `StickyContainer` width on `HeaderNav`.
+
 ## [2.122.0] - 2021-02-25
 
 Features:

--- a/assets/javascripts/kitten/components/navigation/header-nav/index.js
+++ b/assets/javascripts/kitten/components/navigation/header-nav/index.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react'
+import classNames from 'classnames'
 import PropTypes from 'prop-types'
 import styled, { css } from 'styled-components'
 import { ScreenConfig } from '../../../constants/screen-config'
@@ -190,6 +191,10 @@ const HeaderNav = ({
           isSticky={stickyState}
           isMenuExpanded={isMenuExpanded}
           {...stickyProps}
+          className={classNames(
+            'k-HeaderNav__stickyContainer',
+            stickyProps.className,
+          )}
         >
           <Navigation
             ref={headerRef}

--- a/assets/stylesheets/kitten/components/navigation/_header-nav.scss
+++ b/assets/stylesheets/kitten/components/navigation/_header-nav.scss
@@ -71,6 +71,10 @@
     }
   }
 
+  .k-HeaderNav__stickyContainer {
+    width: 100%;
+  }
+
   .k-HeaderNav-Logo {
     padding: k-px-to-rem(10px);
     display: flex;


### PR DESCRIPTION
Closes #.

Vercel link:

- https://kitten-git-…

Screenshot:


TODO:

- [x] Tests
- [ ] Changelog
- [ ] A11Y
- [ ] Stories / Docs
- [ ] BrowserStack (IE11, Chrome & Firefox on Windows 10)
- [ ] New component added to `assets/javascripts/kitten/index.js`
