### PR TITLE
Fix carousel perf issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+Fix: Perf problem with `Carousel` on mobile devices 
+
 ## [2.123.1] - 2021-03-01
 
 Fix:

--- a/assets/javascripts/kitten/components/carousel/carousel/components/carousel-inner.js
+++ b/assets/javascripts/kitten/components/carousel/carousel/components/carousel-inner.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react'
+import React, { useEffect, useRef } from 'react'
 import ResizeObserver from 'resize-observer-polyfill'
 import { domElementHelper } from '../../../../helpers/dom/element-helper'
 import { CarouselPage } from './carousel-page'
@@ -8,6 +8,8 @@ import { usePrevious } from '../../../../helpers/utils/use-previous-hook'
 if (domElementHelper.canUseDom()) {
   require('smoothscroll-polyfill').polyfill()
 }
+
+let isTouched = false
 
 // inspired by https://github.com/cferdinandi/scrollStop
 const scrollStop = callback => {
@@ -63,7 +65,6 @@ export const CarouselInner = ({
   viewedPages,
   pageClickText,
 }) => {
-  const [isTouched, setTouchState] = useState(false)
   const carouselInner = useRef(null)
   const previousIndexPageVisible = usePrevious(currentPageIndex)
 
@@ -154,8 +155,8 @@ export const CarouselInner = ({
     <div
       ref={carouselInner}
       onScroll={handleInnerScroll}
-      onTouchStart={() => setTouchState(true)}
-      onTouchEnd={() => setTouchState(false)}
+      onTouchStart={() => (isTouched = true)}
+      onTouchEnd={() => (isTouched = false)}
       onKeyDown={handleKeyDown}
       className="k-Carousel__inner"
     >

--- a/src/components/carousel/carousel/components/carousel-inner.js
+++ b/src/components/carousel/carousel/components/carousel-inner.js
@@ -27,8 +27,9 @@ var _usePreviousHook = require("../../../../helpers/utils/use-previous-hook");
 
 if (_elementHelper.domElementHelper.canUseDom()) {
   require('smoothscroll-polyfill').polyfill();
-} // inspired by https://github.com/cferdinandi/scrollStop
+}
 
+var isTouched = false; // inspired by https://github.com/cferdinandi/scrollStop
 
 var scrollStop = function scrollStop(callback) {
   if (!callback) return;
@@ -76,12 +77,6 @@ var CarouselInner = function CarouselInner(_ref) {
       pagesClassName = _ref.pagesClassName,
       viewedPages = _ref.viewedPages,
       pageClickText = _ref.pageClickText;
-
-  var _useState = (0, _react.useState)(false),
-      _useState2 = (0, _slicedToArray2.default)(_useState, 2),
-      isTouched = _useState2[0],
-      setTouchState = _useState2[1];
-
   var carouselInner = (0, _react.useRef)(null);
   var previousIndexPageVisible = (0, _usePreviousHook.usePrevious)(currentPageIndex);
   var resizeObserver;
@@ -165,10 +160,10 @@ var CarouselInner = function CarouselInner(_ref) {
     ref: carouselInner,
     onScroll: handleInnerScroll,
     onTouchStart: function onTouchStart() {
-      return setTouchState(true);
+      return isTouched = true;
     },
     onTouchEnd: function onTouchEnd() {
-      return setTouchState(false);
+      return isTouched = false;
     },
     onKeyDown: handleKeyDown,
     className: "k-Carousel__inner"

--- a/src/esm/components/carousel/carousel/components/carousel-inner.js
+++ b/src/esm/components/carousel/carousel/components/carousel-inner.js
@@ -1,6 +1,6 @@
 import _slicedToArray from "@babel/runtime/helpers/esm/slicedToArray";
 import _toConsumableArray from "@babel/runtime/helpers/esm/toConsumableArray";
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import ResizeObserver from 'resize-observer-polyfill';
 import { domElementHelper } from '../../../../helpers/dom/element-helper';
 import { CarouselPage } from './carousel-page';
@@ -9,8 +9,9 @@ import { usePrevious } from '../../../../helpers/utils/use-previous-hook';
 
 if (domElementHelper.canUseDom()) {
   require('smoothscroll-polyfill').polyfill();
-} // inspired by https://github.com/cferdinandi/scrollStop
+}
 
+var isTouched = false; // inspired by https://github.com/cferdinandi/scrollStop
 
 var scrollStop = function scrollStop(callback) {
   if (!callback) return;
@@ -58,12 +59,6 @@ export var CarouselInner = function CarouselInner(_ref) {
       pagesClassName = _ref.pagesClassName,
       viewedPages = _ref.viewedPages,
       pageClickText = _ref.pageClickText;
-
-  var _useState = useState(false),
-      _useState2 = _slicedToArray(_useState, 2),
-      isTouched = _useState2[0],
-      setTouchState = _useState2[1];
-
   var carouselInner = useRef(null);
   var previousIndexPageVisible = usePrevious(currentPageIndex);
   var resizeObserver;
@@ -147,10 +142,10 @@ export var CarouselInner = function CarouselInner(_ref) {
     ref: carouselInner,
     onScroll: handleInnerScroll,
     onTouchStart: function onTouchStart() {
-      return setTouchState(true);
+      return isTouched = true;
     },
     onTouchEnd: function onTouchEnd() {
-      return setTouchState(false);
+      return isTouched = false;
     },
     onKeyDown: handleKeyDown,
     className: "k-Carousel__inner"


### PR DESCRIPTION
L'utilisation du state sur le `isTouched` causait une cascade de rerender qui faisait freeze le navigateur.
Le bug n'était reproductible que sur des devices mobiles (prise en compte des `onTouchStart
` et `onTouchEnd
`

Comme le `isTouched` n'était pas nécessaire pour le render, j'ai juste créé une variable pour sauvegarder la valeur utilisée par le callback `handleInnerScroll`