### PR TITLE
[Field.Input] Recover missing props on Field.Input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Recover missing props on `Field.Input`.
+
 ## [3.2.0] - 2021-04-12
 
 Features:

--- a/assets/javascripts/kitten/components/form/field/components/input.js
+++ b/assets/javascripts/kitten/components/form/field/components/input.js
@@ -26,11 +26,15 @@ export const FieldInput = ({
   return (
     <div
       className={classNames('k-FieldInput',
-        className, 
+        className,
         { 'k-u-margin-top-single': !noMargin },
       )}
     >
-      <Input {...props} />
+      <Input
+        limit={limit}
+        unit={unit}
+        {...props}
+      />
     </div>
   )
 }


### PR DESCRIPTION
Closes #.

Vercel link:

- https://kitten-git-…

Screenshot:


TODO:

- [x] Tests
- [x] Changelog
- [ ] A11Y
- [ ] Stories / Docs
- [ ] BrowserStack (IE11, Chrome & Firefox on Windows 10)
- [ ] New component added to `assets/javascripts/kitten/index.js`
