### PR TITLE
Fix IntersectionObserverClass on Safari

### DIFF
--- a/assets/javascripts/kitten/helpers/utils/lazy-hook.js
+++ b/assets/javascripts/kitten/helpers/utils/lazy-hook.js
@@ -18,6 +18,8 @@ const useLazyObserver = lazyComponentRef => {
     LazyObserver.observe(lazyComponentRef.current, () => setLazyObserver(true))
 
     return () => {
+      const hasNoRef = !lazyComponentRef?.current
+
       if (hasNoRef) return
 
       LazyObserver.unobserve(lazyComponentRef.current)

--- a/assets/javascripts/kitten/helpers/utils/lazy-observer.js
+++ b/assets/javascripts/kitten/helpers/utils/lazy-observer.js
@@ -1,8 +1,9 @@
 import { IntersectionObserverClass } from './intersection-observer'
 
 const LazyObserver = new IntersectionObserverClass({
+  root: null,
   rootMargin: '100px 0px',
-  threshold: 0.5,
+  threshold: 0.1,
 })
 
 export default LazyObserver

--- a/assets/javascripts/kitten/helpers/utils/lazy-observer.js
+++ b/assets/javascripts/kitten/helpers/utils/lazy-observer.js
@@ -2,6 +2,7 @@ import { IntersectionObserverClass } from './intersection-observer'
 
 const LazyObserver = new IntersectionObserverClass({
   rootMargin: '100px 0px',
+  threshold: 0.5,
 })
 
 export default LazyObserver


### PR DESCRIPTION
L'`IntersectionObserverClass` semble fonctionner d'une manière bien à lui sur `Safari`. 
Ça semble être ça qui fait que les images des rewards ne s'affichent pas sur les iPhone.

https://stackoverflow.com/questions/60432805/intersectionobserver-api-erratic-in-safari
https://stackoverflow.com/questions/62084306/intersectionobserver-not-working-in-safari-or-ios
https://developer.mozilla.org/fr/docs/Web/API/Intersection_Observer_API

J'ai pu le constater en testant via Storybook sur Safari. C'est random.
J'ai l'impression qu'en spécifiant un `threshold` ça fonctionne mieux mais bon, c'est juste de l'impression.

@joachimesque t'as plus d'idée ?