### PR TITLE
[KittenV3] fix Carousel resize observer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Replace `ResizeObserver` with `window.resize` on `Carousel`.
+
 ## [3.0.0-beta.19] - 2021-03-19
 
 Breaking changes:

--- a/assets/javascripts/kitten/components/carousel/carousel/components/carousel-inner.js
+++ b/assets/javascripts/kitten/components/carousel/carousel/components/carousel-inner.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef } from 'react'
 import ResizeObserver from 'resize-observer-polyfill'
+import throttle from 'lodash/throttle'
 import { domElementHelper } from '../../../../helpers/dom/element-helper'
 import { CarouselPage } from './carousel-page'
 import classNames from 'classnames'
@@ -68,22 +69,18 @@ export const CarouselInner = ({
   const carouselInner = useRef(null)
   const previousIndexPageVisible = usePrevious(currentPageIndex)
 
-  let resizeObserver
-
-  const onResizeObserve = ([entry]) => {
-    const innerWidth = entry.contentRect.width
-    onResizeInner(innerWidth)
-  }
-
   useEffect(() => {
-    resizeObserver = new ResizeObserver(onResizeObserve)
+    domElementHelper.canUseDom() && window.addEventListener('resize', throttleWindowResize)
 
-    return () => resizeObserver.disconnect()
+    return () => domElementHelper.canUseDom() && window.removeEventListener('resize', throttleWindowResize)
   }, [])
 
-  useEffect(() => {
-    carouselInner.current && resizeObserver.observe(carouselInner.current)
-  }, [carouselInner])
+  const onWindowResize = () => {
+    const innerWidth = carouselInner.current && carouselInner.current.clientWidth
+    innerWidth && onResizeInner(innerWidth)
+  }
+
+  const throttleWindowResize = throttle(onWindowResize, 200)
 
   useEffect(() => {
     if (currentPageIndex !== previousIndexPageVisible) {

--- a/assets/javascripts/kitten/components/carousel/carousel/components/carousel-inner.js
+++ b/assets/javascripts/kitten/components/carousel/carousel/components/carousel-inner.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react'
 import ResizeObserver from 'resize-observer-polyfill'
-import throttle from 'lodash/throttle'
+import throttle from 'lodash/fp/throttle'
 import { domElementHelper } from '../../../../helpers/dom/element-helper'
 import { CarouselPage } from './carousel-page'
 import classNames from 'classnames'
@@ -80,7 +80,7 @@ export const CarouselInner = ({
     innerWidth && onResizeInner(innerWidth)
   }
 
-  const throttleWindowResize = throttle(onWindowResize, 200)
+  const throttleWindowResize = throttle(200)(onWindowResize)
 
   useEffect(() => {
     if (currentPageIndex !== previousIndexPageVisible) {

--- a/assets/javascripts/kitten/components/carousel/carousel/project-carousel.stories.js
+++ b/assets/javascripts/kitten/components/carousel/carousel/project-carousel.stories.js
@@ -150,7 +150,7 @@ export const Default = () => (
           cardTitle={item.title}
           cardSubTitle="Custom subtitle"
           titlesMinHeight
-          progress="84"
+          progress={84}
           state="Custom state"
         />
       ))}
@@ -198,7 +198,7 @@ export const WithSpecificColNumber = () => (
           cardTitle={item.title}
           cardSubTitle="Custom subtitle"
           titlesMinHeight
-          progress="84"
+          progress={84}
           state="Custom state"
         />
       ))}
@@ -235,7 +235,7 @@ export const InNestedGrid = () => (
           cardTitle={item.title}
           cardSubTitle="Custom subtitle"
           titlesMinHeight
-          progress="84"
+          progress={84}
           state="Custom state"
         />
       ))}
@@ -276,7 +276,7 @@ export const InLegacyGrid = () => (
           cardTitle={item.title}
           cardSubTitle="Custom subtitle"
           titlesMinHeight
-          progress="84"
+          progress={84}
           state="Custom state"
         />
       )}
@@ -323,7 +323,7 @@ const CardComponent = ({ item, hasPageBeenViewed, isActivePage }) => (
     cardTitle={item.title}
     cardSubTitle={isActivePage ? 'Is active page' : 'Inactive page'}
     titlesMinHeight
-    progress="84"
+    progress={84}
     state="Custom state"
   />
 )


### PR DESCRIPTION
Closes #.

Vercel link:

- https://kitten-git-…

Screenshot:


TODO:

- [x] Tests
- [x] Changelog
- [ ] A11Y
- [ ] Stories / Docs
- [ ] BrowserStack (IE11, Chrome & Firefox on Windows 10)
- [ ] New component added to `assets/javascripts/kitten/index.js`
