### PR TITLE
[DropdownSelect] Add full options list on menu open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: On `DropdownSelect combobox`, display full list of options on menu open.
+
 ## [3.2.0] - 2021-04-12
 
 Features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [unreleased]
 
 - Fix: On `DropdownSelect combobox`, display full list of options on menu open.
+- Fix: Propagate `className` on `DropdownSelect` and `DropdownSelect combobox`.
+- Fix: Fix styles on `DropdownSelect`.
 
 ## [3.2.0] - 2021-04-12
 

--- a/assets/javascripts/kitten/components/form/dropdown-select/__snapshots__/combobox.test.js.snap
+++ b/assets/javascripts/kitten/components/form/dropdown-select/__snapshots__/combobox.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<DropdownSelect combobox /> should match its snapshot with props 1`] = `
 <div
-  className="sc-bwzfXH ceyZSM k-Form-Dropdown k-Form-Dropdown--andromeda k-Form-Dropdown--normal k-Form-Dropdown--isOpen"
+  className="sc-bwzfXH gTSqXl k-Form-Dropdown k-Form-Dropdown--andromeda k-Form-Dropdown--normal k-Form-Dropdown--isOpen"
   style={
     Object {
       "--menu-z-index": 1000,

--- a/assets/javascripts/kitten/components/form/dropdown-select/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/form/dropdown-select/__snapshots__/test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<DropdownSelect /> should match its snapshot with props 1`] = `
 <div
-  className="sc-bwzfXH ceyZSM k-Form-Dropdown k-Form-Dropdown--andromeda k-Form-Dropdown--normal k-Form-Dropdown--isOpen"
+  className="sc-bwzfXH gTSqXl k-Form-Dropdown k-Form-Dropdown--andromeda k-Form-Dropdown--normal k-Form-Dropdown--isOpen"
   style={
     Object {
       "--menu-z-index": 1000,

--- a/assets/javascripts/kitten/components/form/dropdown-select/combobox.js
+++ b/assets/javascripts/kitten/components/form/dropdown-select/combobox.js
@@ -47,6 +47,7 @@ export const DropdownCombobox = ({
   openOnLoad,
   uniqLabelOnSearch,
   menuZIndex,
+  className,
 }) => {
   const [flattenedOptions, setFlattenedOptions] = useState([])
   const [filteredOptions, setFilteredOptions] = useState([])
@@ -149,6 +150,7 @@ export const DropdownCombobox = ({
         'k-Form-Dropdown',
         `k-Form-Dropdown--${variant}`,
         `k-Form-Dropdown--${size}`,
+        className,
         {
           'k-Form-Dropdown--isOpen': isOpen > 0,
           'k-Form-Dropdown--error': error,

--- a/assets/javascripts/kitten/components/form/dropdown-select/combobox.js
+++ b/assets/javascripts/kitten/components/form/dropdown-select/combobox.js
@@ -80,7 +80,10 @@ export const DropdownCombobox = ({
   }
 
   const onIsOpenChange = changes => {
-    if (changes.isOpen) return onMenuOpen({ changes })
+    if (changes.isOpen) {
+      flattenedOptions && setFilteredOptions(flattenedOptions)
+      return onMenuOpen({ changes })
+    }
 
     return onMenuClose({
       changes,

--- a/assets/javascripts/kitten/components/form/dropdown-select/index.js
+++ b/assets/javascripts/kitten/components/form/dropdown-select/index.js
@@ -36,6 +36,7 @@ export const DropdownSelect = ({ combobox, ...props }) => {
     onMenuOpen,
     openOnLoad,
     menuZIndex,
+    className,
   } = props
 
   const getA11ySelectionMessage = ({ itemToString, selectedItem }) => {
@@ -109,6 +110,7 @@ export const DropdownSelect = ({ combobox, ...props }) => {
         'k-Form-Dropdown',
         `k-Form-Dropdown--${variant}`,
         `k-Form-Dropdown--${size}`,
+        className,
         {
           'k-Form-Dropdown--isOpen': isOpen,
           'k-Form-Dropdown--error': error,

--- a/assets/javascripts/kitten/components/form/dropdown-select/styles.js
+++ b/assets/javascripts/kitten/components/form/dropdown-select/styles.js
@@ -335,6 +335,7 @@ export const StyledDropdown = styled.div`
       .k-Form-DropdownSelect__button {
         height: ${pxToRem(70)};
         padding-right: ${pxToRem(50 + 10)};
+        font-size: ${stepToRem(0)};
       }
 
       .k-Form-DropdownCombobox__arrowButton {
@@ -357,7 +358,7 @@ export const StyledDropdown = styled.div`
         }
       }
 
-      @media (min-width: ${ScreenConfig.S.min}px) {
+      @media (min-width: ${ScreenConfig.M.min}px) {
         .k-Form-DropdownCombobox,
         .k-Form-DropdownSelect__button {
           padding-right: ${pxToRem(60 + 10)};
@@ -551,16 +552,18 @@ export const StyledDropdown = styled.div`
     &.k-Form-Dropdown--huge {
       .k-Form-DropdownCombobox,
       .k-Form-DropdownSelect__button {
-        @media (min-width: ${ScreenConfig.S.min}px) {
+        @media (min-width: ${ScreenConfig.M.min}px) {
           height: ${pxToRem(80)};
+          font-size: ${stepToRem(0)};
         }
       }
     }
     &.k-Form-Dropdown--giant {
       .k-Form-DropdownCombobox,
       .k-Form-DropdownSelect__button {
-        @media (min-width: ${ScreenConfig.S.min}px) {
+        @media (min-width: ${ScreenConfig.M.min}px) {
           height: ${pxToRem(90)};
+          font-size: ${stepToRem(0)};
         }
       }
     }


### PR DESCRIPTION
Closes #.

Vercel link:

- https://kitten-git-dropdown-select-add-full-options-on-o-1520bf.vercel.app/?path=/story/form-dropdownselect--default

Screenshot:


TODO:

- [ ] Tests
- [ ] Changelog
- [ ] A11Y
- [ ] Stories / Docs
- [ ] BrowserStack (IE11, Chrome & Firefox on Windows 10)
- [ ] New component added to `assets/javascripts/kitten/index.js`
