### PR TITLE
[HeaderNav] Fix `UserMenuButton` alignment on Chrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Fix alignment on `HeaderNav` `UserMenuButton`.
+
 ## [3.0.0-beta.15] - 2021-03-12
 
 Fix:

--- a/assets/javascripts/kitten/components/navigation/header-nav/styles.js
+++ b/assets/javascripts/kitten/components/navigation/header-nav/styles.js
@@ -126,8 +126,9 @@ export const StyledHeader = styled.header`
   }
 
   .k-HeaderNav__UserMenuButton {
-    display: flex;
     align-self: center;
+    display: flex;
+    align-items: center;
     justify-content: center;
     height: 100%;
     padding: 0 ${pxToRem(40)};


### PR DESCRIPTION
Closes #.

Vercel link:

- Ouvrir dans Chrome : https://kitten-git-v3-header-navfix-user-menu-button-ali-2effe9.vercel.app/iframe.html?id=navigation-headernav--kiss-kiss-bank-bank&knob-Is%20logged=true&viewMode=story

Screenshot:


TODO:

- [ ] Tests
- [ ] Changelog
- [ ] A11Y
- [ ] Stories / Docs
- [ ] BrowserStack (IE11, Chrome & Firefox on Windows 10)
- [ ] New component added to `assets/javascripts/kitten/index.js`
