### PR TITLE
[Modal/Next] Add Orion variant and subcomponents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [unreleased]
 
 - Feature: `Modal/Next`: Add `Modal.Block` subcomponent.
-- Feature: `Modal/Next`: Add `variant` prop, defaults to `orion`.
+- Feature: `Modal/Next`: Add `variant` prop, defaults to `andromeda`.
 - Feature: `Modal/Next`: Add `giant` size prop.
 - Feature: `Modal/Next`: Add `headerActions` and `headerTitle` props.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Feature: `Modal/Next`: Add `Modal.Block` subcomponent.
+- Feature: `Modal/Next`: Add `variant` prop, defaults to `orion`.
+- Feature: `Modal/Next`: Add `giant` size prop.
+- Feature: `Modal/Next`: Add `headerActions` and `headerTitle` props.
+
 ## [3.4.0] - 2021-04-20
 
 Feature :

--- a/assets/javascripts/kitten/components/modals/modal/stories.js
+++ b/assets/javascripts/kitten/components/modals/modal/stories.js
@@ -67,8 +67,10 @@ export default {
   component: Modal,
 }
 
-export const Default = () => (
+export const OldModal = () => (
   <Marger top="2">
+    <p className="k-u-weight-light">This Modal will be deprecated in the future.</p>
+
     <Modal
       closeButtonLabel="Fermer"
       trigger={<StoryButton children={text('bouton', 'open')} />}

--- a/assets/javascripts/kitten/components/modals/next/Modal.stories.js
+++ b/assets/javascripts/kitten/components/modals/next/Modal.stories.js
@@ -53,6 +53,7 @@ export const OneButton = () => (
     size={select('Size', ['regular', 'big', 'huge', 'giant'], 'regular')}
     variant={select('Variant', ['andromeda', 'orion', 'andromeda'])}
     zIndex={number('Overlay z-index', 110)}
+    headerTitle={text('headerTitle', null)}
   >
     {() => (
       <>
@@ -72,6 +73,7 @@ export const TwoButton = () => (
     hasCloseButton={boolean('Has close button', true)}
     size={select('Size', ['regular', 'big', 'huge', 'giant'], 'regular')}
     variant={select('Variant', ['andromeda', 'orion', 'andromeda'])}
+    headerTitle={text('headerTitle', null)}
   >
     {() => (
       <>

--- a/assets/javascripts/kitten/components/modals/next/Modal.stories.js
+++ b/assets/javascripts/kitten/components/modals/next/Modal.stories.js
@@ -35,7 +35,7 @@ const paragraphContainer = `
 `
 
 export default {
-  title: 'Modals/NEXT/Modal',
+  title: 'Modals/Modal/Next',
   component: Modal,
   subcomponents: {
     Title: Modal.Title,

--- a/assets/javascripts/kitten/components/modals/next/Modal.stories.js
+++ b/assets/javascripts/kitten/components/modals/next/Modal.stories.js
@@ -226,16 +226,17 @@ export const ComplexWithOrion = () => (
   <Modal
     trigger={<Button modifier="helium">Open</Button>}
     variant="orion"
-    headerTitle={OrionHeaderTitle}
+    headerTitle={<OrionHeaderTitle />}
     headerActions={OrionHeaderActions}
     size={select('Size', ['regular', 'big', 'huge', 'giant'], 'giant')}
+    variant={select('Variant', ['andromeda', 'orion', 'orion'])}
   >
     {() => (
       <>
         <Modal.Block className="k-u-background-color-background3">
           {text('content', paragraphContainer)}
         </Modal.Block>
-        <Modal.Paragraph>
+        <Modal.Paragraph align="left">
           {text('content', paragraphContainer)}
         </Modal.Paragraph>
       </>

--- a/assets/javascripts/kitten/components/modals/next/Modal.stories.js
+++ b/assets/javascripts/kitten/components/modals/next/Modal.stories.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import { text, boolean, number, select } from '@storybook/addon-knobs'
 import { Modal } from './index'
 import { Button } from '../../../components/buttons/button'
+import { SaveIcon } from '../../../components/icons/save-icon'
 
 const paragraphContainer = `
   Sed ut perspiciatis unde omnis iste natus error sit voluptatem
@@ -49,7 +50,8 @@ export const OneButton = () => (
   <Modal
     trigger={<Button modifier="helium">Open</Button>}
     hasCloseButton={boolean('Has close button', true)}
-    size={select('Size', ['regular', 'big', 'huge'], 'regular')}
+    size={select('Size', ['regular', 'big', 'huge', 'giant'], 'regular')}
+    variant={select('Variant', ['andromeda', 'orion', 'andromeda'])}
     zIndex={number('Overlay z-index', 110)}
   >
     {() => (
@@ -68,7 +70,8 @@ export const TwoButton = () => (
   <Modal
     trigger={<Button modifier="helium">Open</Button>}
     hasCloseButton={boolean('Has close button', true)}
-    size={select('Size', ['regular', 'big', 'huge'], 'regular')}
+    size={select('Size', ['regular', 'big', 'huge', 'giant'], 'regular')}
+    variant={select('Variant', ['andromeda', 'orion', 'andromeda'])}
   >
     {() => (
       <>
@@ -93,7 +96,8 @@ export const WithState = () => {
       <Modal
         isOpen={showModal}
         hasCloseButton={boolean('Has close button', true)}
-        size={select('Size', ['regular', 'big', 'huge'], 'regular')}
+        size={select('Size', ['regular', 'big', 'huge', 'giant'], 'regular')}
+        variant={select('Variant', ['andromeda', 'orion', 'andromeda'])}
         onClose={() => updateModalState(false)}
       >
         {() => (
@@ -143,8 +147,9 @@ export const Multi = () => {
 export const WithoutButton = () => (
   <Modal
     trigger={<Button modifier="helium">Open</Button>}
-    size={select('Size', ['regular', 'big', 'huge'], 'regular')}
+    size={select('Size', ['regular', 'big', 'huge', 'giant'], 'regular')}
     zIndex={number('Overlay z-index', 110)}
+    variant={select('Variant', ['andromeda', 'orion', 'andromeda'])}
   >
     {() => (
       <>
@@ -162,8 +167,9 @@ export const FullSize = () => (
     trigger={<Button modifier="helium">Open</Button>}
     hasCloseButton={boolean('Has close button', true)}
     zIndex={number('Overlay z-index', 110)}
-    fullSizeTitle="Lorem ipsum dolor sit consectetuer"
-    fullSize={boolean('Has full size', true)}
+    variant={select('Variant', ['andromeda', 'orion', 'andromeda'])}
+    fullSizeTitle={text('fullSizeTitle', 'Lorem ipsum dolor sit consectetuer')}
+    fullSize
   >
     {() => (
       <>
@@ -174,6 +180,64 @@ export const FullSize = () => (
         <Modal.Actions>
           <Modal.Button modifier="helium">Action 1 Button</Modal.Button>
         </Modal.Actions>
+      </>
+    )}
+  </Modal>
+)
+
+const OrionHeaderTitle = () => {
+  return (
+    <p>
+      <strong>Hello world !</strong>
+      <br />
+      Hey
+    </p>
+  )
+}
+const OrionHeaderActions = ({close}) => (
+  <>
+    <Button
+      className="k-u-hidden@xs-down--important"
+      variant="orion"
+      modifier="helium"
+      type="button"
+      onClick={close}
+    >
+      <span>
+        <SaveIcon width="16" />
+      </span>
+      <span>Sauvegarder</span>
+    </Button>
+    <Button
+      className="k-u-hidden@s-up--important"
+      icon
+      variant="orion"
+      modifier="helium"
+      type="button"
+      onClick={close}
+      aria-label="Sauvegarder"
+    >
+      <SaveIcon width="16" />
+    </Button>
+  </>
+)
+
+export const ComplexWithOrion = () => (
+  <Modal
+    trigger={<Button modifier="helium">Open</Button>}
+    variant="orion"
+    headerTitle={OrionHeaderTitle}
+    headerActions={OrionHeaderActions}
+    size={select('Size', ['regular', 'big', 'huge', 'giant'], 'giant')}
+  >
+    {() => (
+      <>
+        <Modal.Block className="k-u-background-color-background3">
+          {text('content', paragraphContainer)}
+        </Modal.Block>
+        <Modal.Paragraph>
+          {text('content', paragraphContainer)}
+        </Modal.Paragraph>
       </>
     )}
   </Modal>

--- a/assets/javascripts/kitten/components/modals/next/index.js
+++ b/assets/javascripts/kitten/components/modals/next/index.js
@@ -3,30 +3,35 @@ import ReactDOM from 'react-dom'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import ReactModal from 'react-modal'
+import styled, { createGlobalStyle, css } from 'styled-components'
 import { CloseButton } from '../../../components/buttons/close-button'
-import { Button } from '../../../components/buttons/button'
+import {
+  Button,
+  ICON_TINY,
+} from '../../../components/buttons/button'
 import { Paragraph } from '../../../components/typography/paragraph/next'
 import { Text } from '../../../components/typography/text'
-import styled, { createGlobalStyle, css } from 'styled-components'
 import { pxToRem } from '../../../helpers/utils/typography'
 import { ScreenConfig } from '../../../constants/screen-config'
 import { Title } from '../../typography/title'
 import COLORS from '../../../constants/colors-config'
 import {
   CONTAINER_PADDING,
+  CONTAINER_PADDING_MOBILE,
   GUTTER,
   CONTAINER_MAX_WIDTH,
 } from '../../../constants/grid-config'
 import { domElementHelper } from '../../../helpers/dom/element-helper'
+import {
+  getReactElementsByType,
+  getReactElementsWithoutType,
+} from '../../../helpers/react/react-elements'
 
 const paddingPlusGutters = 2 * CONTAINER_PADDING + 11 * GUTTER
+
 const oneGridCol = `calc((100vw - ${pxToRem(
   paddingPlusGutters,
 )}) / 12 + ${pxToRem(GUTTER)})`
-
-const negativeOneGridCol = `calc(0px - ((100vw - ${pxToRem(
-  paddingPlusGutters,
-)}) / 12 + ${pxToRem(GUTTER)}))`
 
 const StyledParagraph = styled(Paragraph)`
   font-size: ${pxToRem(12)};
@@ -42,48 +47,67 @@ const GlobalStyle = createGlobalStyle`
   }
 
   .k-ModalNext__content {
+    --Modal-colNumber: 6;
+    --Modal-wrapperMaxWidth: 100vw;
+
     position: relative;
     background-color: ${COLORS.background1};
     box-sizing: border-box;
     transform: scale(0.94);
-    margin-right: ${pxToRem(20)};
-    margin-left: ${pxToRem(20)};
+    margin: auto;
     padding: ${pxToRem(50)} ${pxToRem(30)};
-    width: calc(100vw ${pxToRem(20)});
-    ${props =>
-      props.fullSize &&
-      css`
-        padding-top: 0 !important;
-        min-width: 100vw !important;
-        margin: 0 !important;
-      `};
+    width: calc(100vw - ${pxToRem(2 * CONTAINER_PADDING_MOBILE)});
 
     @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
-      margin: auto;
       padding: ${pxToRem(80)} ${oneGridCol};
-      width: calc((100vw - ${pxToRem(paddingPlusGutters)}) + (${pxToRem(
-  GUTTER,
-)} * 11))
+      width: calc(100vw - ${pxToRem(2 * CONTAINER_PADDING)})
     }
 
     @media (min-width: ${pxToRem(ScreenConfig.L.min)}) {
-      padding: ${pxToRem(80)} ${oneGridCol};
-      ${props => css`
-        width: calc(
-          ((100vw - ${pxToRem(paddingPlusGutters)}) / 12 + ${pxToRem(GUTTER)}) *
-            ${props.cols} - ${pxToRem(GUTTER)}
-        );
-      `}
+      width: calc(
+        ((var(--Modal-wrapperMaxWidth) - ${pxToRem(paddingPlusGutters)}) / 12
+        + ${pxToRem(GUTTER)}) * var(--Modal-colNumber) - ${pxToRem(GUTTER)}
+      );
     }
 
     @media (min-width: ${pxToRem(ScreenConfig.XL.min)}) {
-    ${props => css`
-      width: ${pxToRem(
-        ((CONTAINER_MAX_WIDTH - paddingPlusGutters) / 12 + GUTTER) *
-          props.cols -
-          GUTTER,
-      )};
-    `}
+      --Modal-wrapperMaxWidth: ${pxToRem(CONTAINER_MAX_WIDTH)};
+    }
+
+    &.k-ModalNext__content--big {
+      --Modal-colNumber: 8;
+    }
+    &.k-ModalNext__content--huge {
+      --Modal-colNumber: 10;
+    }
+    &.k-ModalNext__content--giant {
+      --Modal-colNumber: 12;
+    }
+
+
+    &.k-ModalNext__content--fullSize {
+      padding-top: 0 !important;
+      min-width: 100vw !important;
+      margin: 0 !important;
+
+      .k-ModalNext__title {
+        position: sticky;
+        top:0;
+        width: 100vw;
+        text-align: center;
+        margin-left: calc(-1 * ${oneGridCol});
+        box-sizing: border-box;
+        background-color: ${COLORS.background1};
+        padding: ${pxToRem(20)} ${oneGridCol};
+        border-bottom: ${pxToRem(2)} solid ${COLORS.line1};
+        margin-bottom: ${pxToRem(50)};
+      }
+
+      .k-ModalNext__closeButton {
+        position: absolute;
+        left: ${pxToRem(20)};
+        top: ${pxToRem(12)};
+      }
     }
   }
 
@@ -93,7 +117,7 @@ const GlobalStyle = createGlobalStyle`
     right: ${pxToRem(40)};
     @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
       right: ${pxToRem(50)};
-  }
+    }
 
     button {
       margin: 0;
@@ -111,8 +135,9 @@ const GlobalStyle = createGlobalStyle`
     bottom: 0;
     opacity: 0;
     background-color: rgba(34, 34, 34, .8);
-    &::before ,
-    &::after {
+
+    &.k-ModalNext__overlay--adromeda:not(.k-ModalNext__overlay--fullSize)::before ,
+    &.k-ModalNext__overlay--adromeda:not(.k-ModalNext__overlay--fullSize)::after {
       content:'';
       flex:1;
       min-height: ${pxToRem(50)};
@@ -120,12 +145,21 @@ const GlobalStyle = createGlobalStyle`
       @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
         min-height: ${pxToRem(100)};
       }
-      ${props =>
-        props.fullSize &&
-        css`
-          min-height: 0 !important;
-        `}
     }
+
+    &.k-ModalNext__overlay--orion:not(.k-ModalNext__overlay--fullSize)::before ,
+    &.k-ModalNext__overlay--orion:not(.k-ModalNext__overlay--fullSize)::after {
+      @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
+        content:'';
+        flex:1;
+        min-height: ${pxToRem(50)};
+      }
+
+      @media (min-width: ${pxToRem(ScreenConfig.L.min)}) {
+        min-height: ${pxToRem(80)};
+      }
+    }
+
     ${props =>
       css`
         z-index: ${props.zIndex};
@@ -151,23 +185,77 @@ const GlobalStyle = createGlobalStyle`
     opacity: 0;
   }
 
-  .k-ModalNext__title--fullSize {
-    position: sticky;
-    top:0;
-    width: 100vw;
-    text-align: center;
-    margin-left: ${negativeOneGridCol};
-    box-sizing: border-box;
-    background-color: ${COLORS.background1};
-    padding: ${pxToRem(20)} ${oneGridCol};
-    border-bottom: ${pxToRem(2)} solid ${COLORS.line1};
-    margin-bottom: ${pxToRem(50)};
-  }
+  /* ORION STYLES */
 
-  .k-ModalNext__closeButton--fullSize {
-    position: absolute;
-    left: ${pxToRem(20)};
-    top: ${pxToRem(12)};
+  .k-ModalNext__content--orion {
+    padding-top: 0;
+    padding-left: 0;
+    padding-right: 0;
+
+    &.k-ModalNext__content--giant {
+      @media (max-width: ${pxToRem(ScreenConfig.M.max)}) {
+        overflow: auto;
+        margin-left: 0;
+        margin-right: 0;
+        width: 100vw;
+        min-height: calc(100% - ${pxToRem(50 * 2)});
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
+      }
+
+      @media (max-width: ${pxToRem(ScreenConfig.XS.max)}) {
+        margin: 0;
+        min-height: 100%;
+      }
+    }
+
+    @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
+      border-radius: ${pxToRem(12)};
+    }
+
+    .k-ModalNext__orionHeader {
+      height: ${pxToRem(80)};
+      display: grid;
+      gap: ${GUTTER};
+      grid-template-columns: 1fr auto 1fr;
+      align-items: center;
+      padding-left: ${pxToRem(CONTAINER_PADDING_MOBILE)};
+      padding-right: ${pxToRem(CONTAINER_PADDING_MOBILE)};
+
+      @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
+        height: ${pxToRem(100)};
+        padding-left: ${pxToRem(CONTAINER_PADDING)};
+        padding-right: ${pxToRem(CONTAINER_PADDING)};
+      }
+
+      .k-Button {
+        @media (max-width: ${pxToRem(ScreenConfig.XS.max)}) {
+          ${() => ICON_TINY}
+        }
+      }
+    }
+
+    .k-ModalNext__orionHeader__closeButton {
+    }
+
+    .k-ModalNext__orionHeader__title {
+      text-align: center;
+    }
+
+    .k-ModalNext__orionHeader__actions {
+      text-align: right;
+    }
+
+
+    .k-ModalNext__orionBlock {
+      padding-left: ${pxToRem(CONTAINER_PADDING_MOBILE)};
+      padding-right: ${pxToRem(CONTAINER_PADDING_MOBILE)};
+
+      @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
+        padding-left: ${pxToRem(CONTAINER_PADDING)};
+        padding-right: ${pxToRem(CONTAINER_PADDING)};
+      }
+    }
   }
 `
 
@@ -225,6 +313,13 @@ const ModalButton = styled(props => <Button big fluid {...props} />)`
     }
   }
 `
+
+const Block = (props) => (
+  <div
+    {...props}
+    className={classNames(props.className, 'k-ModalNext__orionBlock')}
+  />
+)
 
 const initialState = {
   show: false,
@@ -290,10 +385,12 @@ const InnerModal = ({
   zIndex,
   fullSize,
   fullSizeTitle,
+  variant,
+  headerTitle,
+  headerActions,
   ...others
 }) => {
   const [{ show }, dispatch] = useContext(ModalContext)
-  const colsOnDesktop = size === 'huge' ? 10 : size === 'big' ? 8 : 6
   const close = () => {
     dispatch(updateState(false))
     if (onClose) {
@@ -312,17 +409,30 @@ const InnerModal = ({
 
   const ModalPortal = ReactDOM.createPortal(
     <>
-      <GlobalStyle cols={colsOnDesktop} zIndex={zIndex} fullSize={fullSize} />
+      <GlobalStyle zIndex={zIndex} />
       <ReactModal
         closeTimeoutMS={500}
         role="dialog"
         className={{
-          base: 'k-ModalNext__content',
+          base: classNames(
+            'k-ModalNext__content',
+            `k-ModalNext__content--${size}`,
+            `k-ModalNext__content--${variant}`,
+            {
+              'k-ModalNext__content--fullSize': fullSize,
+            }
+          ),
           afterOpen: 'k-ModalNext--afterOpen',
           beforeClose: 'k-ModalNext--beforeClose',
         }}
         overlayClassName={{
-          base: 'k-ModalNext__overlay',
+          base: classNames(
+            'k-ModalNext__overlay',
+            `k-ModalNext__overlay--${variant}`,
+            {
+              'k-ModalNext__overlay--fullSize': fullSize,
+            }
+          ),
           afterOpen: 'k-ModalNext__overlay--afterOpen',
           beforeClose: 'k-ModalNext__overlay--beforeClose',
         }}
@@ -341,42 +451,78 @@ const InnerModal = ({
         {...modalProps}
       >
         <>
-          {fullSize && Title && (
-            <div className="k-ModalNext__title--fullSize">
-              <CloseButton
-                className="k-ModalNext__closeButton--fullSize"
-                modifier="hydrogen"
-                onClick={close}
-                size="micro"
-                closeButtonLabel={closeButtonLabel}
-              />
-              <Text size="tiny" color="font1" weight="regular">
-                {fullSizeTitle}
-              </Text>
-            </div>
-          )}
-          {children({
-            open: () => dispatch(updateState(true)),
-            close: () => dispatch(updateState(false)),
-          })}
-          {hasCloseButton && !fullSize && (
-            <div className="k-ModalNext__close">
-              <CloseButton
-                style={{ position: 'fixed' }}
-                className="k-u-hidden@s-up"
-                modifier="hydrogen"
-                onClick={close}
-                size="micro"
-                closeButtonLabel={closeButtonLabel}
-              />
-              <CloseButton
-                style={{ position: 'fixed' }}
-                className="k-u-hidden@xs-down"
-                modifier="hydrogen"
-                onClick={close}
-                closeButtonLabel={closeButtonLabel}
-              />
-            </div>
+          {variant === 'orion' ? (
+            <>
+              <div className="k-ModalNext__orionHeader">
+                <div className="k-ModalNext__orionHeader__closeButton">
+                  <CloseButton
+                    modifier="hydrogen"
+                    onClick={close}
+                    variant="orion"
+                    closeButtonLabel={closeButtonLabel}
+                  />
+                </div>
+
+                <div className="k-ModalNext__orionHeader__title">
+                  {headerTitle()}
+                </div>
+
+                <div className="k-ModalNext__orionHeader__actions">
+                  {headerActions({
+                    open: () => dispatch(updateState(true)),
+                    close: () => dispatch(updateState(false)),
+                  })}
+                </div>
+
+              </div>
+
+              {children({
+                open: () => dispatch(updateState(true)),
+                close: () => dispatch(updateState(false)),
+              })}
+            </>
+          )
+          :
+          (
+            <>
+              {fullSize ? (
+                <div className="k-ModalNext__title">
+                  <CloseButton
+                    className="k-ModalNext__closeButton"
+                    modifier="hydrogen"
+                    onClick={close}
+                    size="micro"
+                    closeButtonLabel={closeButtonLabel}
+                  />
+                  <Text size="tiny" color="font1" weight="regular">
+                    {fullSizeTitle}
+                  </Text>
+                </div>
+              ) : hasCloseButton && (
+                <div className="k-ModalNext__close">
+                  <CloseButton
+                    style={{ position: 'fixed' }}
+                    className="k-u-hidden@s-up"
+                    modifier="hydrogen"
+                    onClick={close}
+                    size="micro"
+                    closeButtonLabel={closeButtonLabel}
+                  />
+                  <CloseButton
+                    style={{ position: 'fixed' }}
+                    className="k-u-hidden@xs-down"
+                    modifier="hydrogen"
+                    onClick={close}
+                    closeButtonLabel={closeButtonLabel}
+                  />
+                </div>
+              )}
+
+              {children({
+                open: () => dispatch(updateState(true)),
+                close: () => dispatch(updateState(false)),
+              })}
+            </>
           )}
         </>
       </ReactModal>
@@ -410,10 +556,13 @@ Modal.propTypes = {
   fullSize: PropTypes.bool,
   modalProps: PropTypes.object,
   hasCloseButton: PropTypes.bool,
-  size: PropTypes.oneOf(['regular', 'big', 'huge']),
+  size: PropTypes.oneOf(['regular', 'big', 'huge', 'giant']),
   isOpen: PropTypes.bool,
   zIndex: PropTypes.number,
   fullSizeTitle: PropTypes.string,
+  variant: PropTypes.oneOf(['andromeda', 'orion']),
+  headerTitle: PropTypes.func,
+  headerActions: PropTypes.func,
 }
 
 Modal.defaultProps = {
@@ -428,6 +577,9 @@ Modal.defaultProps = {
   isOpen: false,
   zIndex: 110,
   fullSizeTitle: '',
+  variant: 'andromeda',
+  headerTitle: () => {},
+  headerActions: () => {},
 }
 
 Modal.Title = ModalTitle
@@ -435,3 +587,4 @@ Modal.Paragraph = ModalParagraph
 Modal.Actions = Actions
 Modal.Button = ModalButton
 Modal.CloseButton = CloseActionButton
+Modal.Block = Block

--- a/assets/javascripts/kitten/components/modals/next/index.js
+++ b/assets/javascripts/kitten/components/modals/next/index.js
@@ -511,13 +511,15 @@ const InnerModal = ({
           {(headerTitle || fullSizeTitle) ? (
             <div className="k-ModalNext__header">
               <div className="k-ModalNext__header__closeButton">
-                <CloseButton
-                  modifier="hydrogen"
-                  onClick={close}
-                  variant={variant}
-                  size={variant === 'orion' ? 'regular' : 'micro'}
-                  closeButtonLabel={closeButtonLabel}
-                />
+                {hasCloseButton &&
+                  <CloseButton
+                    modifier="hydrogen"
+                    onClick={close}
+                    variant={variant}
+                    size={variant === 'orion' ? 'regular' : 'micro'}
+                    closeButtonLabel={closeButtonLabel}
+                  />
+                }
               </div>
 
               <div className="k-ModalNext__header__title">

--- a/assets/javascripts/kitten/components/modals/next/index.js
+++ b/assets/javascripts/kitten/components/modals/next/index.js
@@ -1,6 +1,7 @@
 import React, { useEffect, createContext, useReducer, useContext } from 'react'
 import ReactDOM from 'react-dom'
 import PropTypes from 'prop-types'
+import deprecated from 'prop-types-extra/lib/deprecated'
 import classNames from 'classnames'
 import ReactModal from 'react-modal'
 import styled, { createGlobalStyle, css } from 'styled-components'
@@ -49,21 +50,23 @@ const GlobalStyle = createGlobalStyle`
   .k-ModalNext__content {
     --Modal-colNumber: 6;
     --Modal-wrapperMaxWidth: 100vw;
+    --Modal-contentCols: 4;
+    --Modal-contentMargin: 1;
 
     position: relative;
     background-color: ${COLORS.background1};
     box-sizing: border-box;
     transform: scale(0.94);
     margin: auto;
-    padding: ${pxToRem(50)} ${pxToRem(30)};
     width: calc(100vw - ${pxToRem(2 * CONTAINER_PADDING_MOBILE)});
 
     @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
-      padding: ${pxToRem(80)} ${oneGridCol};
       width: calc(100vw - ${pxToRem(2 * CONTAINER_PADDING)})
     }
 
     @media (min-width: ${pxToRem(ScreenConfig.L.min)}) {
+      --Modal-contentMargin: calc((var(--Modal-colNumber) - var(--Modal-contentCols)) / 2);
+
       width: calc(
         ((var(--Modal-wrapperMaxWidth) - ${pxToRem(paddingPlusGutters)}) / 12
         + ${pxToRem(GUTTER)}) * var(--Modal-colNumber) - ${pxToRem(GUTTER)}
@@ -76,53 +79,175 @@ const GlobalStyle = createGlobalStyle`
 
     &.k-ModalNext__content--big {
       --Modal-colNumber: 8;
+
+      @media (min-width: ${pxToRem(ScreenConfig.L.min)}) {
+        --Modal-contentCols: 6;
+      }
     }
     &.k-ModalNext__content--huge {
       --Modal-colNumber: 10;
+
+      @media (min-width: ${pxToRem(ScreenConfig.L.min)}) {
+        --Modal-contentCols: 6;
+      }
     }
     &.k-ModalNext__content--giant {
       --Modal-colNumber: 12;
+
+      @media (min-width: ${pxToRem(ScreenConfig.L.min)}) {
+        --Modal-contentCols: 8;
+      }
+      @media (min-width: ${pxToRem(ScreenConfig.XL.min)}) {
+        --Modal-contentCols: 6;
+      }
     }
-
-
     &.k-ModalNext__content--fullSize {
-      padding-top: 0 !important;
       min-width: 100vw !important;
       margin: 0 !important;
+    }
 
-      .k-ModalNext__title {
-        position: sticky;
-        top:0;
-        width: 100vw;
+    .k-ModalNext__header {
+      position: sticky;
+      top: 0;
+      display: grid;
+      gap: ${GUTTER};
+      grid-template-columns: 1fr auto 1fr;
+      align-items: center;
+      padding-left: ${pxToRem(CONTAINER_PADDING_MOBILE)};
+      padding-right: ${pxToRem(CONTAINER_PADDING_MOBILE)};
+      background-color: ${COLORS.background1};
+
+      @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
+        height: ${pxToRem(100)};
+        padding-left: ${pxToRem(CONTAINER_PADDING)};
+        padding-right: ${pxToRem(CONTAINER_PADDING)};
+      }
+
+      .k-ModalNext__header__closeButton {
+        text-align: left;
+      }
+
+      .k-ModalNext__header__title {
         text-align: center;
-        margin-left: calc(-1 * ${oneGridCol});
-        box-sizing: border-box;
-        background-color: ${COLORS.background1};
-        padding: ${pxToRem(20)} ${oneGridCol};
-        border-bottom: ${pxToRem(2)} solid ${COLORS.line1};
-        margin-bottom: ${pxToRem(50)};
       }
 
-      .k-ModalNext__closeButton {
-        position: absolute;
-        left: ${pxToRem(20)};
-        top: ${pxToRem(12)};
+      .k-ModalNext__header__actions {
+        text-align: right;
+      }
+    }
+
+    .k-ModalNext__closeButton {
+      position: absolute;
+      top: 0;
+      right: ${pxToRem(40)};
+      @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
+        right: ${pxToRem(50)};
+      }
+    }
+
+    .k-ModalNext__actions {
+      display: flex;
+      flex-direction: column;
+
+      @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
+        gap: ${pxToRem(GUTTER)};
+        flex-direction: row;
+      }
+
+      .k-Button {
+        margin-top: ${pxToRem(20)};
+      }
+    }
+
+    .k-ModalNext__main {
+      padding: 0 ${pxToRem(CONTAINER_PADDING_MOBILE)} ${pxToRem(50)};
+
+      @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
+        padding: 0 calc(var(--Modal-contentMargin) * ${oneGridCol}) ${pxToRem(80)};
+      }
+
+      & > *:not(.k-ModalNext__block):first-child {
+        margin-top: ${pxToRem(50)};
+
+        @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
+          margin-top: ${pxToRem(80)};
+        }
+      }
+    }
+
+    .k-ModalNext__block {
+      margin-left: -${pxToRem(CONTAINER_PADDING_MOBILE)};
+      margin-right: -${pxToRem(CONTAINER_PADDING_MOBILE)};
+      padding-left: ${pxToRem(CONTAINER_PADDING_MOBILE)};
+      padding-right: ${pxToRem(CONTAINER_PADDING_MOBILE)};
+
+      @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
+        margin-left: calc(-1 * var(--Modal-contentMargin) * ${oneGridCol});
+        margin-right: calc(-1 * var(--Modal-contentMargin) * ${oneGridCol});
+        padding-left: ${pxToRem(CONTAINER_PADDING)};
+        padding-right: ${pxToRem(CONTAINER_PADDING)};
       }
     }
   }
 
-  .k-ModalNext__close {
-    position: absolute;
-    top: 0;
-    right: ${pxToRem(40)};
-    @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
-      right: ${pxToRem(50)};
-    }
+  /* ANDROMEDA STYLES */
 
-    button {
-      margin: 0;
+  .k-ModalNext__content--andromeda {
+    .k-ModalNext__header {
+      height: ${pxToRem(60)};
+      border-bottom: ${pxToRem(2)} solid ${COLORS.line1};
+      margin-bottom: ${pxToRem(50)}
     }
   }
+
+
+  /* ORION STYLES */
+
+  .k-ModalNext__content--orion {
+    padding-top: 0;
+    padding-left: 0;
+    padding-right: 0;
+    border-radius: ${pxToRem(12)};
+
+    .k-ModalNext__header {
+      border-top-left-radius: ${pxToRem(12)};
+      border-top-right-radius: ${pxToRem(12)};
+      height: ${pxToRem(80)};
+
+      @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
+        height: ${pxToRem(100)};
+      }
+
+      .k-Button {
+        @media (max-width: ${pxToRem(ScreenConfig.XS.max)}) {
+          ${() => ICON_TINY}
+        }
+      }
+    }
+
+    &.k-ModalNext__content--giant {
+      @media (max-width: ${pxToRem(ScreenConfig.M.max)}) {
+        margin-left: 0;
+        margin-right: 0;
+        width: 100vw;
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
+      }
+
+      @media (max-width: ${pxToRem(ScreenConfig.XS.max)}) {
+        overflow: auto;
+        min-height: calc(100% - ${pxToRem(50 * 2)});
+        margin: 0;
+        min-height: 100%;
+        border-radius: 0;
+      }
+    }
+
+
+  }
+
+
+  /* OVERLAY STYLES */
 
   .k-ModalNext__overlay {
     position: fixed;
@@ -136,27 +261,47 @@ const GlobalStyle = createGlobalStyle`
     opacity: 0;
     background-color: rgba(34, 34, 34, .8);
 
-    &.k-ModalNext__overlay--adromeda:not(.k-ModalNext__overlay--fullSize)::before ,
-    &.k-ModalNext__overlay--adromeda:not(.k-ModalNext__overlay--fullSize)::after {
-      content:'';
-      flex:1;
-      min-height: ${pxToRem(50)};
+    &.k-ModalNext__overlay--andromeda {
+      &:not(.k-ModalNext__overlay--fullSize) {
+        &::before,
+        &::after {
+          content:'';
+          flex:1;
+          min-height: ${pxToRem(50)};
 
-      @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
-        min-height: ${pxToRem(100)};
+          @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
+            min-height: ${pxToRem(100)};
+          }
+        }
       }
     }
 
-    &.k-ModalNext__overlay--orion:not(.k-ModalNext__overlay--fullSize)::before ,
-    &.k-ModalNext__overlay--orion:not(.k-ModalNext__overlay--fullSize)::after {
-      @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
-        content:'';
-        flex:1;
-        min-height: ${pxToRem(50)};
-      }
+    &.k-ModalNext__overlay--orion {
+      &:not(.k-ModalNext__overlay--giant):not(.k-ModalNext__overlay--fullSize) {
+        &::before,
+        &::after {
+          content:'';
+          flex:1;
+          min-height: ${pxToRem(50)};
 
-      @media (min-width: ${pxToRem(ScreenConfig.L.min)}) {
-        min-height: ${pxToRem(80)};
+          @media (min-width: ${pxToRem(ScreenConfig.L.min)}) {
+            min-height: ${pxToRem(80)};
+          }
+        }
+      }
+      &.k-ModalNext__overlay--giant {
+        &::before,
+        &::after {
+          @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
+            content:'';
+            flex:1;
+            min-height: ${pxToRem(50)};
+          }
+
+          @media (min-width: ${pxToRem(ScreenConfig.L.min)}) {
+            min-height: ${pxToRem(80)};
+          }
+        }
       }
     }
 
@@ -185,78 +330,6 @@ const GlobalStyle = createGlobalStyle`
     opacity: 0;
   }
 
-  /* ORION STYLES */
-
-  .k-ModalNext__content--orion {
-    padding-top: 0;
-    padding-left: 0;
-    padding-right: 0;
-
-    &.k-ModalNext__content--giant {
-      @media (max-width: ${pxToRem(ScreenConfig.M.max)}) {
-        overflow: auto;
-        margin-left: 0;
-        margin-right: 0;
-        width: 100vw;
-        min-height: calc(100% - ${pxToRem(50 * 2)});
-        border-bottom-left-radius: 0;
-        border-bottom-right-radius: 0;
-      }
-
-      @media (max-width: ${pxToRem(ScreenConfig.XS.max)}) {
-        margin: 0;
-        min-height: 100%;
-      }
-    }
-
-    @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
-      border-radius: ${pxToRem(12)};
-    }
-
-    .k-ModalNext__orionHeader {
-      height: ${pxToRem(80)};
-      display: grid;
-      gap: ${GUTTER};
-      grid-template-columns: 1fr auto 1fr;
-      align-items: center;
-      padding-left: ${pxToRem(CONTAINER_PADDING_MOBILE)};
-      padding-right: ${pxToRem(CONTAINER_PADDING_MOBILE)};
-
-      @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
-        height: ${pxToRem(100)};
-        padding-left: ${pxToRem(CONTAINER_PADDING)};
-        padding-right: ${pxToRem(CONTAINER_PADDING)};
-      }
-
-      .k-Button {
-        @media (max-width: ${pxToRem(ScreenConfig.XS.max)}) {
-          ${() => ICON_TINY}
-        }
-      }
-    }
-
-    .k-ModalNext__orionHeader__closeButton {
-    }
-
-    .k-ModalNext__orionHeader__title {
-      text-align: center;
-    }
-
-    .k-ModalNext__orionHeader__actions {
-      text-align: right;
-    }
-
-
-    .k-ModalNext__orionBlock {
-      padding-left: ${pxToRem(CONTAINER_PADDING_MOBILE)};
-      padding-right: ${pxToRem(CONTAINER_PADDING_MOBILE)};
-
-      @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
-        padding-left: ${pxToRem(CONTAINER_PADDING)};
-        padding-right: ${pxToRem(CONTAINER_PADDING)};
-      }
-    }
-  }
 `
 
 const ModalTitle = ({ children }) => (
@@ -276,7 +349,7 @@ const ModalParagraph = ({ children, withoutMargin, className, align }) => (
     style={{ textAlign: align }}
     noMargin
     tag="p"
-    className={classNames('k-Modal__paragraph', className, {
+    className={classNames('k-ModalNext__paragraph', className, {
       'k-u-margin-bottom-triple': !withoutMargin,
       'k-u-margin-bottom-quadruple@s-up': !withoutMargin,
     })}
@@ -293,31 +366,14 @@ ModalParagraph.defaultProps = {
   align: 'center',
 }
 
-const Actions = styled.div`
-  display: flex;
-  flex-direction: column;
-  @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
-    flex-direction: row;
-  }
-`
+const Actions = props => <div {...props} className={classNames('k-ModalNext__actions', props.className)} />
 
-const ModalButton = styled(props => <Button big fluid {...props} />)`
-  @media (max-width: ${pxToRem(ScreenConfig.XS.max)}) {
-    :not(:last-child) {
-      margin-bottom: ${pxToRem(20)};
-    }
-  }
-  @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
-    :not(:first-child) {
-      margin-left: ${pxToRem(GUTTER)};
-    }
-  }
-`
+const ModalButton = props => <Button big fluid {...props} className={classNames('k-ModalNext__buttons', props.className)} />
 
 const Block = (props) => (
   <div
     {...props}
-    className={classNames(props.className, 'k-ModalNext__orionBlock')}
+    className={classNames(props.className, 'k-ModalNext__block')}
   />
 )
 
@@ -428,6 +484,7 @@ const InnerModal = ({
         overlayClassName={{
           base: classNames(
             'k-ModalNext__overlay',
+            `k-ModalNext__overlay--${size}`,
             `k-ModalNext__overlay--${variant}`,
             {
               'k-ModalNext__overlay--fullSize': fullSize,
@@ -451,79 +508,59 @@ const InnerModal = ({
         {...modalProps}
       >
         <>
-          {variant === 'orion' ? (
-            <>
-              <div className="k-ModalNext__orionHeader">
-                <div className="k-ModalNext__orionHeader__closeButton">
-                  <CloseButton
-                    modifier="hydrogen"
-                    onClick={close}
-                    variant="orion"
-                    closeButtonLabel={closeButtonLabel}
-                  />
-                </div>
-
-                <div className="k-ModalNext__orionHeader__title">
-                  {headerTitle()}
-                </div>
-
-                <div className="k-ModalNext__orionHeader__actions">
-                  {headerActions({
-                    open: () => dispatch(updateState(true)),
-                    close: () => dispatch(updateState(false)),
-                  })}
-                </div>
-
+          {(headerTitle || fullSizeTitle) ? (
+            <div className="k-ModalNext__header">
+              <div className="k-ModalNext__header__closeButton">
+                <CloseButton
+                  modifier="hydrogen"
+                  onClick={close}
+                  variant={variant}
+                  size={variant === 'orion' ? 'regular' : 'micro'}
+                  closeButtonLabel={closeButtonLabel}
+                />
               </div>
 
-              {children({
-                open: () => dispatch(updateState(true)),
-                close: () => dispatch(updateState(false)),
-              })}
-            </>
-          )
-          :
-          (
-            <>
-              {fullSize ? (
-                <div className="k-ModalNext__title">
-                  <CloseButton
-                    className="k-ModalNext__closeButton"
-                    modifier="hydrogen"
-                    onClick={close}
-                    size="micro"
-                    closeButtonLabel={closeButtonLabel}
-                  />
+              <div className="k-ModalNext__header__title">
+                {headerTitle ? headerTitle : (
                   <Text size="tiny" color="font1" weight="regular">
                     {fullSizeTitle}
                   </Text>
-                </div>
-              ) : hasCloseButton && (
-                <div className="k-ModalNext__close">
-                  <CloseButton
-                    style={{ position: 'fixed' }}
-                    className="k-u-hidden@s-up"
-                    modifier="hydrogen"
-                    onClick={close}
-                    size="micro"
-                    closeButtonLabel={closeButtonLabel}
-                  />
-                  <CloseButton
-                    style={{ position: 'fixed' }}
-                    className="k-u-hidden@xs-down"
-                    modifier="hydrogen"
-                    onClick={close}
-                    closeButtonLabel={closeButtonLabel}
-                  />
-                </div>
-              )}
+                )}
+              </div>
 
-              {children({
-                open: () => dispatch(updateState(true)),
-                close: () => dispatch(updateState(false)),
-              })}
-            </>
+              <div className="k-ModalNext__header__actions">
+                {headerActions({
+                  open: () => dispatch(updateState(true)),
+                  close: () => dispatch(updateState(false)),
+                })}
+              </div>
+
+            </div>
+          ) : hasCloseButton && (
+            <div className="k-ModalNext__closeButton">
+              <CloseButton
+                style={{ position: 'fixed' }}
+                className="k-u-hidden@s-up k-u-margin-none"
+                modifier="hydrogen"
+                onClick={close}
+                size="micro"
+                closeButtonLabel={closeButtonLabel}
+              />
+              <CloseButton
+                style={{ position: 'fixed' }}
+                className="k-u-hidden@xs-down k-u-margin-none"
+                modifier="hydrogen"
+                onClick={close}
+                closeButtonLabel={closeButtonLabel}
+              />
+            </div>
           )}
+          <div class="k-ModalNext__main">
+            {children({
+              open: () => dispatch(updateState(true)),
+              close: () => dispatch(updateState(false)),
+            })}
+          </div>
         </>
       </ReactModal>
     </>,
@@ -559,9 +596,9 @@ Modal.propTypes = {
   size: PropTypes.oneOf(['regular', 'big', 'huge', 'giant']),
   isOpen: PropTypes.bool,
   zIndex: PropTypes.number,
-  fullSizeTitle: PropTypes.string,
+  fullSizeTitle: deprecated(PropTypes.string, 'Please use `headerTitle`.'),
   variant: PropTypes.oneOf(['andromeda', 'orion']),
-  headerTitle: PropTypes.func,
+  headerTitle: PropTypes.node,
   headerActions: PropTypes.func,
 }
 
@@ -578,7 +615,7 @@ Modal.defaultProps = {
   zIndex: 110,
   fullSizeTitle: '',
   variant: 'andromeda',
-  headerTitle: () => {},
+  headerTitle: null,
   headerActions: () => {},
 }
 


### PR DESCRIPTION
Closes #.

Vercel link:

- https://kitten-git-modal-next-add-orion-variant-kisskissbankbank.vercel.app/?path=/story/modals-modal-next--complex-with-orion

Screenshot:


TODO:

- [ ] Tests
- [x] Changelog
- [x] A11Y
- [x] Stories / Docs
- [ ] BrowserStack (IE11, Chrome & Firefox on Windows 10)
- [ ] New component added to `assets/javascripts/kitten/index.js`
