### PR TITLE
set back npm install before I run storybook

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "test": "jest --maxWorkers=2",
     "test:update:snapshots": "jest --updateSnapshot",
     "prepublishOnly": "npm run test && npm run build:js",
-    "storybook": "start-storybook -s .storybook/public -p 6006 --no-manager-cache",
+    "storybook": "npm i && start-storybook -s .storybook/public -p 6006 --no-manager-cache",
     "build-storybook": "build-storybook -s .storybook/public",
     "deploy-storybook": "storybook-to-ghpages",
     "clean:src": "rm -rf src/components src/config src/constants src/handlers src/helpers src/hoc",


### PR DESCRIPTION
Je remets l'étape `npm install` pour éviter des surprises