### PR TITLE
[AvatarWithTextAndBadge] Fix ellipsis for children of `AvaratWithText…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Fix ellipsis for children of `AvaratWithTextAndBadge`.
+
 ## [3.0.0-beta.15] - 2021-03-12
 
 Fix:

--- a/assets/javascripts/kitten/components/atoms/status-with-bullet/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/atoms/status-with-bullet/__snapshots__/test.js.snap
@@ -2,40 +2,52 @@
 
 exports[`<StatusWithBullet /> should match its empty snapshot 1`] = `
 <span
-  className="sc-bdVaJa kyWlgl k-StatusWithBullet k-StatusWithBullet--success k-StatusWithBullet--tiny k-StatusWithBullet--regular"
+  className="sc-bdVaJa hpjRKv k-StatusWithBullet k-StatusWithBullet--success k-StatusWithBullet--tiny k-StatusWithBullet--regular"
 >
   <span
     aria-hidden="true"
     className="k-StatusWithBullet__bullet"
   />
-  This is a text
+  <span
+    className="k-StatusWithBullet__status"
+  >
+    This is a text
+  </span>
 </span>
 `;
 
 exports[`<StatusWithBullet /> should match its snapshot with children 1`] = `
 <span
-  className="sc-bdVaJa kyWlgl k-StatusWithBullet k-StatusWithBullet--danger k-StatusWithBullet--tiny k-StatusWithBullet--regular"
+  className="sc-bdVaJa hpjRKv k-StatusWithBullet k-StatusWithBullet--danger k-StatusWithBullet--tiny k-StatusWithBullet--regular"
 >
   <span
     aria-hidden="true"
     className="k-StatusWithBullet__bullet"
   />
-  Sample message
+  <span
+    className="k-StatusWithBullet__status"
+  >
+    Sample message
+  </span>
 </span>
 `;
 
 exports[`<StatusWithBullet /> should match its snapshot with many props 1`] = `
 <span
-  className="sc-bdVaJa kyWlgl k-StatusWithBullet k-u-sample-class k-StatusWithBullet--none k-StatusWithBullet--micro k-StatusWithBullet--light"
+  className="sc-bdVaJa hpjRKv k-StatusWithBullet k-u-sample-class k-StatusWithBullet--none k-StatusWithBullet--micro k-StatusWithBullet--light"
 >
   <span
     aria-hidden="true"
     className="k-StatusWithBullet__bullet k-u-sample-class"
   />
   <span
-    className="k-u-sample-class"
+    className="k-StatusWithBullet__status"
   >
-    Sample message
+    <span
+      className="k-u-sample-class"
+    >
+      Sample message
+    </span>
   </span>
 </span>
 `;

--- a/assets/javascripts/kitten/components/atoms/status-with-bullet/index.js
+++ b/assets/javascripts/kitten/components/atoms/status-with-bullet/index.js
@@ -16,6 +16,11 @@ const StyledStatus = styled.span`
     background-color: currentColor;
     border-radius: 50%;
     margin-top: ${pxToRem(2)};
+    flex: 0 0 auto;
+  }
+
+  .k-StatusWithBullet__status {
+    flex: 0 1 auto;
   }
 
   &.k-StatusWithBullet--danger {
@@ -101,7 +106,9 @@ export const StatusWithBullet = ({
           bulletProps?.className,
         )}
       />
-      {statusMessage || children}
+      <span className="k-StatusWithBullet__status">
+        {statusMessage || children}
+      </span>
     </StyledStatus>
   )
 }

--- a/assets/javascripts/kitten/components/avatar/avatar-with-text-and-badge/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/avatar/avatar-with-text-and-badge/__snapshots__/test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<AvatarWithTextAndBadge /> with multiple lines and badge should match with snapshot 1`] = `
 <div
-  className="sc-bwzfXH djXFQD k-Avatar__wrapper"
+  className="sc-bwzfXH fUWdyG k-Avatar__wrapper"
 >
   <div
     className="k-Avatar k-Avatar--big"
@@ -56,7 +56,7 @@ exports[`<AvatarWithTextAndBadge /> with multiple lines and badge should match w
 
 exports[`<AvatarWithTextAndBadge /> with simple props and avatar should match with snapshot 1`] = `
 <div
-  className="sc-bwzfXH djXFQD k-Avatar__wrapper"
+  className="sc-bwzfXH fUWdyG k-Avatar__wrapper"
 >
   <div
     className="k-Avatar k-Avatar--regular"
@@ -89,7 +89,7 @@ exports[`<AvatarWithTextAndBadge /> with simple props and avatar should match wi
 
 exports[`<AvatarWithTextAndBadge /> with simple props and no avatar image should match with snapshot 1`] = `
 <div
-  className="sc-bwzfXH djXFQD k-Avatar__wrapper"
+  className="sc-bwzfXH fUWdyG k-Avatar__wrapper"
 >
   <div
     className="k-Avatar k-Avatar--regular"

--- a/assets/javascripts/kitten/components/avatar/avatar-with-text-and-badge/index.js
+++ b/assets/javascripts/kitten/components/avatar/avatar-with-text-and-badge/index.js
@@ -83,10 +83,12 @@ const StyledWrapper = styled.div`
   }
 
   .k-Avatar__text--hasEllipsis {
-    max-width: 100%;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    overflow: hidden;
+    &, & * {
+      max-width: 100%;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      overflow: hidden;
+    }
   }
 
   .k-Avatar--big {

--- a/assets/javascripts/kitten/components/layout/dashboard-layout/stories.js
+++ b/assets/javascripts/kitten/components/layout/dashboard-layout/stories.js
@@ -99,25 +99,18 @@ export const Default = () => {
               T-shirts brodés Free Boobs Club
             </Text>
             <br />
-            <Text
-              lineHeight="normal"
+            <StatusWithBullet
+              as="span"
               weight="light"
-              size="nano"
-              color="background1"
+              size="micro"
+              statusType={select(
+                'Status type',
+                ['danger', 'success', 'warning', 'neutral', 'none'],
+                'success',
+              )}
             >
-              <StatusWithBullet
-                as="span"
-                weight="light"
-                size="micro"
-                statusType={select(
-                  'Status type',
-                  ['danger', 'success', 'warning', 'neutral', 'none'],
-                  'success',
-                )}
-              >
-                Prêt a être partagé
-              </StatusWithBullet>
-            </Text>
+              Prêt a être partagé avec un texte long pour tester l’ellipse
+            </StatusWithBullet>
           </AvatarWithTextAndBadge.Text>
         </AvatarWithTextAndBadge>
       </DashboardLayout.Header>


### PR DESCRIPTION
…AndBadge`

Closes #.

Vercel link:

- Visible en Desktop : https://kitten-git-v3-avatar-with-text-and-badgefix-elli-b2dcbb.vercel.app/iframe.html?id=layout-dashboardlayout--default&viewMode=story

Screenshot:


TODO:

- [x] Tests
- [x] Changelog
- [ ] A11Y
- [x] Stories / Docs
- [ ] BrowserStack (IE11, Chrome & Firefox on Windows 10)
- [ ] New component added to `assets/javascripts/kitten/index.js`
