### PR TITLE
[Modal/Next] Fix negative margin for Modal.Block at XL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: `Modal/Next`: Fix negative margin calculation for `Modal.Block` at `XL`.
+
 ## [3.7.0] - 2021-04-30
 
 Feature:

--- a/assets/javascripts/kitten/components/modals/next/Modal.stories.js
+++ b/assets/javascripts/kitten/components/modals/next/Modal.stories.js
@@ -264,6 +264,9 @@ export const CustomContentCols = () => (
     {() => (
       <>
         <Modal.Title>Lorem ipsum dolor sit consectetuer</Modal.Title>
+        <Modal.Block className="k-u-background-color-background3">
+          {text('content', paragraphContainer)}
+        </Modal.Block>
         <Modal.Paragraph>{text('content', paragraphContainer)}</Modal.Paragraph>
         <Modal.Actions>
           <Modal.Button modifier="helium">Action 1 Button</Modal.Button>

--- a/assets/javascripts/kitten/components/modals/next/index.js
+++ b/assets/javascripts/kitten/components/modals/next/index.js
@@ -210,6 +210,12 @@ const GlobalStyle = createGlobalStyle`
         padding-left: ${pxToRem(CONTAINER_PADDING)};
         padding-right: ${pxToRem(CONTAINER_PADDING)};
       }
+      @media (min-width: ${pxToRem(ScreenConfig.XL.min)}) {
+        margin-left: calc(-1 * var(--Modal-contentMargin) * ${oneGridColXl});
+        margin-right: calc(-1 * var(--Modal-contentMargin) * ${oneGridColXl});
+        padding-left: ${pxToRem(CONTAINER_PADDING)};
+        padding-right: ${pxToRem(CONTAINER_PADDING)};
+      }
     }
   }
 


### PR DESCRIPTION
Closes #.

Vercel link:

- https://kitten-git-…

Screenshot:


TODO:

- [ ] Tests
- [x] Changelog
- [ ] A11Y
- [ ] Stories / Docs
- [ ] BrowserStack (IE11, Chrome & Firefox on Windows 10)
- [ ] New component added to `assets/javascripts/kitten/index.js`
