### PR TITLE
[Button] Add neon modifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+Feature: Add `neon` modifier to Button component.
+
 ## [3.13.1] - 2021-05-20
  
 Fixes:

--- a/assets/javascripts/kitten/components/buttons/button/button.stories.js
+++ b/assets/javascripts/kitten/components/buttons/button/button.stories.js
@@ -42,6 +42,7 @@ const modifierOptions = {
   Checked: 'checked',
   Copper: 'copper',
   Boron: 'boron',
+  Neon: 'neon',
   Social_facebook: 'social_facebook',
   Social_twitter: 'social_twitter',
   Social_linkedin: 'social_linkedin',

--- a/assets/javascripts/kitten/components/buttons/button/button.stories.mdx
+++ b/assets/javascripts/kitten/components/buttons/button/button.stories.mdx
@@ -57,6 +57,7 @@ import { Button } from '@kisskissbankbank/kitten'
 <Button modifier="carbon">MyButton</Button>
 <Button modifier="oxygen">MyButton</Button>
 <Button modifier="boron">MyButton</Button>
+<Button modifier="neon">MyButton</Button>
 ```
 
 #### Tag

--- a/assets/javascripts/kitten/components/buttons/button/helpers/modifier-styles.js
+++ b/assets/javascripts/kitten/components/buttons/button/helpers/modifier-styles.js
@@ -78,6 +78,18 @@ export const modifierStyles = modifier => {
       activeColor = COLORS.font2
       break
 
+    case 'neon':
+      borderColor = COLORS.orange
+      backgroundColor = COLORS.orange
+      color = COLORS.background1
+      hoverBorderColor = '#f57905'
+      hoverBgColor = '#f57905'
+      hoverColor = COLORS.background1
+      activeBorderColor = '#eb6e00'
+      activeBgColor = '#eb6e00'
+      activeColor = COLORS.background1
+      break
+
     /* Social modifiers */
     case 'social_facebook':
       borderColor = '#3b5998'

--- a/assets/javascripts/kitten/components/buttons/button/index.js
+++ b/assets/javascripts/kitten/components/buttons/button/index.js
@@ -417,6 +417,7 @@ Button.propTypes = {
     'oxygen',
     'copper',
     'boron',
+    'neon',
     'social_facebook',
     'social_twitter',
     'social_linkedin',

--- a/assets/javascripts/kitten/components/cards/vertical-card-with-action/vertical-card-with-action.stories.js
+++ b/assets/javascripts/kitten/components/cards/vertical-card-with-action/vertical-card-with-action.stories.js
@@ -13,7 +13,8 @@ const buttonModifierOptions = {
   Oxygen: 'oxygen',
   Checked: 'checked',
   Copper: 'copper',
-  Boron : 'boron',
+  Boron: 'boron',
+  Neon: 'neon', 
 }
 
 export const Default = () => (

--- a/assets/javascripts/kitten/components/menus/header-menu/components/item.js
+++ b/assets/javascripts/kitten/components/menus/header-menu/components/item.js
@@ -85,6 +85,7 @@ Item.propTypes = {
     'copper',
     'checked',
     'boron',
+    'neon',
   ]),
   size: PropTypes.oneOf(['normal', 'tiny', 'big']),
   as: deprecated(PropTypes.string, 'Please use `tag` instead.'),


### PR DESCRIPTION
Closes #.

Vercel link:

- https://kitten-git-feature-button-neon-kisskissbankbank.vercel.app/?path=/story/buttons-button--with-text

Screenshot:
<img width="250" alt="Capture d’écran 2021-05-21 à 14 55 59" src="https://user-images.githubusercontent.com/11648042/119140644-b577c580-ba44-11eb-8adf-2690b9a21b5e.png">


TODO:

- [ ] Tests
- [ ] Changelog
- [ ] A11Y
- [ ] Stories / Docs
- [ ] BrowserStack (IE11, Chrome & Firefox on Windows 10)
- [ ] New component added to `assets/javascripts/kitten/index.js`
