### PR TITLE
[DropdownSelectWithInput] Fix input padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: `DropdownSelectWithInput`: Fix input padding.
+
 ## [3.9.0] - 2021-05-06
 
 Feature:

--- a/assets/javascripts/kitten/components/form/dropdown-phone-select/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/form/dropdown-phone-select/__snapshots__/test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<DropdownPhoneSelect /> should match its snapshot with props 1`] = `
 <div
-  className="sc-bwzfXH hyMeYz k-Form-DropdownSelectWithInput k-Form-DropdownSelectWithInput--isOpen"
+  className="sc-bwzfXH hITxTM k-Form-DropdownSelectWithInput k-Form-DropdownSelectWithInput--isOpen"
   style={
     Object {
       "--menu-z-index": 1000,

--- a/assets/javascripts/kitten/components/form/dropdown-select-with-input/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/form/dropdown-select-with-input/__snapshots__/test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<DropdownSelectWithInput /> should match its snapshot with props 1`] = `
 <div
-  className="sc-bwzfXH hyMeYz k-Form-DropdownSelectWithInput k-Form-DropdownSelectWithInput--isOpen"
+  className="sc-bwzfXH hITxTM k-Form-DropdownSelectWithInput k-Form-DropdownSelectWithInput--isOpen"
   style={
     Object {
       "--menu-z-index": 1000,

--- a/assets/javascripts/kitten/components/form/dropdown-select-with-input/index.js
+++ b/assets/javascripts/kitten/components/form/dropdown-select-with-input/index.js
@@ -167,7 +167,7 @@ const StyledDropdownSelectWithInput = styled.div`
     font-size: ${stepToRem(-1)};
     color: ${COLORS.font1};
     appearance: none;
-    padding: 0 ${pxToRem(7)};
+    padding: 0 ${pxToRem(5 + 2)};
     border: none;
     background-color: transparent;
 

--- a/assets/javascripts/kitten/components/form/dropdown-select-with-input/index.js
+++ b/assets/javascripts/kitten/components/form/dropdown-select-with-input/index.js
@@ -67,7 +67,7 @@ const StyledDropdownSelectWithInput = styled.div`
     align-items: center;
     ${TYPOGRAPHY.fontStyles.light}
     color: ${COLORS.font1};
-    margin: 0 ${pxToRem(15)} 0 ${pxToRem(40)};
+    margin: 0 ${pxToRem(10)} 0 ${pxToRem(40)};
     font-size: ${pxToRem(-2)};
 
     @media (min-width: ${ScreenConfig.S.min}px) {
@@ -167,7 +167,7 @@ const StyledDropdownSelectWithInput = styled.div`
     font-size: ${stepToRem(-1)};
     color: ${COLORS.font1};
     appearance: none;
-    padding: 0;
+    padding: 0 ${pxToRem(7)};
     border: none;
     background-color: transparent;
 

--- a/assets/javascripts/kitten/components/form/text-input/text-input.stories.mdx
+++ b/assets/javascripts/kitten/components/form/text-input/text-input.stories.mdx
@@ -64,5 +64,5 @@ import { TextInput } from '@kisskissbankbank/kitten'
 You can only use `size="big"` with `variant="orion"`.
 
 ```js
-  <TextInput variant="orion= size="big" />
+  <TextInput variant="orion" size="big" />
 ```


### PR DESCRIPTION
Closes #.

Vercel link:

- https://kitten-git-…

Screenshot:


TODO:

- [x] Tests
- [x] Changelog
- [ ] A11Y
- [ ] Stories / Docs
- [ ] BrowserStack (IE11, Chrome & Firefox on Windows 10)
- [ ] New component added to `assets/javascripts/kitten/index.js`
