### PR TITLE
[HeaderNav] Add `as` prop to `HeaderNav.Item`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
-- Feature: `HeaderMenu`: Add `as` prop to `HeaderMenu.Item`.
+- Feature: `HeaderMenu`: Add `tag` (and deprecated `as`) props to `HeaderMenu.Item`.
 - Fix: `HeaderMenu`: Fix focus styles.
 
 ## [3.10.0] - 2021-05-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Feature: `HeaderMenu`: Add `as` prop to `HeaderMenu.Item`.
+- Fix: `HeaderMenu`: Fix focus styles.
+
 ## [3.10.0] - 2021-05-11
 
 Features:

--- a/assets/javascripts/kitten/components/menus/header-menu/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/menus/header-menu/__snapshots__/test.js.snap
@@ -5,12 +5,16 @@ exports[`<HeaderMenu /> with border to right matches with snapshot 1`] = `
   --headerMenu-background-colors-hover: #fff;
   margin: 0;
   padding: 0;
+  border: none;
   list-style: none;
 }
 
 .c0 .k-HeaderMenu__item__link {
   display: block;
   position: relative;
+  width: 100%;
+  text-align: left;
+  border: none;
   height: 3.125rem;
   box-sizing: border-box;
   padding: 1.125rem 1.875rem 1.125rem;
@@ -22,18 +26,20 @@ exports[`<HeaderMenu /> with border to right matches with snapshot 1`] = `
   font-size: 0.875rem;
   -webkit-text-decoration: none;
   text-decoration: none;
+  cursor: pointer;
+  -webkit-transition: color 0.2s,background-color 0.4s;
+  transition: color 0.2s,background-color 0.4s;
 }
 
 .c0 .k-HeaderMenu__item__link:focus {
-  outline-offset: -0.1875rem;
+  outline: #bae8fd solid 0.125rem;
+  outline-offset: -0.0625rem;
 }
 
 .c0 .k-HeaderMenu__item__link:hover,
 .c0 .k-HeaderMenu__item__link:focus {
   color: #19b4fa;
   background-color: var(--headerMenu-background-colors-hover);
-  -webkit-transition: color 0.2s,background-color 0.4s;
-  transition: color 0.2s,background-color 0.4s;
 }
 
 .c0 .k-HeaderMenu__item__link:focus:not(:focus-visible) {
@@ -187,7 +193,7 @@ exports[`<HeaderMenu /> with border to right matches with snapshot 1`] = `
   border-right: 0.0625rem solid #eee;
 }
 
-.c0.k-HeaderMenu--hasBorders .k-HeaderMenu__item__link {
+.c0.k-HeaderMenu--hasBorders .k-HeaderMenu__item {
   border-bottom: 0.0625rem solid #eee;
 }
 
@@ -243,12 +249,16 @@ exports[`<HeaderMenu /> with one custom item matches with snapshot 1`] = `
   --headerMenu-background-colors-hover: #fff;
   margin: 0;
   padding: 0;
+  border: none;
   list-style: none;
 }
 
 .c0 .k-HeaderMenu__item__link {
   display: block;
   position: relative;
+  width: 100%;
+  text-align: left;
+  border: none;
   height: 3.125rem;
   box-sizing: border-box;
   padding: 1.125rem 1.875rem 1.125rem;
@@ -260,18 +270,20 @@ exports[`<HeaderMenu /> with one custom item matches with snapshot 1`] = `
   font-size: 0.875rem;
   -webkit-text-decoration: none;
   text-decoration: none;
+  cursor: pointer;
+  -webkit-transition: color 0.2s,background-color 0.4s;
+  transition: color 0.2s,background-color 0.4s;
 }
 
 .c0 .k-HeaderMenu__item__link:focus {
-  outline-offset: -0.1875rem;
+  outline: #bae8fd solid 0.125rem;
+  outline-offset: -0.0625rem;
 }
 
 .c0 .k-HeaderMenu__item__link:hover,
 .c0 .k-HeaderMenu__item__link:focus {
   color: #19b4fa;
   background-color: var(--headerMenu-background-colors-hover);
-  -webkit-transition: color 0.2s,background-color 0.4s;
-  transition: color 0.2s,background-color 0.4s;
 }
 
 .c0 .k-HeaderMenu__item__link:focus:not(:focus-visible) {
@@ -425,7 +437,7 @@ exports[`<HeaderMenu /> with one custom item matches with snapshot 1`] = `
   border-right: 0.0625rem solid #eee;
 }
 
-.c0.k-HeaderMenu--hasBorders .k-HeaderMenu__item__link {
+.c0.k-HeaderMenu--hasBorders .k-HeaderMenu__item {
   border-bottom: 0.0625rem solid #eee;
 }
 
@@ -503,12 +515,16 @@ exports[`<HeaderMenu /> with one selected item matches with snapshot 1`] = `
   --headerMenu-background-colors-hover: #fff;
   margin: 0;
   padding: 0;
+  border: none;
   list-style: none;
 }
 
 .c0 .k-HeaderMenu__item__link {
   display: block;
   position: relative;
+  width: 100%;
+  text-align: left;
+  border: none;
   height: 3.125rem;
   box-sizing: border-box;
   padding: 1.125rem 1.875rem 1.125rem;
@@ -520,18 +536,20 @@ exports[`<HeaderMenu /> with one selected item matches with snapshot 1`] = `
   font-size: 0.875rem;
   -webkit-text-decoration: none;
   text-decoration: none;
+  cursor: pointer;
+  -webkit-transition: color 0.2s,background-color 0.4s;
+  transition: color 0.2s,background-color 0.4s;
 }
 
 .c0 .k-HeaderMenu__item__link:focus {
-  outline-offset: -0.1875rem;
+  outline: #bae8fd solid 0.125rem;
+  outline-offset: -0.0625rem;
 }
 
 .c0 .k-HeaderMenu__item__link:hover,
 .c0 .k-HeaderMenu__item__link:focus {
   color: #19b4fa;
   background-color: var(--headerMenu-background-colors-hover);
-  -webkit-transition: color 0.2s,background-color 0.4s;
-  transition: color 0.2s,background-color 0.4s;
 }
 
 .c0 .k-HeaderMenu__item__link:focus:not(:focus-visible) {
@@ -685,7 +703,7 @@ exports[`<HeaderMenu /> with one selected item matches with snapshot 1`] = `
   border-right: 0.0625rem solid #eee;
 }
 
-.c0.k-HeaderMenu--hasBorders .k-HeaderMenu__item__link {
+.c0.k-HeaderMenu--hasBorders .k-HeaderMenu__item {
   border-bottom: 0.0625rem solid #eee;
 }
 
@@ -741,12 +759,16 @@ exports[`<HeaderMenu /> with three items matches with snapshot 1`] = `
   --headerMenu-background-colors-hover: #fff;
   margin: 0;
   padding: 0;
+  border: none;
   list-style: none;
 }
 
 .c0 .k-HeaderMenu__item__link {
   display: block;
   position: relative;
+  width: 100%;
+  text-align: left;
+  border: none;
   height: 3.125rem;
   box-sizing: border-box;
   padding: 1.125rem 1.875rem 1.125rem;
@@ -758,18 +780,20 @@ exports[`<HeaderMenu /> with three items matches with snapshot 1`] = `
   font-size: 0.875rem;
   -webkit-text-decoration: none;
   text-decoration: none;
+  cursor: pointer;
+  -webkit-transition: color 0.2s,background-color 0.4s;
+  transition: color 0.2s,background-color 0.4s;
 }
 
 .c0 .k-HeaderMenu__item__link:focus {
-  outline-offset: -0.1875rem;
+  outline: #bae8fd solid 0.125rem;
+  outline-offset: -0.0625rem;
 }
 
 .c0 .k-HeaderMenu__item__link:hover,
 .c0 .k-HeaderMenu__item__link:focus {
   color: #19b4fa;
   background-color: var(--headerMenu-background-colors-hover);
-  -webkit-transition: color 0.2s,background-color 0.4s;
-  transition: color 0.2s,background-color 0.4s;
 }
 
 .c0 .k-HeaderMenu__item__link:focus:not(:focus-visible) {
@@ -923,7 +947,7 @@ exports[`<HeaderMenu /> with three items matches with snapshot 1`] = `
   border-right: 0.0625rem solid #eee;
 }
 
-.c0.k-HeaderMenu--hasBorders .k-HeaderMenu__item__link {
+.c0.k-HeaderMenu--hasBorders .k-HeaderMenu__item {
   border-bottom: 0.0625rem solid #eee;
 }
 

--- a/assets/javascripts/kitten/components/menus/header-menu/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/menus/header-menu/__snapshots__/test.js.snap
@@ -244,6 +244,599 @@ exports[`<HeaderMenu /> with border to right matches with snapshot 1`] = `
 </ul>
 `;
 
+exports[`<HeaderMenu /> with button items matches with snapshot 1`] = `
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  position: relative;
+  box-sizing: border-box;
+  font-family: Maax,Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-size: 0.8888888888888888rem;
+  color: #222;
+  line-height: 1.3;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  cursor: pointer;
+  min-width: 12.5rem;
+  min-height: 3.125rem;
+  padding: 0.625rem 1.875rem;
+  font-size: 0.8888888888888888rem;
+  border: 0.125rem solid;
+  -webkit-transition: background-color 0.2s,color 0.2s,border-color 0.2s;
+  transition: background-color 0.2s,color 0.2s,border-color 0.2s;
+}
+
+.c1:disabled {
+  cursor: not-allowed;
+}
+
+.c1:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c1 >:nth-child(n) {
+  margin-right: 0.625rem;
+  text-align: left;
+}
+
+.c1 >:last-child {
+  margin-right: 0;
+}
+
+.c1:focus {
+  outline: #bae8fd solid 0.125rem;
+  outline-offset: 0.125rem;
+}
+
+.c1:focus:not(:focus-visible) {
+  outline-color: transparent;
+}
+
+.c1:focus-visible {
+  outline-color: #bae8fd;
+}
+
+.c1.k-Button--hasBorderRadius {
+  border-radius: var(--border-radius);
+}
+
+.c1.k-Button--nano {
+  min-width: 6.25rem;
+  min-height: 1.25rem;
+  padding: 0 0.375rem;
+  font-size: 0.7901234567901234rem;
+}
+
+.c1.k-Button--micro {
+  min-width: 8.125rem;
+  min-height: 1.875rem;
+  padding: 0.3125rem 0.625rem;
+  font-size: 0.7901234567901234rem;
+}
+
+.c1.k-Button--tiny {
+  min-width: 10rem;
+  min-height: 2.5rem;
+  padding: 0.4375rem 1.25rem;
+  font-size: 0.8888888888888888rem;
+}
+
+.c1.k-Button--huge {
+  min-height: 4.375rem;
+  font-size: 0.8888888888888888rem;
+  padding: 0.625rem 0.625rem;
+}
+
+.c1.k-Button--giant {
+  min-height: 4.375rem;
+  font-size: 0.8888888888888888rem;
+  padding: 0.625rem 0.625rem;
+}
+
+.c1.k-Button--hasIcon:not(.k-Button--fluid) {
+  min-width: initial;
+  min-height: initial;
+  width: 3.125rem;
+  height: 3.125rem;
+  padding: 0;
+}
+
+.c1.k-Button--hasIcon:not(.k-Button--fluid).k-Button--nano {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.c1.k-Button--hasIcon:not(.k-Button--fluid).k-Button--micro {
+  width: 1.875rem;
+  height: 1.875rem;
+}
+
+.c1.k-Button--hasIcon:not(.k-Button--fluid).k-Button--tiny {
+  width: 2.5rem;
+  height: 2.5rem;
+}
+
+.c1.k-Button--hasIcon:not(.k-Button--fluid).k-Button--huge {
+  min-width: initial;
+  width: 4.375rem;
+  height: 4.375rem;
+}
+
+.c1.k-Button--hasIcon:not(.k-Button--fluid).k-Button--giant {
+  min-width: initial;
+  width: 4.375rem;
+  height: 4.375rem;
+}
+
+.c1.k-Button--fluid {
+  min-width: initial;
+  width: 100%;
+}
+
+.c1.k-Button--rounded {
+  border-radius: 50%;
+}
+
+.c1.k-Button--orion {
+  border-radius: 0.375rem;
+}
+
+.c1 svg,
+.c1 path {
+  fill: currentColor;
+  -webkit-transition: fill 0.2s;
+  transition: fill 0.2s;
+}
+
+.c1:hover,
+.c1:focus {
+  border-color: #05a8e6;
+  background-color: #05a8e6;
+  color: #fff;
+}
+
+.c1:active {
+  border-color: #0496cc;
+  background-color: #0496cc;
+  color: #fff;
+}
+
+.c1:focus {
+  outline: #bae8fd solid 0.125rem;
+  outline-offset: 0.125rem;
+}
+
+.c1:focus:not(:focus-visible) {
+  outline-color: transparent;
+}
+
+.c1:focus-visible {
+  outline-color: #bae8fd;
+}
+
+.c1:disabled {
+  border-color: #d8d8d8;
+  background-color: #d8d8d8;
+  color: #fff;
+}
+
+.c0 {
+  --headerMenu-background-colors-hover: #fff;
+  margin: 0;
+  padding: 0;
+  border: none;
+  list-style: none;
+}
+
+.c0 .k-HeaderMenu__item__link {
+  display: block;
+  position: relative;
+  width: 100%;
+  text-align: left;
+  border: none;
+  height: 3.125rem;
+  box-sizing: border-box;
+  padding: 1.125rem 1.875rem 1.125rem;
+  background-color: #fff;
+  font-family: Maax,Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  color: #222;
+  line-height: 1;
+  font-size: 0.875rem;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  cursor: pointer;
+  -webkit-transition: color 0.2s,background-color 0.4s;
+  transition: color 0.2s,background-color 0.4s;
+}
+
+.c0 .k-HeaderMenu__item__link:focus {
+  outline: #bae8fd solid 0.125rem;
+  outline-offset: -0.0625rem;
+}
+
+.c0 .k-HeaderMenu__item__link:hover,
+.c0 .k-HeaderMenu__item__link:focus {
+  color: #19b4fa;
+  background-color: var(--headerMenu-background-colors-hover);
+}
+
+.c0 .k-HeaderMenu__item__link:focus:not(:focus-visible) {
+  outline-color: transparent;
+}
+
+.c0 .k-HeaderMenu__item__link:focus-visible {
+  outline-color: #bae8fd;
+}
+
+.c0 .k-HeaderMenu__item--external .k-HeaderMenu__item__link {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 4.375rem;
+  padding: 1.4375rem 1.3125rem 1.375rem 1.875rem;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: start;
+  align-self: flex-start;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  background-color: #f6f6f6;
+}
+
+.c0 .k-HeaderMenu__item--external .k-HeaderMenu__item__link .k-HeaderMenu__item__arrow {
+  margin-left: 1.25rem;
+  position: relative;
+  left: 0;
+  -webkit-transition: left 0.2s;
+  transition: left 0.2s;
+}
+
+.c0 .k-HeaderMenu__item--external .k-HeaderMenu__item__link svg,
+.c0 .k-HeaderMenu__item--external .k-HeaderMenu__item__link img {
+  max-height: 1.5rem;
+  width: auto;
+}
+
+.c0 .k-HeaderMenu__item--external .k-HeaderMenu__item__link:focus,
+.c0 .k-HeaderMenu__item--external .k-HeaderMenu__item__link:hover {
+  color: #222;
+}
+
+.c0 .k-HeaderMenu__item--external .k-HeaderMenu__item__link:focus .k-HeaderMenu__item__arrow,
+.c0 .k-HeaderMenu__item--external .k-HeaderMenu__item__link:hover .k-HeaderMenu__item__arrow {
+  left: 0.3125rem;
+}
+
+.c0 .k-HeaderMenu__item--external .k-HeaderMenu__item__link::before {
+  display: none;
+}
+
+.c0 .k-HeaderMenu__item--hasButton {
+  padding: 1.25rem;
+  background-color: #fff;
+}
+
+.c0.k-HeaderMenu--hasBorderOnSide .k-HeaderMenu__item__link::before {
+  content: '';
+  position: absolute;
+  top: -0.0625rem;
+  bottom: 0;
+  width: 0;
+  background-color: transparent;
+  -webkit-transition: background-color 0.2s,width 0.2s;
+  transition: background-color 0.2s,width 0.2s;
+}
+
+.c0.k-HeaderMenu--hasBorderOnSide .k-HeaderMenu__item__link:hover::before,
+.c0.k-HeaderMenu--hasBorderOnSide .k-HeaderMenu__item__link:focus::before {
+  background-color: #19b4fa;
+  -webkit-transition: width 0.2s;
+  transition: width 0.2s;
+}
+
+.c0.k-HeaderMenu--hasBorderOnSide-left .k-HeaderMenu__item__link::before {
+  left: -0.0625rem;
+}
+
+.c0.k-HeaderMenu--hasBorderOnSide-right .k-HeaderMenu__item__link::before {
+  right: -0.0625rem;
+}
+
+.c0.k-HeaderMenu--hasBorderOnSideOnHover .k-HeaderMenu__item__link:hover,
+.c0.k-HeaderMenu--hasBorderOnSideOnHover .k-HeaderMenu__item__link:focus {
+  color: #19b4fa;
+}
+
+.c0.k-HeaderMenu--hasBorderOnSideOnHover .k-HeaderMenu__item__link:hover::before,
+.c0.k-HeaderMenu--hasBorderOnSideOnHover .k-HeaderMenu__item__link:focus::before {
+  width: 0.25rem;
+  background-color: #19b4fa;
+  -webkit-transition: width 0.2s;
+  transition: width 0.2s;
+}
+
+.c0.k-HeaderMenu--hasBigItems .k-HeaderMenu__item .k-HeaderMenu__item__link {
+  height: 4.375rem;
+  padding: 1.75rem 1.3125rem 1.75rem 2.5rem;
+}
+
+.c0.k-HeaderMenu--hasBigItems .k-HeaderMenu__item--external .k-HeaderMenu__item__link {
+  height: 4.375rem;
+  padding: 1.4375rem 1.3125rem 1.375rem 2.5rem;
+}
+
+.c0 .k-HeaderMenu__item--tiny .k-HeaderMenu__item__link {
+  height: auto;
+  padding-top: 0;
+  padding-bottom: 0.625rem;
+  font-family: Maax,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+}
+
+.c0 .k-HeaderMenu__item--tiny + .k-HeaderMenu__item--tiny .k-HeaderMenu__item__link {
+  padding-top: 0.3125rem;
+}
+
+.c0 .k-HeaderMenu__item--big .k-HeaderMenu__item__link {
+  height: 4.375rem;
+  padding: 1.75rem 1.3125rem 1.75rem 2.5rem;
+}
+
+.c0 .k-HeaderMenu__item--big.k-HeaderMenu__item--external .k-HeaderMenu__item__link {
+  height: 4.375rem;
+  padding: 1.4375rem 1.3125rem 1.375rem 2.5rem;
+}
+
+.c0 .k-HeaderMenu__item--light {
+  color: #b8b8b8;
+}
+
+.c0 .k-HeaderMenu__item--isSelected .k-HeaderMenu__item__link {
+  color: #19b4fa;
+}
+
+.c0.k-HeaderMenu--hasBorderOnSide .k-HeaderMenu__item--isSelected .k-HeaderMenu__item__link::before {
+  width: 0.25rem;
+  background-color: #19b4fa;
+}
+
+.c0.k-HeaderMenu--hasBorders {
+  border-left: 0.0625rem solid #eee;
+  border-right: 0.0625rem solid #eee;
+}
+
+.c0.k-HeaderMenu--hasBorders .k-HeaderMenu__item {
+  border-bottom: 0.0625rem solid #eee;
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c1 {
+    width: 12.5rem;
+    height: 3.125rem;
+  }
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c1.k-Button--nano {
+    width: 6.25rem;
+    height: 1.25rem;
+  }
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c1.k-Button--micro {
+    width: 6.25rem;
+    height: 1.25rem;
+  }
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c1.k-Button--tiny {
+    width: 10rem;
+    height: 2.5rem;
+  }
+}
+
+@media (min-width:40rem) {
+  .c1.k-Button--big {
+    min-width: 13.75rem;
+    min-height: 4.375rem;
+    padding: 0.625rem 2.5rem;
+    font-size: 1rem;
+  }
+}
+
+@media screen and (min-width:40rem) and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c1.k-Button--big {
+    width: 13.75rem;
+    height: 4.375rem;
+  }
+}
+
+@media (min-width:768px) {
+  .c1.k-Button--huge {
+    min-width: 13.75rem;
+    min-height: 5rem;
+    font-size: 1rem;
+    padding: 0.625rem 2.5rem;
+  }
+}
+
+@media screen and (min-width:48rem) and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c1.k-Button--huge {
+    width: 13.75rem;
+    height: 5rem;
+  }
+}
+
+@media (min-width:768px) {
+  .c1.k-Button--giant {
+    min-width: 13.75rem;
+    min-height: 5.625rem;
+    font-size: 1rem;
+    padding: 0.625rem 2.5rem;
+  }
+}
+
+@media screen and (min-width:48rem) and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c1.k-Button--giant {
+    width: 13.75rem;
+    height: 5.625rem;
+  }
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c1.k-Button--hasIcon:not(.k-Button--fluid) {
+    width: 3.125rem;
+    min-width: 0;
+    min-height: 0;
+  }
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c1.k-Button--hasIcon:not(.k-Button--fluid).k-Button--nano {
+    width: 1.25rem;
+  }
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c1.k-Button--hasIcon:not(.k-Button--fluid).k-Button--micro {
+    width: 1.875rem;
+  }
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c1.k-Button--hasIcon:not(.k-Button--fluid).k-Button--tiny {
+    width: 2.5rem;
+  }
+}
+
+@media (min-width:40rem) {
+  .c1.k-Button--hasIcon:not(.k-Button--fluid).k-Button--big {
+    min-width: 0;
+    min-height: 0;
+    padding: 0;
+    width: 4.375rem;
+    height: 4.375rem;
+  }
+}
+
+@media screen and (min-width:40rem) and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c1.k-Button--hasIcon:not(.k-Button--fluid).k-Button--big {
+    width: 4.375rem;
+  }
+}
+
+@media (min-width:48rem) {
+  .c1.k-Button--hasIcon:not(.k-Button--fluid).k-Button--huge {
+    min-width: initial;
+    width: 5rem;
+    height: 5rem;
+  }
+}
+
+@media screen and (min-width:48rem) and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c1.k-Button--hasIcon:not(.k-Button--fluid).k-Button--huge {
+    width: 5rem;
+  }
+}
+
+@media (min-width:48rem) {
+  .c1.k-Button--hasIcon:not(.k-Button--fluid).k-Button--giant {
+    min-width: initial;
+    width: 5.625rem;
+    height: 5.625rem;
+  }
+}
+
+@media screen and (min-width:48rem) and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c1.k-Button--hasIcon:not(.k-Button--fluid).k-Button--giant {
+    width: 5.625rem;
+  }
+}
+
+@media (min-width:40rem) {
+  .c1.k-Button--orion {
+    border-radius: 0.5rem;
+  }
+}
+
+<ul
+  className="c0 k-HeaderMenu k-HeaderMenu--hasBorders k-HeaderMenu--hasBorderOnSide k-HeaderMenu--hasBorderOnSide-right k-HeaderMenu--hasBorderOnSideOnHover"
+  style={
+    Object {
+      "--headerMenu-background-colors-hover": undefined,
+    }
+  }
+>
+  <li
+    className="k-HeaderMenu__item k-HeaderMenu__item--normal"
+    role="menuitem"
+  >
+    <a
+      aria-current={null}
+      className="k-HeaderMenu__item__link"
+      href="#"
+    >
+      Item 1
+    </a>
+  </li>
+  <li
+    className="k-HeaderMenu__item k-HeaderMenu__item--normal"
+    role="menuitem"
+  >
+    <button
+      aria-current={null}
+      className="k-HeaderMenu__item__link"
+      href={null}
+      onClick={[Function]}
+      type="button"
+    >
+      Button item
+    </button>
+  </li>
+  <li
+    className="k-HeaderMenu__item k-HeaderMenu__item--normal k-HeaderMenu__item--hasButton"
+    role="menuitem"
+  >
+    <button
+      className="c1 k-Button k-HeaderMenu__item__button k-Button--regular k-Button--null k-Button--andromeda k-Button--fluid"
+      href="#"
+      style={
+        Object {
+          "--border-radius": 0,
+        }
+      }
+      type="button"
+    >
+      Item 3
+    </button>
+  </li>
+</ul>
+`;
+
 exports[`<HeaderMenu /> with one custom item matches with snapshot 1`] = `
 .c0 {
   --headerMenu-background-colors-hover: #fff;

--- a/assets/javascripts/kitten/components/menus/header-menu/components/item.js
+++ b/assets/javascripts/kitten/components/menus/header-menu/components/item.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import deprecated from 'prop-types-extra/lib/deprecated'
 import classNames from 'classnames'
 
 import { ArrowIcon } from '../../../icons/arrow-icon'
@@ -14,9 +15,10 @@ export const Item = ({
   size,
   isSelected,
   as,
+  tag,
   ...other
 }) => {
-  const Component = as
+  const Component = as || tag
 
   return (
     <li
@@ -84,7 +86,8 @@ Item.propTypes = {
     'checked',
   ]),
   size: PropTypes.oneOf(['normal', 'tiny', 'big']),
-  as: PropTypes.string,
+  as: deprecated(PropTypes.string, 'Please use `tag` instead.'),
+  tag: PropTypes.string,
 }
 
 Item.defaultProps = {
@@ -95,5 +98,5 @@ Item.defaultProps = {
   isSelected: false,
   liProps: {},
   size: 'normal',
-  as: 'a',
+  tag: 'a',
 }

--- a/assets/javascripts/kitten/components/menus/header-menu/components/item.js
+++ b/assets/javascripts/kitten/components/menus/header-menu/components/item.js
@@ -13,50 +13,55 @@ export const Item = ({
   button,
   size,
   isSelected,
+  as,
   ...other
-}) => (
-  <li
-    role="menuitem"
-    {...liProps}
-    className={classNames(
-      'k-HeaderMenu__item',
-      liProps.className,
-      `k-HeaderMenu__item--${size}`,
-      {
-        'k-HeaderMenu__item--external': external,
-        'k-HeaderMenu__item--isSelected': isSelected,
-        'k-HeaderMenu__item--hasButton': button,
-        'k-HeaderMenu__item--light': modifier === 'light',
-      },
-    )}
-  >
-    {button ? (
-      <Button
-        {...other}
-        className={classNames('k-HeaderMenu__item__button', other.className)}
-        as="a"
-        modifier={modifier}
-        fluid
-      >
-        {children}
-      </Button>
-    ) : (
-      <a
-        {...other}
-        className={classNames('k-HeaderMenu__item__link', other.className)}
-        aria-current={isSelected ? 'page' : null}
-      >
-        {children}
-        {external && (
-          <ArrowIcon
-            className="k-HeaderMenu__item__arrow headerMenuArrowIcon"
-            direction="right"
-          />
-        )}
-      </a>
-    )}
-  </li>
-)
+}) => {
+  const Component = as
+
+  return (
+    <li
+      role="menuitem"
+      {...liProps}
+      className={classNames(
+        'k-HeaderMenu__item',
+        liProps.className,
+        `k-HeaderMenu__item--${size}`,
+        {
+          'k-HeaderMenu__item--external': external,
+          'k-HeaderMenu__item--isSelected': isSelected,
+          'k-HeaderMenu__item--hasButton': button,
+          'k-HeaderMenu__item--light': modifier === 'light',
+        },
+      )}
+    >
+      {button ? (
+        <Button
+          modifier={modifier}
+          fluid
+          {...other}
+          className={classNames('k-HeaderMenu__item__button', other.className)}
+          as={as}
+        >
+          {children}
+        </Button>
+      ) : (
+        <Component
+          {...other}
+          className={classNames('k-HeaderMenu__item__link', other.className)}
+          aria-current={isSelected ? 'page' : null}
+        >
+          {children}
+          {external && (
+            <ArrowIcon
+              className="k-HeaderMenu__item__arrow headerMenuArrowIcon"
+              direction="right"
+            />
+          )}
+        </Component>
+      )}
+    </li>
+  )
+}
 
 Item.propTypes = {
   external: PropTypes.bool,
@@ -79,6 +84,7 @@ Item.propTypes = {
     'checked',
   ]),
   size: PropTypes.oneOf(['normal', 'tiny', 'big']),
+  as: PropTypes.string,
 }
 
 Item.defaultProps = {
@@ -89,4 +95,5 @@ Item.defaultProps = {
   isSelected: false,
   liProps: {},
   size: 'normal',
+  as: 'a',
 }

--- a/assets/javascripts/kitten/components/menus/header-menu/stories.js
+++ b/assets/javascripts/kitten/components/menus/header-menu/stories.js
@@ -3,18 +3,13 @@ import { select, boolean } from '@storybook/addon-knobs'
 import { HeaderMenu } from './index'
 import { Marger } from '../../layout/marger'
 import { Container } from '../../grid/container'
-import { Grid, GridCol } from '../../grid/grid'
 import { LendopolisLogo } from '../../logos/lendopolis-logo'
 
 const StoryGrid = ({ children }) => (
   <Container>
-    <Grid>
-      <GridCol col="3">
-        <Marger top="5" bottom="5">
-          {children}
-        </Marger>
-      </GridCol>
-    </Grid>
+    <Marger top="5" bottom="5" style={{ width: '100%', maxWidth: '250px' }}>
+      {children}
+    </Marger>
   </Container>
 )
 
@@ -48,6 +43,12 @@ export const Default = () => {
         </HeaderMenu.Item>
         <HeaderMenu.Item external href="#">
           Item 5
+        </HeaderMenu.Item>
+        <HeaderMenu.Item as="button" type="button">
+          Item as button
+        </HeaderMenu.Item>
+        <HeaderMenu.Item button href="#">
+          Item with button prop
         </HeaderMenu.Item>
       </HeaderMenu>
     </StoryGrid>

--- a/assets/javascripts/kitten/components/menus/header-menu/styles.js
+++ b/assets/javascripts/kitten/components/menus/header-menu/styles.js
@@ -9,11 +9,15 @@ export const StyledList = styled.ul`
 
   margin: 0;
   padding: 0;
+  border: none;
   list-style: none;
 
   .k-HeaderMenu__item__link {
     display: block;
     position: relative;
+    width: 100%;
+    text-align: left;
+    border: none;
     height: ${pxToRem(50)};
     box-sizing: border-box;
 
@@ -27,14 +31,17 @@ export const StyledList = styled.ul`
     font-size: ${pxToRem(14)};
     text-decoration: none;
 
+    cursor: pointer;
+    transition: color 0.2s, background-color 0.4s;
+
     &:focus {
-      outline-offset: ${pxToRem(-3)};
+      outline: ${COLORS.primary4} solid ${pxToRem(2)};
+      outline-offset: ${pxToRem(-1)};
     }
     &:hover,
     &:focus {
       color: ${COLORS.primary1};
       background-color: var(--headerMenu-background-colors-hover);
-      transition: color 0.2s, background-color 0.4s;
     }
     &:focus:not(:focus-visible) {
       outline-color: transparent;
@@ -182,7 +189,7 @@ export const StyledList = styled.ul`
     border-left: ${pxToRem(1)} solid ${COLORS.line1};
     border-right: ${pxToRem(1)} solid ${COLORS.line1};
 
-    .k-HeaderMenu__item__link {
+    .k-HeaderMenu__item {
       border-bottom: ${pxToRem(1)} solid ${COLORS.line1};
     }
   }

--- a/assets/javascripts/kitten/components/menus/header-menu/test.js
+++ b/assets/javascripts/kitten/components/menus/header-menu/test.js
@@ -87,4 +87,26 @@ describe('<HeaderMenu />', () => {
       expect(component).toMatchSnapshot()
     })
   })
+
+  describe('with button items', () => {
+    beforeEach(() => {
+      component = renderer
+        .create(
+          <HeaderMenu borderSide="right">
+            <HeaderMenu.Item href="#">Item 1</HeaderMenu.Item>
+            <HeaderMenu.Item tag="button" type="button" onClick={() => {}}>
+              Button item
+            </HeaderMenu.Item>
+            <HeaderMenu.Item button href="#">
+              Item 3
+            </HeaderMenu.Item>
+          </HeaderMenu>,
+        )
+        .toJSON()
+    })
+
+    it('matches with snapshot', () => {
+      expect(component).toMatchSnapshot()
+    })
+  })
 })


### PR DESCRIPTION
Closes #.

Vercel link:

- https://kitten-git-header-menu-item-add-as-prop-kisskissbankbank.vercel.app/?path=/story/menus-headermenu--default

Screenshot:


TODO:

- [x] Tests
- [x] Changelog
- [x] A11Y
- [ ] Stories / Docs
- [ ] BrowserStack (IE11, Chrome & Firefox on Windows 10)
- [ ] New component added to `assets/javascripts/kitten/index.js`
