### PR TITLE
[Carousel] Revert ResizeObserver fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Revert: Fix: Replace `ResizeObserver` with `window.resize` on `Carousel`. (beta.20)
 Breaking Change: Remove `RichTextInput` component
 
 ## [3.0.0-beta.20] - 2021-03-23

--- a/assets/javascripts/kitten/components/carousel/carousel/components/carousel-inner.js
+++ b/assets/javascripts/kitten/components/carousel/carousel/components/carousel-inner.js
@@ -1,6 +1,5 @@
 import React, { useEffect, useRef } from 'react'
 import ResizeObserver from 'resize-observer-polyfill'
-import throttle from 'lodash/fp/throttle'
 import { domElementHelper } from '../../../../helpers/dom/element-helper'
 import { CarouselPage } from './carousel-page'
 import classNames from 'classnames'
@@ -69,18 +68,22 @@ export const CarouselInner = ({
   const carouselInner = useRef(null)
   const previousIndexPageVisible = usePrevious(currentPageIndex)
 
-  useEffect(() => {
-    domElementHelper.canUseDom() && window.addEventListener('resize', throttleWindowResize)
+  let resizeObserver
 
-    return () => domElementHelper.canUseDom() && window.removeEventListener('resize', throttleWindowResize)
-  }, [])
-
-  const onWindowResize = () => {
-    const innerWidth = carouselInner.current && carouselInner.current.clientWidth
-    innerWidth && onResizeInner(innerWidth)
+  const onResizeObserve = ([entry]) => {
+    const innerWidth = entry.contentRect.width
+    onResizeInner(innerWidth)
   }
 
-  const throttleWindowResize = throttle(200)(onWindowResize)
+  useEffect(() => {
+    resizeObserver = new ResizeObserver(onResizeObserve)
+
+    return () => resizeObserver.disconnect()
+  }, [])
+
+  useEffect(() => {
+    carouselInner.current && resizeObserver.observe(carouselInner.current)
+  }, [carouselInner])
 
   useEffect(() => {
     if (currentPageIndex !== previousIndexPageVisible) {


### PR DESCRIPTION
Closes #.

Vercel link:

- https://kitten-git-…

Screenshot:


TODO:

- [ ] Tests
- [ ] Changelog
- [ ] A11Y
- [ ] Stories / Docs
- [ ] BrowserStack (IE11, Chrome & Firefox on Windows 10)
- [ ] New component added to `assets/javascripts/kitten/index.js`
