### PR TITLE
rollback-cropper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Rollback: Version: `"react-cropper": "2.1.1"`
+
 ## [3.0.0-beta.21] - 2021-03-25
 
 Breaking Change:

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "modularscale-sass": "^3.0.10",
     "prop-types": "^15.7.2",
     "prop-types-extra": "^1.1.1",
-    "react-cropper": "2.1.6",
+    "react-cropper": "2.1.1",
     "react-day-picker": "^7.4.10",
     "react-modal": "^3.12.1",
     "react-number-format": "^4.5.1",


### PR DESCRIPTION
La version `2.1.6` corrigeait le bug sur Storybook mais pas sur KissKiss… En testant avec la version `2.1.1` le bug est corrigé sur KissKiss. Aucune idée de pourquoi 🤷‍♂️ 