### PR TITLE
[KittenV3] Fix `getScssPaths` import

### DIFF
--- a/assets/javascripts/kitten/index.js
+++ b/assets/javascripts/kitten/index.js
@@ -424,9 +424,3 @@ export { hexToRgba } from './helpers/utils/hex-to-rgba'
 
 export { default as withLazy } from './hoc/with-lazy'
 export { withMediaQueries, mediaQueries } from './hoc/media-queries'
-
-// ------
-// CONFIG
-// ------
-
-export { getScssPaths } from './config/paths'


### PR DESCRIPTION
Closes #.

Vercel link:

- https://kitten-git-…

Screenshot:


TODO:

- [ ] Tests
- [ ] Changelog
- [ ] A11Y
- [ ] Stories / Docs
- [ ] BrowserStack (IE11, Chrome & Firefox on Windows 10)
- [ ] New component added to `assets/javascripts/kitten/index.js`
