### PR TITLE
[Tables] Fix classNames on SingleEntryTable and DoubleEntryTable 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Feature: Add `className` prop propagation to `SingleEntryTable` and subcomponents:
+  - `SingleEntryTable.Col`
+  - `SingleEntryTable.HeaderCol`
+- Feature: Add `className` prop propagation to `DoubleEntryTable` and subcomponents:
+  - `DoubleEntryTable.Col`
+  - `DoubleEntryTable.HeaderCol`
+  - `DoubleEntryTable.TitleCol`
+
+
 ## [2.123.3] - 2021-03-10
 
 Fix:

--- a/assets/javascripts/kitten/components/tables/double-entry-table/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/tables/double-entry-table/__snapshots__/test.js.snap
@@ -8,7 +8,7 @@ exports[`<DoubleEntryTable /> with a complete structure and custom classes match
     className="DoubleEntryTable__TableContainer"
   >
     <table
-      className="DoubleEntryTable__Table"
+      className="DoubleEntryTable__Table customClass"
       id="DestBoubleEntryTable"
     >
       <thead
@@ -28,7 +28,7 @@ exports[`<DoubleEntryTable /> with a complete structure and custom classes match
             Header 2
           </th>
           <th
-            className="DoubleEntryTable__Column DoubleEntryTable__Column--HeaderCol"
+            className="DoubleEntryTable__Column DoubleEntryTable__Column--HeaderCol customHeaderColClass"
             scope="column"
           >
             Header 3
@@ -38,13 +38,13 @@ exports[`<DoubleEntryTable /> with a complete structure and custom classes match
       <tbody>
         <tr>
           <th
-            className="DoubleEntryTable__Column DoubleEntryTable__Column--TitleCol"
+            className="DoubleEntryTable__Column DoubleEntryTable__Column--TitleCol customTitleColClass"
             scope="row"
           >
             Content 1
           </th>
           <td
-            className="DoubleEntryTable__Column DoubleEntryTable__Column--Col"
+            className="DoubleEntryTable__Column DoubleEntryTable__Column--Col customColClass"
           >
             Content 2
           </td>

--- a/assets/javascripts/kitten/components/tables/double-entry-table/index.js
+++ b/assets/javascripts/kitten/components/tables/double-entry-table/index.js
@@ -1,11 +1,15 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import classNames from 'classnames'
 import { Styles } from './styles'
 
-export const DoubleEntryTable = ({ firstColWidth, ...props }) => (
+export const DoubleEntryTable = ({ firstColWidth, className, ...props }) => (
   <Styles className="DoubleEntryTable__Container" firstColWidth={firstColWidth}>
     <div className="DoubleEntryTable__TableContainer">
-      <table className="DoubleEntryTable__Table" {...props} />
+      <table
+        className={classNames('DoubleEntryTable__Table', className)}
+        {...props}
+      />
     </div>
   </Styles>
 )
@@ -17,22 +21,31 @@ DoubleEntryTable.Header = ({ children, headerRowProps, ...others }) => (
 )
 DoubleEntryTable.Body = props => <tbody {...props} />
 DoubleEntryTable.Row = props => <tr {...props} />
-DoubleEntryTable.Col = props => (
+DoubleEntryTable.Col = ({ className, ...props }) => (
   <td
-    className="DoubleEntryTable__Column DoubleEntryTable__Column--Col"
+    className={classNames(
+      'DoubleEntryTable__Column DoubleEntryTable__Column--Col',
+      className,
+    )}
     {...props}
   />
 )
-DoubleEntryTable.HeaderCol = props => (
+DoubleEntryTable.HeaderCol = ({ className, ...props }) => (
   <th
-    className="DoubleEntryTable__Column DoubleEntryTable__Column--HeaderCol"
+    className={classNames(
+      'DoubleEntryTable__Column DoubleEntryTable__Column--HeaderCol',
+      className,
+    )}
     scope="column"
     {...props}
   />
 )
-DoubleEntryTable.TitleCol = props => (
+DoubleEntryTable.TitleCol = ({ className, ...props }) => (
   <th
-    className="DoubleEntryTable__Column DoubleEntryTable__Column--TitleCol"
+    className={classNames(
+      'DoubleEntryTable__Column DoubleEntryTable__Column--TitleCol',
+      className,
+    )}
     scope="row"
     {...props}
   />

--- a/assets/javascripts/kitten/components/tables/double-entry-table/test.js
+++ b/assets/javascripts/kitten/components/tables/double-entry-table/test.js
@@ -9,17 +9,23 @@ describe('<DoubleEntryTable />', () => {
     beforeEach(() => {
       component = renderer
         .create(
-          <DoubleEntryTable id="DestBoubleEntryTable">
+          <DoubleEntryTable id="DestBoubleEntryTable" className="customClass">
             <DoubleEntryTable.Header className="customHeaderClass">
               <DoubleEntryTable.HeaderCol>Header 1</DoubleEntryTable.HeaderCol>
               <DoubleEntryTable.HeaderCol>Header 2</DoubleEntryTable.HeaderCol>
-              <DoubleEntryTable.HeaderCol>Header 3</DoubleEntryTable.HeaderCol>
+              <DoubleEntryTable.HeaderCol className="customHeaderColClass">
+                Header 3
+              </DoubleEntryTable.HeaderCol>
             </DoubleEntryTable.Header>
 
             <DoubleEntryTable.Body>
               <DoubleEntryTable.Row>
-                <DoubleEntryTable.TitleCol>Content 1</DoubleEntryTable.TitleCol>
-                <DoubleEntryTable.Col>Content 2</DoubleEntryTable.Col>
+                <DoubleEntryTable.TitleCol className="customTitleColClass">
+                  Content 1
+                </DoubleEntryTable.TitleCol>
+                <DoubleEntryTable.Col className="customColClass">
+                  Content 2
+                </DoubleEntryTable.Col>
                 <DoubleEntryTable.Col>Content 3</DoubleEntryTable.Col>
               </DoubleEntryTable.Row>
               <DoubleEntryTable.Row className="customRowClass">

--- a/assets/javascripts/kitten/components/tables/single-entry-table/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/tables/single-entry-table/__snapshots__/test.js.snap
@@ -82,7 +82,7 @@ exports[`<SingleEntryTable /> with a complete structure and custom classes match
     className="SingleEntryTable__TableContainer"
   >
     <table
-      className="SingleEntryTable__Table"
+      className="SingleEntryTable__Table customClass"
       id="SingleEntryTable"
     >
       <thead
@@ -90,7 +90,7 @@ exports[`<SingleEntryTable /> with a complete structure and custom classes match
       >
         <tr>
           <th
-            className="SingleEntryTable__Column SingleEntryTable__Column--HeaderCol"
+            className="SingleEntryTable__Column SingleEntryTable__Column--HeaderCol customHeaderColClass"
             scope="column"
           >
             Header 1
@@ -112,7 +112,7 @@ exports[`<SingleEntryTable /> with a complete structure and custom classes match
       <tbody>
         <tr>
           <td
-            className="SingleEntryTable__Column SingleEntryTable__Column--Col"
+            className="SingleEntryTable__Column SingleEntryTable__Column--Col customColClass"
           >
             Content 1
           </td>

--- a/assets/javascripts/kitten/components/tables/single-entry-table/index.js
+++ b/assets/javascripts/kitten/components/tables/single-entry-table/index.js
@@ -2,14 +2,21 @@ import React from 'react'
 import { Styles } from './styles'
 import classNames from 'classnames'
 
-export const SingleEntryTable = ({ isSliding = false, ...props }) => (
+export const SingleEntryTable = ({
+  className,
+  isSliding = false,
+  ...props
+}) => (
   <Styles
     className={classNames('SingleEntryTable__Container', {
       'SingleEntryTable--isSliding': isSliding,
     })}
   >
     <div className="SingleEntryTable__TableContainer">
-      <table className="SingleEntryTable__Table" {...props} />
+      <table
+        className={classNames('SingleEntryTable__Table', className)}
+        {...props}
+      />
     </div>
   </Styles>
 )
@@ -24,16 +31,22 @@ SingleEntryTable.Body = props => <tbody {...props} />
 
 SingleEntryTable.Row = props => <tr {...props} />
 
-SingleEntryTable.Col = props => (
+SingleEntryTable.Col = ({ className, ...props }) => (
   <td
-    className="SingleEntryTable__Column SingleEntryTable__Column--Col"
+    className={classNames(
+      'SingleEntryTable__Column SingleEntryTable__Column--Col',
+      className,
+    )}
     {...props}
   />
 )
 
-SingleEntryTable.HeaderCol = props => (
+SingleEntryTable.HeaderCol = ({ className, ...props }) => (
   <th
-    className="SingleEntryTable__Column SingleEntryTable__Column--HeaderCol"
+    className={classNames(
+      'SingleEntryTable__Column SingleEntryTable__Column--HeaderCol',
+      className,
+    )}
     scope="column"
     {...props}
   />

--- a/assets/javascripts/kitten/components/tables/single-entry-table/test.js
+++ b/assets/javascripts/kitten/components/tables/single-entry-table/test.js
@@ -9,16 +9,20 @@ describe('<SingleEntryTable />', () => {
     beforeEach(() => {
       component = renderer
         .create(
-          <SingleEntryTable id="SingleEntryTable">
+          <SingleEntryTable id="SingleEntryTable" className="customClass">
             <SingleEntryTable.Header className="customHeaderClass">
-              <SingleEntryTable.HeaderCol>Header 1</SingleEntryTable.HeaderCol>
+              <SingleEntryTable.HeaderCol className="customHeaderColClass">
+                Header 1
+              </SingleEntryTable.HeaderCol>
               <SingleEntryTable.HeaderCol>Header 2</SingleEntryTable.HeaderCol>
               <SingleEntryTable.HeaderCol>Header 3</SingleEntryTable.HeaderCol>
             </SingleEntryTable.Header>
 
             <SingleEntryTable.Body>
               <SingleEntryTable.Row>
-                <SingleEntryTable.Col>Content 1</SingleEntryTable.Col>
+                <SingleEntryTable.Col className="customColClass">
+                  Content 1
+                </SingleEntryTable.Col>
                 <SingleEntryTable.Col>Content 2</SingleEntryTable.Col>
                 <SingleEntryTable.Col>Content 3</SingleEntryTable.Col>
               </SingleEntryTable.Row>


### PR DESCRIPTION
Closes #.

Vercel link:

- https://kitten-git-…

Screenshot:


TODO:

- [x] Tests
- [x] Changelog
- [ ] A11Y
- [ ] Stories / Docs
- [ ] BrowserStack (IE11, Chrome & Firefox on Windows 10)
- [ ] New component added to `assets/javascripts/kitten/index.js`
