### PR TITLE
[HeaderNav] Allow for null value on stickyProps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Allow for `null` value on `HeaderNav` `stickyProps` prop.
+
 ## [2.123.0] - 2021-03-01
 
 Feature:

--- a/assets/javascripts/kitten/components/navigation/header-nav/index.js
+++ b/assets/javascripts/kitten/components/navigation/header-nav/index.js
@@ -193,7 +193,7 @@ const HeaderNav = ({
           {...stickyProps}
           className={classNames(
             'k-HeaderNav__stickyContainer',
-            stickyProps?.className || null,
+            stickyProps?.className,
           )}
         >
           <Navigation

--- a/assets/javascripts/kitten/components/navigation/header-nav/index.js
+++ b/assets/javascripts/kitten/components/navigation/header-nav/index.js
@@ -193,7 +193,7 @@ const HeaderNav = ({
           {...stickyProps}
           className={classNames(
             'k-HeaderNav__stickyContainer',
-            stickyProps.className,
+            stickyProps?.className || null,
           )}
         >
           <Navigation

--- a/assets/javascripts/kitten/components/navigation/header-nav/stories.js
+++ b/assets/javascripts/kitten/components/navigation/header-nav/stories.js
@@ -27,6 +27,7 @@ export const Lendopolis = () => (
     <LendopolisHeaderNavStory
       isLogged={boolean('Is logged', false)}
       isFixed={boolean('Is fixed', false)}
+      stickyProps={boolean('null stickyProps?') ? null : {}}
     />
   </Container>
 )

--- a/assets/javascripts/kitten/components/navigation/header-nav/stories/lendopolis.js
+++ b/assets/javascripts/kitten/components/navigation/header-nav/stories/lendopolis.js
@@ -93,7 +93,11 @@ const InnerAnonymousMenu = () => (
   </HeaderMenu>
 )
 
-export const LendopolisHeaderNavStory = ({ isLogged, isFixed }) => {
+export const LendopolisHeaderNavStory = ({
+  isLogged,
+  isFixed,
+  stickyProps,
+}) => {
   const [burgerMenuWidth, setBurgerMenuWidth] = useState(null)
   const [userMenuWidth, setUserMenuWidth] = useState(null)
 
@@ -121,6 +125,7 @@ export const LendopolisHeaderNavStory = ({ isLogged, isFixed }) => {
         text: 'Aller au contenu',
         zIndex: 300,
       }}
+      stickyProps={stickyProps}
     >
       <HeaderNav.BurgerMenu dropdownContentWidth={pxToRem(burgerMenuWidth)}>
         <InnerBurgerMenu />


### PR DESCRIPTION
Closes #.

Vercel link:

- https://kitten-git-fix-header-nav-kisskissbankbank.vercel.app/?path=/story/navigation-headernav--lendopolis

Screenshot:


TODO:

- [ ] Tests
- [x] Changelog
- [ ] A11Y
- [ ] Stories / Docs
- [ ] BrowserStack (IE11, Chrome & Firefox on Windows 10)
- [ ] New component added to `assets/javascripts/kitten/index.js`
