### PR TITLE
[DashboardLayout] Use common CSS property for content margin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: `DashboardLayout`: use `--DashboardLayout-main-margin` for main margin on Desktop.
 - Feature: `Modal/Next`: Add `contentCols` prop, to specify content col number at breakpoints `S` and above. Accepts `default`, `s`, `m`, `l`, `xl` keys, with number values.
 - Fix: `HeaderNav`: Fix burger menu button dimensions and improve affordance.
 - Fix: Replace occurences of `CONTAINER_PADDING_MOBILE` with `CONTAINER_PADDING_THIN`.

--- a/assets/javascripts/kitten/components/layout/dashboard-layout/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/layout/dashboard-layout/__snapshots__/test.js.snap
@@ -1301,6 +1301,7 @@ button:hover .c1 {
 
 @media (min-width:67.5rem) {
   .c0 .k-DashboardLayout {
+    --DashboardLayout-main-margin: 7.5vw;
     grid-template-columns: 25vw 1fr;
   }
 
@@ -1394,8 +1395,8 @@ button:hover .c1 {
   }
 
   .c0 .k-DashboardLayout .k-DashboardLayout__mainWrapper .k-DashboardLayout__main > *:not(.k-DashboardLayout__fullWidth) {
-    margin-left: 7.5vw;
-    margin-right: 7.5vw;
+    margin-left: var(--DashboardLayout-main-margin);
+    margin-right: var(--DashboardLayout-main-margin);
   }
 }
 

--- a/assets/javascripts/kitten/components/layout/dashboard-layout/index.js
+++ b/assets/javascripts/kitten/components/layout/dashboard-layout/index.js
@@ -240,6 +240,7 @@ const StyledDashboard = styled.div`
 
   @media (min-width: ${pxToRem(ScreenConfig.L.min)}) {
     .k-DashboardLayout {
+      --DashboardLayout-main-margin: 7.5vw;
       grid-template-columns: 25vw 1fr;
 
       .k-DashboardLayout__sideWrapper {
@@ -306,8 +307,8 @@ const StyledDashboard = styled.div`
           }
 
           > *:not(.k-DashboardLayout__fullWidth) {
-            margin-left: 7.5vw;
-            margin-right: 7.5vw;
+            margin-left: var(--DashboardLayout-main-margin);
+            margin-right: var(--DashboardLayout-main-margin);
           }
         }
       }


### PR DESCRIPTION
Closes #.

Vercel link:

- https://kitten-git-dashboard-layout-use-margin-custom-pr-579e89.vercel.app/?path=/story/layout-dashboardlayout--default
- 
Screenshot:


TODO:

- [x] Tests
- [x] Changelog
- [ ] A11Y
- [ ] Stories / Docs
- [ ] BrowserStack (IE11, Chrome & Firefox on Windows 10)
- [ ] New component added to `assets/javascripts/kitten/index.js`
