### PR TITLE
[TextInput] Update style type="textarea" with Orion variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: Recover missing style on `Field.Input`.
+
 ## [3.3.0] - 2021-04-15
 
 Features:

--- a/assets/javascripts/kitten/components/form/text-input/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/form/text-input/__snapshots__/test.js.snap
@@ -86,7 +86,7 @@ exports[`<TextInput /> with \`valid\` prop matches with snapshot 1`] = `
 
 exports[`<TextInput /> with \`variant\` prop matches with snapshot 1`] = `
 <input
-  className="sc-bdVaJa cjMkbU k-Form-TextInput k-Form-TextInput--andromeda k-Form-TextInput--regular"
+  className="sc-bdVaJa cjMkbU k-Form-TextInput k-Form-TextInput--orion k-Form-TextInput--regular"
   disabled={false}
   name="text"
 />

--- a/assets/javascripts/kitten/components/form/text-input/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/form/text-input/__snapshots__/test.js.snap
@@ -63,7 +63,7 @@ exports[`<TextInput /> with \`tag\` prop matches with snapshot 1`] = `
 
 exports[`<TextInput /> with \`textarea\` tag matches with snapshot 1`] = `
 <div
-  className="sc-bwzfXH bEnvnC k-Form-TextInput__textareaContainer k-Form-TextInput__textareaContainer--andromeda"
+  className="sc-bwzfXH kAQPnk k-Form-TextInput__textareaContainer"
 >
   <textarea
     className="sc-bdVaJa cjMkbU k-Form-TextInput k-Form-TextInput--andromeda"
@@ -76,17 +76,17 @@ exports[`<TextInput /> with \`textarea\` tag matches with snapshot 1`] = `
 </div>
 `;
 
-exports[`<TextInput /> with \`tiny\` prop matches with snapshot 1`] = `
+exports[`<TextInput /> with \`valid\` prop matches with snapshot 1`] = `
 <input
-  className="sc-bdVaJa cjMkbU k-Form-TextInput k-Form-TextInput--andromeda k-Form-TextInput--regular"
+  className="sc-bdVaJa cjMkbU k-Form-TextInput k-Form-TextInput--andromeda k-Form-TextInput--regular k-Form-TextInput--valid"
   disabled={false}
   name="text"
 />
 `;
 
-exports[`<TextInput /> with \`valid\` prop matches with snapshot 1`] = `
+exports[`<TextInput /> with \`variant\` prop matches with snapshot 1`] = `
 <input
-  className="sc-bdVaJa cjMkbU k-Form-TextInput k-Form-TextInput--andromeda k-Form-TextInput--regular k-Form-TextInput--valid"
+  className="sc-bdVaJa cjMkbU k-Form-TextInput k-Form-TextInput--andromeda k-Form-TextInput--regular"
   disabled={false}
   name="text"
 />

--- a/assets/javascripts/kitten/components/form/text-input/index.js
+++ b/assets/javascripts/kitten/components/form/text-input/index.js
@@ -203,6 +203,7 @@ const StyledTextareaContainer = styled.div`
     &.k-Form-TextInput--orion {
       padding: ${pxToRem(21)} ${pxToRem(15)} 0;
       min-height: ${pxToRem(60)};
+      border-radius: ${pxToRem(4)};
 
       @media (min-width: ${ScreenConfig.M.min}px) {
         padding: ${pxToRem(25)} ${pxToRem(30)} 0;
@@ -282,7 +283,6 @@ export class TextInput extends PureComponent {
         <StyledTextareaContainer
           className={classNames(
             'k-Form-TextInput__textareaContainer',
-            `k-Form-TextInput__textareaContainer--${variant}`,
           )}
         >
           <StyledInput

--- a/assets/javascripts/kitten/components/form/text-input/test.js
+++ b/assets/javascripts/kitten/components/form/text-input/test.js
@@ -35,16 +35,6 @@ describe('<TextInput />', () => {
     })
   })
 
-  describe('with `tiny` prop', () => {
-    beforeEach(() => {
-      component = renderer.create(<TextInput tiny />).toJSON()
-    })
-
-    it('matches with snapshot', () => {
-      expect(component).toMatchSnapshot()
-    })
-  })
-
   describe('with `size` prop', () => {
     beforeEach(() => {
       component = renderer.create(<TextInput size="regular" />).toJSON()
@@ -100,6 +90,16 @@ describe('<TextInput />', () => {
       component = renderer
         .create(<TextInput tag="textarea" name="message" />)
         .toJSON()
+    })
+
+    it('matches with snapshot', () => {
+      expect(component).toMatchSnapshot()
+    })
+  })
+
+  describe('with `variant` prop', () => {
+    beforeEach(() => {
+      component = renderer.create(<TextInput variant="andromeda" />).toJSON()
     })
 
     it('matches with snapshot', () => {

--- a/assets/javascripts/kitten/components/form/text-input/test.js
+++ b/assets/javascripts/kitten/components/form/text-input/test.js
@@ -99,7 +99,7 @@ describe('<TextInput />', () => {
 
   describe('with `variant` prop', () => {
     beforeEach(() => {
-      component = renderer.create(<TextInput variant="andromeda" />).toJSON()
+      component = renderer.create(<TextInput variant="orion" />).toJSON()
     })
 
     it('matches with snapshot', () => {


### PR DESCRIPTION
Corrige l'erreur de style sur la variant `orion` quand on a `type="textarea"`


Vercel link:

- https://kitten-git-…

Screenshot:


TODO:

- [x] Tests
- [x] Changelog
- [ ] A11Y
- [x] Stories / Docs
- [ ] BrowserStack (IE11, Chrome & Firefox on Windows 10)
- [ ] New component added to `assets/javascripts/kitten/index.js`
