### PR TITLE
[DashboardLayout] Add background color to `DashboardLayout`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: `DashboardLayout`: Fix `DashboardLayout` background color.
 - Feature: `Modal/Next`: Add `tag` prop on `Modal.Paragraph`.
 - Fix: `Modal/Next`: Remove `className` console error.
 - Fix: `Modal/Next`: Fix `customContentCols` class condition.

--- a/assets/javascripts/kitten/components/layout/dashboard-layout/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/layout/dashboard-layout/__snapshots__/test.js.snap
@@ -1029,6 +1029,7 @@ button:hover .c1 {
 .c0 .k-DashboardLayout {
   min-height: 100vh;
   display: grid;
+  background-color: #fff;
 }
 
 .c0 .k-DashboardLayout .k-DashboardLayout__sideWrapper {

--- a/assets/javascripts/kitten/components/layout/dashboard-layout/index.js
+++ b/assets/javascripts/kitten/components/layout/dashboard-layout/index.js
@@ -51,6 +51,7 @@ const StyledDashboard = styled.div`
   .k-DashboardLayout {
     min-height: 100vh;
     display: grid;
+    background-color: ${COLORS.background1};
 
     .k-DashboardLayout__sideWrapper {
       background-color: ${COLORS.font1};


### PR DESCRIPTION
Closes #.

Vercel link:

- https://kitten-git-…

Screenshot:


TODO:

- [ ] Tests
- [ ] Changelog
- [ ] A11Y
- [ ] Stories / Docs
- [ ] BrowserStack (IE11, Chrome & Firefox on Windows 10)
- [ ] New component added to `assets/javascripts/kitten/index.js`
