### PR TITLE
[Modal/Next] Add `sticky` and `fullSize` props on Actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [unreleased]
 
 - Feature: `Modal/Next`: Add `fullSizeOnMobile` prop, defaults to false.
-- Feature: `Modal/Next`: Add `sticky` and `stickyOnMobile` props to `Actions`.
+- Feature: `Modal/Next`: Add the following props to `Modal.Actions`:
+  - `sticky`
+  - `stickyOnMobile`
+  - `fullSize`
+  - `fullSizeOnMobile`
 
 ## [3.11.0] - 2021-05-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - `stickyOnMobile`
   - `fullSize`
   - `fullSizeOnMobile`
+- Feature: `Modal/Next`: Deprecate `withoutMargin` prop on `Modal.Paragraph` in favor of `noMargin`.
 - Feature: Add new color: `font3`.
 
 ## [3.11.0] - 2021-05-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Feature: `Modal/Next`: Add `fullSizeOnMobile` prop, defaults to false.
+- Feature: `Modal/Next`: Add `sticky` and `stickyOnMobile` props to `Actions`.
+
 ## [3.11.0] - 2021-05-14
 
 Feature:

--- a/assets/javascripts/kitten/components/modals/next/Modal.stories.js
+++ b/assets/javascripts/kitten/components/modals/next/Modal.stories.js
@@ -54,12 +54,16 @@ export const OneButton = () => (
     variant={select('Variant', ['andromeda', 'orion', 'andromeda'])}
     zIndex={number('Overlay z-index', 110)}
     headerTitle={text('headerTitle', null)}
+    fullSizeOnMobile={boolean('Full size on Mobile', false)}
   >
     {() => (
       <>
         <Modal.Title>Lorem ipsum dolor sit consectetuer</Modal.Title>
         <Modal.Paragraph>{text('content', paragraphContainer)}</Modal.Paragraph>
-        <Modal.Actions>
+        <Modal.Actions
+          sticky={boolean('Actions sticky', false)}
+          stickyOnMobile={boolean('Actions sticky on Mobile only', false)}
+        >
           <Modal.Button modifier="helium">Action 1 Button</Modal.Button>
         </Modal.Actions>
       </>
@@ -74,6 +78,7 @@ export const TwoButton = () => (
     size={select('Size', ['regular', 'big', 'huge', 'giant'], 'regular')}
     variant={select('Variant', ['andromeda', 'orion', 'andromeda'])}
     headerTitle={text('headerTitle', null)}
+    fullSizeOnMobile={boolean('Full size on Mobile', false)}
   >
     {() => (
       <>

--- a/assets/javascripts/kitten/components/modals/next/Modal.stories.js
+++ b/assets/javascripts/kitten/components/modals/next/Modal.stories.js
@@ -1,8 +1,7 @@
 import React, { useState } from 'react'
 import { text, boolean, number, select } from '@storybook/addon-knobs'
 import { Modal } from './index'
-import { Button } from '../../../components/buttons/button'
-import { SaveIcon } from '../../../components/icons/save-icon'
+import { Button, Text, SaveIcon } from '../../..'
 
 const paragraphContainer = `
   Sed ut perspiciatis unde omnis iste natus error sit voluptatem
@@ -46,95 +45,76 @@ export default {
   },
 }
 
-export const OneButton = () => (
-  <Modal
-    trigger={<Button modifier="helium">Open</Button>}
-    hasCloseButton={boolean('Has close button', true)}
-    size={select('Size', ['regular', 'big', 'huge', 'giant'], 'regular')}
-    variant={select('Variant', ['andromeda', 'orion', 'andromeda'])}
-    zIndex={number('Overlay z-index', 110)}
-    headerTitle={text('headerTitle', null)}
-    fullSizeOnMobile={boolean('Full size on Mobile', false)}
-  >
-    {() => (
-      <>
-        <Modal.Title>Lorem ipsum dolor sit consectetuer</Modal.Title>
-        <Modal.Paragraph>{text('content', paragraphContainer)}</Modal.Paragraph>
-        <Modal.Actions
-          sticky={boolean('Actions sticky', false)}
-          stickyOnMobile={boolean('Actions sticky on Mobile only', false)}
-        >
-          <Modal.Button modifier="helium">Action 1 Button</Modal.Button>
-        </Modal.Actions>
-      </>
-    )}
-  </Modal>
-)
+const buttonSelectionChoices = {
+  'None': 0,
+  'One button': 1,
+  'Two with Close': 2,
+}
 
-export const TwoButton = () => (
-  <Modal
-    trigger={<Button modifier="helium">Open</Button>}
-    hasCloseButton={boolean('Has close button', true)}
-    size={select('Size', ['regular', 'big', 'huge', 'giant'], 'regular')}
-    variant={select('Variant', ['andromeda', 'orion', 'andromeda'])}
-    headerTitle={text('headerTitle', null)}
-    fullSizeOnMobile={boolean('Full size on Mobile', false)}
-  >
-    {() => (
-      <>
-        <Modal.Title>Lorem ipsum dolor sit consectetuer</Modal.Title>
-        <Modal.Paragraph>{text('content', paragraphContainer)}</Modal.Paragraph>
-        <Modal.Actions>
-          <Modal.Button modifier="helium">Action 1 Button</Modal.Button>
-          <Modal.Button modifier="oxygen">Action 2 Button</Modal.Button>
-        </Modal.Actions>
-      </>
-    )}
-  </Modal>
-)
+export const Default = () => {
+  const buttonSelection = select('Display Buttons', buttonSelectionChoices, 1)
 
-export const WithState = () => {
+  return (
+    <Modal
+      trigger={<Button modifier="helium">Open</Button>}
+      hasCloseButton={boolean('Has header close button', true)}
+      size={select('Size', ['regular', 'big', 'huge', 'giant'], 'regular')}
+      variant={select('Variant', ['andromeda', 'orion', 'andromeda'])}
+      zIndex={number('Overlay z-index', 110)}
+      headerTitle={text('headerTitle', null)}
+      fullSizeOnMobile={boolean('Full size on Mobile', false)}
+    >
+      {() => (
+        <>
+          <Modal.Title>Lorem ipsum dolor sit consectetuer</Modal.Title>
+          <Modal.Paragraph>{text('content', paragraphContainer)}</Modal.Paragraph>
+          <Modal.Actions
+            sticky={boolean('Actions sticky', false)}
+            stickyOnMobile={boolean('Actions sticky on Mobile only', false)}
+            fullSize={boolean('Actions fullSize', false)}
+            fullSizeOnMobile={boolean('Actions fullSize on Mobile only', false)}
+          >
+            {buttonSelection > 0 &&
+              <Modal.Button modifier="helium">Modal.Button</Modal.Button>
+            }
+            {buttonSelection > 1 &&
+              <Modal.CloseButton modifier="hydrogen">Modal.CloseButton</Modal.CloseButton>
+            }
+          </Modal.Actions>
+        </>
+      )}
+    </Modal>
+  )
+}
+
+export const Controlled = () => {
   const [showModal, updateModalState] = useState(false)
   return (
     <>
       <Button modifier="helium" onClick={() => updateModalState(!showModal)}>
         Open
       </Button>
+      <Text tag="p" weight="light">
+        The modal is controlled through a state that controls the <code>isOpen</code> prop.
+      </Text>
       <Modal
         isOpen={showModal}
-        hasCloseButton={boolean('Has close button', true)}
-        size={select('Size', ['regular', 'big', 'huge', 'giant'], 'regular')}
-        variant={select('Variant', ['andromeda', 'orion', 'andromeda'])}
+        hasCloseButton={true}
         onClose={() => updateModalState(false)}
       >
         {() => (
           <>
             <Modal.Title>Lorem ipsum dolor sit consectetuer</Modal.Title>
             <Modal.Paragraph>
-              {text('content', paragraphContainer)}
+              {paragraphContainer}
             </Modal.Paragraph>
             <Modal.Actions>
-              <Modal.Button modifier="helium">Action 1 Button</Modal.Button>
+              <Modal.Button modifier="helium">Modal.Button</Modal.Button>
             </Modal.Actions>
           </>
         )}
       </Modal>
     </>
-  )
-}
-
-export const WithCloseButton = () => {
-  return (
-    <Modal trigger={<Button modifier="helium">Open</Button>}>
-      {() => (
-        <>
-          <Modal.Title>Modal</Modal.Title>
-          <Modal.Actions>
-            <Modal.CloseButton>Close it !</Modal.CloseButton>
-          </Modal.Actions>
-        </>
-      )}
-    </Modal>
   )
 }
 
@@ -151,38 +131,26 @@ export const Multi = () => {
   )
 }
 
-export const WithoutButton = () => (
-  <Modal
-    trigger={<Button modifier="helium">Open</Button>}
-    size={select('Size', ['regular', 'big', 'huge', 'giant'], 'regular')}
-    zIndex={number('Overlay z-index', 110)}
-    variant={select('Variant', ['andromeda', 'orion', 'andromeda'])}
-  >
-    {() => (
-      <>
-        <Modal.Title>Lorem ipsum dolor sit consectetuer</Modal.Title>
-        <Modal.Paragraph withoutMargin>
-          {text('content', paragraphContainer)}
-        </Modal.Paragraph>
-      </>
-    )}
-  </Modal>
-)
-
 export const FullSize = () => (
   <Modal
     trigger={<Button modifier="helium">Open</Button>}
     hasCloseButton={boolean('Has close button', true)}
-    zIndex={number('Overlay z-index', 110)}
     variant={select('Variant', ['andromeda', 'orion', 'andromeda'])}
     fullSizeTitle={text('fullSizeTitle', 'Lorem ipsum dolor sit consectetuer')}
     fullSize
   >
     {() => (
       <>
-        <Modal.Title>Lorem ipsum dolor sit consectetuer</Modal.Title>
+        <Modal.Title>This modal is full sized</Modal.Title>
         <Modal.Paragraph>
-          {text('content', `${paragraphContainer} ${paragraphContainer}`)}
+          The display of a header depends on the <code>fullSizeTitle</code>{' '}
+          prop.
+        </Modal.Paragraph>
+        <Modal.Paragraph>
+          {paragraphContainer}
+        </Modal.Paragraph>
+        <Modal.Paragraph>
+          {paragraphContainer}
         </Modal.Paragraph>
         <Modal.Actions>
           <Modal.Button modifier="helium">Action 1 Button</Modal.Button>
@@ -236,12 +204,13 @@ export const ComplexWithOrion = () => (
     headerTitle={<OrionHeaderTitle />}
     headerActions={OrionHeaderActions}
     size={select('Size', ['regular', 'big', 'huge', 'giant'], 'giant')}
-    variant={select('Variant', ['andromeda', 'orion', 'orion'])}
   >
     {() => (
       <>
         <Modal.Block className="k-u-background-color-background3">
-          {text('content', paragraphContainer)}
+          <Text weight="light" tag="p" className="k-u-margin-vertical-triple">
+            {text('content', paragraphContainer)}
+          </Text>
         </Modal.Block>
         <Modal.Paragraph align="left">
           {text('content', paragraphContainer)}
@@ -251,7 +220,7 @@ export const ComplexWithOrion = () => (
   </Modal>
 )
 
-export const CustomContentCols = () => (
+export const CustomInnerSize = () => (
   <Modal
     trigger={<Button modifier="helium">Open</Button>}
     hasCloseButton={boolean('Has close button', true)}
@@ -268,13 +237,17 @@ export const CustomContentCols = () => (
   >
     {() => (
       <>
-        <Modal.Title>Lorem ipsum dolor sit consectetuer</Modal.Title>
         <Modal.Block className="k-u-background-color-background3">
-          {text('content', paragraphContainer)}
+          <Text weight="light" tag="p" className="k-u-margin-vertical-triple">
+            This Modal has the following inner size, defined by <code>contentCols</code> prop:
+            <br />
+            <code>{'{ xxs: 12, s: 10, l: 8, xl: 6 }'}</code>
+
+          </Text>
         </Modal.Block>
         <Modal.Paragraph>{text('content', paragraphContainer)}</Modal.Paragraph>
         <Modal.Actions>
-          <Modal.Button modifier="helium">Action 1 Button</Modal.Button>
+          <Modal.CloseButton modifier="helium">Modal.CloseButton</Modal.CloseButton>
         </Modal.Actions>
       </>
     )}

--- a/assets/javascripts/kitten/components/modals/next/index.js
+++ b/assets/javascripts/kitten/components/modals/next/index.js
@@ -103,16 +103,16 @@ const GlobalStyle = createGlobalStyle`
       }
     }
     &.k-ModalNext__content--fullSize {
-      min-width: 100vw !important;
+      min-width: 100vw;
       height: 100%;
-      margin: 0 !important;
+      margin: 0;
     }
 
     @media (max-width: ${pxToRem(ScreenConfig.XS.max)}) {
       &.k-ModalNext__content--fullSizeOnMobile {
-        min-width: 100vw !important;
+        min-width: 100vw;
         height: 100%;
-        margin: 0 !important;
+        margin: 0;
       }
     }
 

--- a/assets/javascripts/kitten/components/modals/next/index.js
+++ b/assets/javascripts/kitten/components/modals/next/index.js
@@ -681,7 +681,7 @@ const InnerModal = ({
               </div>
 
               <div className="k-ModalNext__header__actions">
-                {headerActions({
+                {headerActions && headerActions({
                   open: () => dispatch(updateState(true)),
                   close: () => dispatch(updateState(false)),
                 })}
@@ -772,7 +772,7 @@ Modal.defaultProps = {
   zIndex: 110,
   variant: 'andromeda',
   headerTitle: null,
-  headerActions: () => {},
+  headerActions: null,
   contentCols: {},
   headerZIndex: 10,
 }

--- a/assets/javascripts/kitten/components/modals/next/index.js
+++ b/assets/javascripts/kitten/components/modals/next/index.js
@@ -383,8 +383,14 @@ const GlobalStyle = createGlobalStyle`
       }
     }
 
+    &.k-ModalNext__overlay--fullSize {
+      background: white;
+    }
+
     @media (max-width: ${pxToRem(ScreenConfig.XS.max)}) {
       &.k-ModalNext__overlay--fullSizeOnMobile {
+        background: white;
+
         .k-ModalNext__content {
           flex: 1;
         }

--- a/assets/javascripts/kitten/components/modals/next/index.js
+++ b/assets/javascripts/kitten/components/modals/next/index.js
@@ -50,7 +50,7 @@ const GlobalStyle = createGlobalStyle`
     --Modal-wrapperMaxWidth: 100vw;
     --Modal-contentCols: 4;
     --Modal-contentMargin: 1;
-    --Modal-headerHeight: 0;
+    --Modal-headerHeight: 0px;
 
     position: relative;
     background-color: ${COLORS.background1};

--- a/assets/javascripts/kitten/components/modals/next/index.js
+++ b/assets/javascripts/kitten/components/modals/next/index.js
@@ -139,7 +139,7 @@ const GlobalStyle = createGlobalStyle`
       height: var(--Modal-headerHeight);
       display: grid;
       gap: ${pxToRem(GUTTER)};
-      grid-template-columns: 1fr calc(100% - 2 * (${pxToRem(GUTTER + 40)})) 1fr;
+      grid-template-columns: 1fr auto 1fr;
       align-items: center;
       padding-left: ${pxToRem(CONTAINER_PADDING_THIN)};
       padding-right: ${pxToRem(CONTAINER_PADDING_THIN)};
@@ -151,14 +151,17 @@ const GlobalStyle = createGlobalStyle`
       }
 
       .k-ModalNext__header__closeButton {
+        min-width: ${pxToRem(40)};
         text-align: left;
       }
 
       .k-ModalNext__header__title {
+        min-width: ${pxToRem(40)};
         text-align: center;
       }
 
       .k-ModalNext__header__actions {
+        min-width: ${pxToRem(40)};
         text-align: right;
       }
     }

--- a/assets/javascripts/kitten/components/modals/next/index.js
+++ b/assets/javascripts/kitten/components/modals/next/index.js
@@ -287,6 +287,10 @@ const GlobalStyle = createGlobalStyle`
         margin-bottom: 0;
       }
     }
+
+    .k-ModalNext__main__title {
+      margin-bottom:
+    }
   }
 
   /* ANDROMEDA STYLES */
@@ -467,12 +471,17 @@ const GlobalStyle = createGlobalStyle`
 
 `
 
-const ModalTitle = ({ children }) => (
+const ModalTitle = ({ children, className, ...props }) => (
   <Title
     modifier="quaternary"
     noMargin
     tag="p"
-    className="k-u-margin-bottom-singleHalf--important k-u-align-center"
+    className={classNames(
+      'k-ModalNext__main__title',
+      className,
+      'k-u-align-center',
+    )}
+    {...props}
   >
     {children}
   </Title>
@@ -491,12 +500,12 @@ const ModalParagraph = ({
     noMargin
     tag={tag || 'p'}
     className={classNames(
-      'k-ModalNext__paragraph',
+      'k-ModalNext__main__paragraph',
       className,
       `k-u-align-${align}`,
       {
-        'k-u-margin-bottom-triple': !withoutMargin,
-        'k-u-margin-bottom-quadruple@s-up': !withoutMargin,
+        'k-u-margin-bottom-triple': !withoutMargin || !noMargin,
+        'k-u-margin-bottom-quadruple@s-up': !withoutMargin || !noMargin,
       },
     )}
     {...props}
@@ -506,10 +515,13 @@ const ModalParagraph = ({
 )
 
 ModalParagraph.propTypes = {
+  withoutMargin: deprecated(PropTypes.bool, 'Please use `noMargin` instead'),
+  noMargin: PropTypes.bool,
   align: PropTypes.oneOf(['center', 'left', 'right', 'justify']),
 }
 
 ModalParagraph.defaultProps = {
+  noMargin: false,
   align: 'center',
 }
 

--- a/assets/javascripts/kitten/components/modals/next/index.js
+++ b/assets/javascripts/kitten/components/modals/next/index.js
@@ -50,6 +50,7 @@ const GlobalStyle = createGlobalStyle`
     --Modal-wrapperMaxWidth: 100vw;
     --Modal-contentCols: 4;
     --Modal-contentMargin: 1;
+    --Modal-headerHeight: 0;
 
     position: relative;
     background-color: ${COLORS.background1};
@@ -57,6 +58,8 @@ const GlobalStyle = createGlobalStyle`
     transform: scale(0.94);
     margin: auto;
     width: calc(100vw - ${pxToRem(2 * CONTAINER_PADDING_THIN)});
+    display: flex;
+    flex-direction: column;
 
     @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
       width: calc(100vw - ${pxToRem(2 * CONTAINER_PADDING)})
@@ -101,12 +104,14 @@ const GlobalStyle = createGlobalStyle`
     }
     &.k-ModalNext__content--fullSize {
       min-width: 100vw !important;
+      height: 100%;
       margin: 0 !important;
     }
 
     @media (max-width: ${pxToRem(ScreenConfig.XS.max)}) {
       &.k-ModalNext__content--fullSizeOnMobile {
         min-width: 100vw !important;
+        height: 100%;
         margin: 0 !important;
       }
     }
@@ -127,9 +132,11 @@ const GlobalStyle = createGlobalStyle`
     }
 
     .k-ModalNext__header {
+      flex: 0 0 auto;
       position: sticky;
       z-index: var(--Modal-headerZIndex);
       top: 0;
+      height: var(--Modal-headerHeight);
       display: grid;
       gap: ${pxToRem(GUTTER)};
       grid-template-columns: 1fr calc(100% - 2 * (${pxToRem(GUTTER + 40)})) 1fr;
@@ -195,6 +202,10 @@ const GlobalStyle = createGlobalStyle`
 
     .k-ModalNext__main {
       padding: 0 ${pxToRem(CONTAINER_PADDING_THIN)} ${pxToRem(50)};
+      flex: 1 0 auto;
+      display: flex;
+      flex-direction: column;
+      box-sizing: border-box;
 
       @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
         padding: 0 calc(var(--Modal-contentMargin) * ${oneGridCol}) ${pxToRem(
@@ -214,6 +225,14 @@ const GlobalStyle = createGlobalStyle`
         @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
           margin-top: ${pxToRem(80)};
         }
+      }
+
+      & > * {
+        flex: 0 0 auto;
+      }
+
+      & > :nth-last-child(2) {
+        flex-grow: 1;
       }
     }
 
@@ -242,9 +261,11 @@ const GlobalStyle = createGlobalStyle`
 
   .k-ModalNext__content--andromeda {
     .k-ModalNext__header {
-      height: ${pxToRem(60)};
       border-bottom: ${pxToRem(2)} solid ${COLORS.line1};
       margin-bottom: ${pxToRem(50)}
+
+    &.k-ModalNext__content--hasHeader {
+      --Modal-headerHeight: ${pxToRem(60)};
     }
   }
 
@@ -265,16 +286,17 @@ const GlobalStyle = createGlobalStyle`
       }
     }
 
+    &.k-ModalNext__content--hasHeader {
+      --Modal-headerHeight: ${pxToRem(80)};
 
+      @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
+        --Modal-headerHeight: ${pxToRem(100)};
+      }
+    }
 
     .k-ModalNext__header {
       border-top-left-radius: ${pxToRem(12)};
       border-top-right-radius: ${pxToRem(12)};
-      height: ${pxToRem(80)};
-
-      @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
-        height: ${pxToRem(100)};
-      }
 
       .k-Button {
         @media (max-width: ${pxToRem(ScreenConfig.XS.max)}) {
@@ -582,6 +604,8 @@ const InnerModal = ({
     }
   }
 
+  const shouldDisplayHeader = !!headerTitle || !!fullSizeTitle || !!headerActions
+
   const ModalPortal = ReactDOM.createPortal(
     <>
       <GlobalStyle zIndex={zIndex} />
@@ -594,6 +618,7 @@ const InnerModal = ({
             `k-ModalNext__content--${size}`,
             `k-ModalNext__content--${variant}`,
             {
+              'k-ModalNext__content--hasHeader': shouldDisplayHeader,
               'k-ModalNext__content--fullSize': fullSize,
               'k-ModalNext__content--fullSizeOnMobile': fullSizeOnMobile,
               'k-ModalNext__content--customContentCols': !isEmpty(contentCols),
@@ -631,7 +656,7 @@ const InnerModal = ({
         {...modalProps}
       >
         <>
-          {headerTitle || fullSizeTitle ? (
+          {shouldDisplayHeader ? (
             <div className="k-ModalNext__header">
               <div className="k-ModalNext__header__closeButton">
                 {hasCloseButton && (

--- a/assets/javascripts/kitten/components/modals/next/index.js
+++ b/assets/javascripts/kitten/components/modals/next/index.js
@@ -104,6 +104,13 @@ const GlobalStyle = createGlobalStyle`
       margin: 0 !important;
     }
 
+    @media (max-width: ${pxToRem(ScreenConfig.XS.max)}) {
+      &.k-ModalNext__content--fullSizeOnMobile {
+        min-width: 100vw !important;
+        margin: 0 !important;
+      }
+    }
+
     &.k-ModalNext__content--customContentCols {
       @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
         --Modal-contentCols: var(--Modal-contentCols--s, var(--Modal-contentCols--default, 4));
@@ -124,8 +131,8 @@ const GlobalStyle = createGlobalStyle`
       z-index: var(--Modal-headerZIndex);
       top: 0;
       display: grid;
-      gap: ${GUTTER};
-      grid-template-columns: 1fr auto 1fr;
+      gap: ${pxToRem(GUTTER)};
+      grid-template-columns: 1fr calc(100% - 2 * (${pxToRem(GUTTER + 40)})) 1fr;
       align-items: center;
       padding-left: ${pxToRem(CONTAINER_PADDING_THIN)};
       padding-right: ${pxToRem(CONTAINER_PADDING_THIN)};
@@ -153,7 +160,8 @@ const GlobalStyle = createGlobalStyle`
     .k-ModalNext__closeButton {
       position: absolute;
       top: 0;
-      right: ${pxToRem(40)};
+      right: ${pxToRem(30)};
+
       @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
         right: ${pxToRem(50)};
       }
@@ -162,6 +170,7 @@ const GlobalStyle = createGlobalStyle`
     .k-ModalNext__actions {
       display: flex;
       flex-direction: column;
+      background-color: ${COLORS.background1};
 
       @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
         gap: ${pxToRem(GUTTER)};
@@ -170,6 +179,17 @@ const GlobalStyle = createGlobalStyle`
 
       .k-Button {
         margin-top: ${pxToRem(20)};
+      }
+
+      &.k-ModalNext__actions--sticky {
+        position: sticky;
+        bottom: 0;
+      }
+      @media (max-width: ${pxToRem(ScreenConfig.XS.max)}) {
+        &.k-ModalNext__actions--stickyOnMobile {
+          position: sticky;
+          bottom: 0;
+        }
       }
     }
 
@@ -235,7 +255,17 @@ const GlobalStyle = createGlobalStyle`
     padding-top: 0;
     padding-left: 0;
     padding-right: 0;
-    border-radius: ${pxToRem(12)};
+
+    &:not(.k-ModalNext__content--fullSize) {
+      border-radius: ${pxToRem(12)};
+    }
+    @media (max-width: ${pxToRem(ScreenConfig.XS.max)}) {
+      &.k-ModalNext__content--fullSizeOnMobile {
+        border-radius: 0 !important;
+      }
+    }
+
+
 
     .k-ModalNext__header {
       border-top-left-radius: ${pxToRem(12)};
@@ -331,6 +361,19 @@ const GlobalStyle = createGlobalStyle`
       }
     }
 
+    @media (max-width: ${pxToRem(ScreenConfig.XS.max)}) {
+      &.k-ModalNext__overlay--fullSizeOnMobile {
+        .k-ModalNext__content {
+          flex: 1;
+        }
+
+        &::before, &::after {
+          min-height: 0 !important;
+          flex: 0 !important;
+        }
+      }
+    }
+
     ${props =>
       css`
         z-index: ${props.zIndex};
@@ -404,10 +447,24 @@ ModalParagraph.defaultProps = {
   align: 'center',
 }
 
-const Actions = props => (
+const Actions = ({
+  className,
+  sticky,
+  stickyOnMobile,
+  ...props
+}) => (
   <div
+    className={
+      classNames(
+        'k-ModalNext__actions',
+        className,
+        {
+          'k-ModalNext__actions--sticky': sticky,
+          'k-ModalNext__actions--stickyOnMobile': stickyOnMobile,
+        }
+      )
+    }
     {...props}
-    className={classNames('k-ModalNext__actions', props.className)}
   />
 )
 
@@ -490,6 +547,7 @@ const InnerModal = ({
   isOpen,
   zIndex,
   fullSize,
+  fullSizeOnMobile,
   fullSizeTitle,
   variant,
   headerTitle,
@@ -537,6 +595,7 @@ const InnerModal = ({
             `k-ModalNext__content--${variant}`,
             {
               'k-ModalNext__content--fullSize': fullSize,
+              'k-ModalNext__content--fullSizeOnMobile': fullSizeOnMobile,
               'k-ModalNext__content--customContentCols': !isEmpty(contentCols),
             },
           ),
@@ -550,6 +609,7 @@ const InnerModal = ({
             `k-ModalNext__overlay--${variant}`,
             {
               'k-ModalNext__overlay--fullSize': fullSize,
+              'k-ModalNext__overlay--fullSizeOnMobile': fullSizeOnMobile,
             },
           ),
           afterOpen: 'k-ModalNext__overlay--afterOpen',
@@ -607,7 +667,7 @@ const InnerModal = ({
               <div className="k-ModalNext__closeButton">
                 <CloseButton
                   style={{ position: 'fixed' }}
-                  className="k-u-hidden@s-up k-u-margin-none"
+                  className="k-u-hidden@s-up--important k-u-margin-none"
                   modifier="hydrogen"
                   onClick={close}
                   size="micro"
@@ -615,7 +675,7 @@ const InnerModal = ({
                 />
                 <CloseButton
                   style={{ position: 'fixed' }}
-                  className="k-u-hidden@xs-down k-u-margin-none"
+                  className="k-u-hidden@xs-down--important k-u-margin-none"
                   modifier="hydrogen"
                   onClick={close}
                   closeButtonLabel={closeButtonLabel}
@@ -659,6 +719,7 @@ Modal.propTypes = {
   describedby: PropTypes.string,
   closeButtonLabel: PropTypes.string,
   fullSize: PropTypes.bool,
+  fullSizeOnMobile: PropTypes.bool,
   modalProps: PropTypes.object,
   hasCloseButton: PropTypes.bool,
   size: PropTypes.oneOf(['regular', 'big', 'huge', 'giant']),
@@ -678,12 +739,12 @@ Modal.defaultProps = {
   describedby: '',
   closeButtonLabel: 'Fermer',
   fullSize: false,
+  fullSizeOnMobile: false,
   modalProps: {},
   hasCloseButton: true,
   size: 'regular',
   isOpen: false,
   zIndex: 110,
-  fullSizeTitle: '',
   variant: 'andromeda',
   headerTitle: null,
   headerActions: () => {},

--- a/assets/javascripts/kitten/components/modals/next/index.js
+++ b/assets/javascripts/kitten/components/modals/next/index.js
@@ -146,7 +146,6 @@ const GlobalStyle = createGlobalStyle`
       background-color: ${COLORS.background1};
 
       @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
-        height: ${pxToRem(100)};
         padding-left: ${pxToRem(CONTAINER_PADDING)};
         padding-right: ${pxToRem(CONTAINER_PADDING)};
       }
@@ -201,22 +200,18 @@ const GlobalStyle = createGlobalStyle`
     }
 
     .k-ModalNext__main {
-      padding: 0 ${pxToRem(CONTAINER_PADDING_THIN)} ${pxToRem(50)};
       flex: 1 0 auto;
       display: flex;
       flex-direction: column;
       box-sizing: border-box;
+      padding: 0 ${pxToRem(CONTAINER_PADDING_THIN)};
 
       @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
-        padding: 0 calc(var(--Modal-contentMargin) * ${oneGridCol}) ${pxToRem(
-  80,
-)};
+        padding: 0 calc(var(--Modal-contentMargin) * ${oneGridCol});
       }
 
       @media (min-width: ${pxToRem(ScreenConfig.XL.min)}) {
-        padding: 0 calc(var(--Modal-contentMargin) * ${oneGridColXl}) ${pxToRem(
-  80,
-)};
+        padding: 0 calc(var(--Modal-contentMargin) * ${oneGridColXl});
       }
 
       & > *:not(.k-ModalNext__block):first-child {
@@ -234,6 +229,18 @@ const GlobalStyle = createGlobalStyle`
       & > :nth-last-child(2) {
         flex-grow: 1;
       }
+
+      & > *:last-child {
+        margin-bottom: ${pxToRem(50)};
+
+        @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
+          margin-bottom: ${pxToRem(80)};
+        }
+      }
+    }
+
+    .k-ModalNext__header ~ .k-ModalNext__main > *:not(.k-ModalNext__block):first-child {
+      margin-top: 0;
     }
 
     .k-ModalNext__block {
@@ -255,6 +262,28 @@ const GlobalStyle = createGlobalStyle`
         padding-right: ${pxToRem(CONTAINER_PADDING)};
       }
     }
+
+    .k-ModalNext__actions.k-ModalNext__actions--fullSize {
+      margin-left: -${pxToRem(CONTAINER_PADDING_THIN)};
+      margin-right: -${pxToRem(CONTAINER_PADDING_THIN)};
+      margin-bottom: 0;
+
+      @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
+        margin-left: calc(-1 * var(--Modal-contentMargin) * ${oneGridCol});
+        margin-right: calc(-1 * var(--Modal-contentMargin) * ${oneGridCol});
+      }
+      @media (min-width: ${pxToRem(ScreenConfig.XL.min)}) {
+        margin-left: calc(-1 * var(--Modal-contentMargin) * ${oneGridColXl});
+        margin-right: calc(-1 * var(--Modal-contentMargin) * ${oneGridColXl});
+      }
+    }
+    @media (max-width: ${pxToRem(ScreenConfig.XS.max)}) {
+      .k-ModalNext__actions.k-ModalNext__actions--fullSizeOnMobile {
+        margin-left: -${pxToRem(CONTAINER_PADDING_THIN)};
+        margin-right: -${pxToRem(CONTAINER_PADDING_THIN)};
+        margin-bottom: 0;
+      }
+    }
   }
 
   /* ANDROMEDA STYLES */
@@ -262,7 +291,13 @@ const GlobalStyle = createGlobalStyle`
   .k-ModalNext__content--andromeda {
     .k-ModalNext__header {
       border-bottom: ${pxToRem(2)} solid ${COLORS.line1};
-      margin-bottom: ${pxToRem(50)}
+      margin-bottom: ${pxToRem(50)};
+
+      @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
+        padding-left: ${pxToRem(CONTAINER_PADDING)};
+        padding-right: ${pxToRem(CONTAINER_PADDING)};
+      }
+    }
 
     &.k-ModalNext__content--hasHeader {
       --Modal-headerHeight: ${pxToRem(60)};
@@ -479,6 +514,8 @@ const Actions = ({
   className,
   sticky,
   stickyOnMobile,
+  fullSize,
+  fullSizeOnMobile,
   ...props
 }) => (
   <div
@@ -489,6 +526,8 @@ const Actions = ({
         {
           'k-ModalNext__actions--sticky': sticky,
           'k-ModalNext__actions--stickyOnMobile': stickyOnMobile,
+          'k-ModalNext__actions--fullSize': fullSize,
+          'k-ModalNext__actions--fullSizeOnMobile': fullSizeOnMobile,
         }
       )
     }

--- a/assets/javascripts/kitten/components/modals/next/index.js
+++ b/assets/javascripts/kitten/components/modals/next/index.js
@@ -321,6 +321,10 @@ const GlobalStyle = createGlobalStyle`
 
     &:not(.k-ModalNext__content--fullSize) {
       border-radius: ${pxToRem(12)};
+
+      .k-ModalNext__closeButton .k-Button {
+        border-top-right-radius: ${pxToRem(12)};
+      }
     }
     @media (max-width: ${pxToRem(ScreenConfig.XS.max)}) {
       &.k-ModalNext__content--fullSizeOnMobile {


### PR DESCRIPTION
Closes #.

Vercel link:

- https://kitten-git-modal-next-add-sticky-mobile-action-kisskissbankbank.vercel.app/?path=/story/modals-modal-next--default

Screenshot:


TODO:

- [ ] Tests
- [ ] Changelog
- [ ] A11Y
- [ ] Stories / Docs
- [ ] BrowserStack (IE11, Chrome & Firefox on Windows 10)
- [ ] New component added to `assets/javascripts/kitten/index.js`
