### PR TITLE
[DashboardLayout] Add Alert subcomponent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Feature: `DashboardLayout`: Add `Alert` subcomponent.
 - Fix: `Separator`: Reduce specificity of the styles.
 - Fix: `HeaderNav`: Fix accessibility error.
 - Feature: `CrowdfundingCard`: Add `progressLabel` prop.

--- a/assets/javascripts/kitten/components/layout/dashboard-layout/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/layout/dashboard-layout/__snapshots__/test.js.snap
@@ -1000,6 +1000,655 @@ exports[`<DashboardLayout /> <DefaultLayout.Flow loading /> matches with snapsho
 </div>
 `;
 
+exports[`<DashboardLayout /> with Header and Alert matches with snapshot 1`] = `
+.c1 {
+  overflow: visible;
+  fill: #fff;
+}
+
+.c1:hover,
+button:hover .c1 {
+  fill: #19b4fa;
+}
+
+.c1 rect {
+  -webkit-transition: -webkit-transform 0.2s ease-out,fill 0.15s;
+  -webkit-transition: transform 0.2s ease-out,fill 0.15s;
+  transition: transform 0.2s ease-out,fill 0.15s;
+}
+
+.c2 {
+  font-family: Maax,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  position: relative;
+  overflow: hidden;
+  background-color: #e8f7fe;
+  color: #19b4fa;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c2 .k-Alert__text {
+  padding: 0.8125rem 1.25rem;
+  -webkit-flex: 1 0 0;
+  -ms-flex: 1 0 0;
+  flex: 1 0 0;
+  font-size: 0.8888888888888888rem;
+}
+
+.c2 .k-Alert__button {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-transition: all 0.2s ease;
+  transition: all 0.2s ease;
+}
+
+.c2 .k-Alert__button svg,
+.c2 .k-Alert__button svg path {
+  -webkit-transition: fill 0.2s ease;
+  transition: fill 0.2s ease;
+}
+
+.c2 .k-Alert__button:focus {
+  outline: #fff solid 0.125rem;
+  outline-offset: -0.25rem;
+}
+
+.c2 .k-Alert__button:focus:not(:focus-visible) {
+  outline-color: transparent;
+}
+
+.c2 .k-Alert__button:focus-visible {
+  outline-color: #bae8fd;
+}
+
+.c2 a {
+  font-family: Maax,Helvetica,Arial,sans-serif;
+  -webkit-letter-spacing: .01rem;
+  -moz-letter-spacing: .01rem;
+  -ms-letter-spacing: .01rem;
+  letter-spacing: .01rem;
+  font-weight: 600;
+  color: inherit;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c2.k-Alert--success {
+  color: #61d079;
+  background-color: #effaf1;
+}
+
+.c2.k-Alert--error {
+  color: #ff0046;
+  background-color: #ffe5ec;
+}
+
+.c2.k-Alert--warning {
+  color: #8a6d3b;
+  background-color: #fcf8e3;
+}
+
+.c2.k-Alert--shouldHide {
+  pointer-events: none;
+  -webkit-animation: ggXszE 0.4s cubic-bezier(0.895,0.03,0.685,0.22) forwards;
+  animation: ggXszE 0.4s cubic-bezier(0.895,0.03,0.685,0.22) forwards;
+}
+
+.c0 {
+  --dashboardLayout-siteHeaderHeight: 0px;
+  position: relative;
+  overscroll-behavior: none;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 .k-DashboardLayout__siteHeader,
+.c0 .k-DashboardLayout__siteHeader ~ .k-DashboardLayout__quickAccessLink {
+  display: none;
+}
+
+.c0 .k-DashboardLayout {
+  min-height: calc(100vh - var(--dashboardLayout-siteHeaderHeight));
+  min-height: -webkit-fill-available;
+  display: grid;
+  background-color: #fff;
+}
+
+.c0 .k-DashboardLayout .k-DashboardLayout__sideWrapper {
+  background-color: #222;
+}
+
+.c0 .k-DashboardLayout__backLink:focus {
+  outline: #bae8fd solid 0.125rem;
+  outline-offset: 0.125rem;
+}
+
+.c0 .k-DashboardLayout__backLink:focus:not(:focus-visible) {
+  outline-color: transparent;
+}
+
+.c0 .k-DashboardLayout__backLink:focus-visible {
+  outline-color: #bae8fd;
+}
+
+.c0 .k-DashboardLayout__sideWrapper:focus,
+.c0 .k-DashboardLayout__mainWrapper:focus {
+  outline: 0.125rem solid #bae8fd;
+}
+
+.c0 .k-DashboardLayout__quickAccessLink {
+  position: absolute;
+  top: 0;
+  left: -100%;
+  z-index: 110;
+  padding: 1.25rem 1.875rem;
+  color: #fff;
+  background-color: #222;
+  font-family: Maax,Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  line-height: 1;
+  font-size: 1.125rem;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  -webkit-transition: opacity 0.2s ease,left 0.2s ease;
+  transition: opacity 0.2s ease,left 0.2s ease;
+  -webkit-transition-delay: 0,0;
+  transition-delay: 0,0;
+  opacity: 0;
+}
+
+.c0 .k-DashboardLayout__quickAccessLink:focus,
+.c0 .k-DashboardLayout__quickAccessLink:active {
+  left: 0;
+  opacity: 1;
+  -webkit-transition-delay: 0,0.2s;
+  transition-delay: 0,0.2s;
+  outline: 0.125rem solid #bae8fd;
+}
+
+.c0 .k-DashboardLayout__backLink {
+  -webkit-flex: 0 0 2.5rem;
+  -ms-flex: 0 0 2.5rem;
+  flex: 0 0 2.5rem;
+  -webkit-align-self: start;
+  -ms-flex-item-align: start;
+  align-self: start;
+  height: 2.5rem;
+  padding: 0 0.9375rem;
+  background-color: #2d2d2d;
+  border-radius: 0.375rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #fff;
+  -webkit-transition: color 0.2s ease,background-color 0.2s ease;
+  transition: color 0.2s ease,background-color 0.2s ease;
+  font-family: Maax,Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-size: 0.8888888888888888rem;
+  line-height: 1.2;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0 .k-DashboardLayout__backLink svg {
+  fill: currentColor;
+}
+
+.c0 .k-DashboardLayout__backLink:hover {
+  color: #19b4fa;
+}
+
+.c0 .k-DashboardLayout__backLink .k-DashboardLayout__backLink__text {
+  margin-left: 0.9375rem;
+}
+
+@media (min-width:40rem) {
+  .c2 .k-Alert__text {
+    text-align: center;
+  }
+}
+
+@media (min-width:40rem) {
+  .c2.k-Alert--hasCloseButton .k-Alert__text {
+    margin-left: 3.125rem;
+  }
+}
+
+@media (min-width:67.5rem) {
+  .c0 .k-DashboardLayout__siteHeader,
+  .c0 .k-DashboardLayout__siteHeader ~ .k-DashboardLayout {
+    --dashboardLayout-siteHeaderHeight: 4.0625rem;
+  }
+
+  .c0 .k-DashboardLayout__siteHeader {
+    display: block;
+    height: var(--dashboardLayout-siteHeaderHeight);
+    background: #fff;
+  }
+
+  .c0 .k-DashboardLayout__siteHeader ~ .k-DashboardLayout .k-DashboardLayout__backLink {
+    display: none;
+  }
+}
+
+@media (max-width:67.4375rem) {
+  .c0 {
+    overflow: hidden;
+    position: relative;
+  }
+
+  .c0 .k-DashboardLayout {
+    --DashboardLayout-main-margin: calc( ((100vw - 18.75rem) / 12) + 3.75rem );
+    width: calc(((100vw - 18.75rem) / 2 + 8.75rem) + 100vw);
+    grid-template-columns: calc(((100vw - 18.75rem) / 2 + 8.75rem)) calc(100vw + 0.125rem);
+    -webkit-transform: translateX(calc(-1 * ((100vw - 18.75rem) / 2 + 8.75rem) - 0.125rem));
+    -ms-transform: translateX(calc(-1 * ((100vw - 18.75rem) / 2 + 8.75rem) - 0.125rem));
+    transform: translateX(calc(-1 * ((100vw - 18.75rem) / 2 + 8.75rem) - 0.125rem));
+    -webkit-transition: -webkit-transform 0.3s ease-in-out;
+    -webkit-transition: transform 0.3s ease-in-out;
+    transition: transform 0.3s ease-in-out;
+  }
+
+  .c0 .k-DashboardLayout .k-DashboardLayout__heading__button__text {
+    -webkit-clip: rect(0 0 0 0);
+    clip: rect(0 0 0 0);
+    -webkit-clip-path: inset(100%);
+    clip-path: inset(100%);
+    height: 0.0625rem;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+    width: 0.0625rem;
+  }
+
+  .c0 .k-DashboardLayout.k-DashboardLayout--isOpen {
+    position: fixed;
+    -webkit-transform: none;
+    -ms-transform: none;
+    transform: none;
+    -webkit-transition: -webkit-transform 0.3s ease-in-out;
+    -webkit-transition: transform 0.3s ease-in-out;
+    transition: transform 0.3s ease-in-out;
+  }
+
+  .c0 .k-DashboardLayout.k-DashboardLayout--isOpen .k-DashboardLayout__mainWrapper .k-DashboardLayout__main::before {
+    opacity: 0.8;
+    background-color: #222;
+    pointer-events: all;
+  }
+
+  .c0 .k-DashboardLayout .k-DashboardLayout__sideWrapper {
+    height: calc(100vh - var(--dashboardLayout-siteHeaderHeight));
+    overflow-y: scroll;
+    padding: 1.875rem;
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+  }
+
+  .c0 .k-DashboardLayout .k-DashboardLayout__sideWrapper >:not(:last-child) {
+    margin-bottom: 1.875rem;
+  }
+
+  .c0 .k-DashboardLayout .k-DashboardLayout__sideWrapper .k-DashboardLayout__heading {
+    display: none;
+  }
+
+  .c0 .k-DashboardLayout .k-DashboardLayout__sideWrapper .k-DashboardLayout__navigation {
+    -webkit-flex: 1 1 100%;
+    -ms-flex: 1 1 100%;
+    flex: 1 1 100%;
+  }
+
+  .c0 .k-DashboardLayout .k-DashboardLayout__sideWrapper .k-DashboardLayout__footer {
+    -webkit-flex: 0 1 auto;
+    -ms-flex: 0 1 auto;
+    flex: 0 1 auto;
+  }
+
+  .c0 .k-DashboardLayout .k-DashboardLayout__mainWrapper {
+    background-color: #fff;
+    width: calc(100vw + 0.125rem);
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+  }
+
+  .c0 .k-DashboardLayout .k-DashboardLayout__mainWrapper .k-DashboardLayout__heading {
+    padding-left: 2.5rem;
+    padding-right: 2.5rem;
+    height: 4.0625rem;
+    -webkit-flex: 0 0 4.0625rem;
+    -ms-flex: 0 0 4.0625rem;
+    flex: 0 0 4.0625rem;
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-align-items: center;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    background-color: #222;
+    border-left: 0.125rem solid #2d2d2d;
+  }
+
+  .c0 .k-DashboardLayout .k-DashboardLayout__mainWrapper .k-DashboardLayout__heading > * {
+    -webkit-align-self: initial;
+    -ms-flex-item-align: initial;
+    align-self: initial;
+  }
+
+  .c0 .k-DashboardLayout .k-DashboardLayout__mainWrapper .k-DashboardLayout__heading__buttonWrapper {
+    -webkit-flex: 0 0 2.25rem;
+    -ms-flex: 0 0 2.25rem;
+    flex: 0 0 2.25rem;
+    margin-left: -0.75rem;
+    margin-right: 0.75rem;
+  }
+
+  .c0 .k-DashboardLayout .k-DashboardLayout__mainWrapper .k-DashboardLayout__heading__button {
+    padding: 0.75rem;
+  }
+
+  .c0 .k-DashboardLayout .k-DashboardLayout__mainWrapper .k-DashboardLayout__main {
+    position: relative;
+    margin-left: 0.125rem;
+    -webkit-flex: 1 0 auto;
+    -ms-flex: 1 0 auto;
+    flex: 1 0 auto;
+  }
+
+  .c0 .k-DashboardLayout .k-DashboardLayout__mainWrapper .k-DashboardLayout__main::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: -0.125rem;
+    right: 0;
+    bottom: 0;
+    background-color: #fff;
+    opacity: 0;
+    pointer-events: none;
+    z-index: 100;
+    -webkit-transition: background-color 0.2s ease-in-out,opacity 0.2s ease-in-out;
+    transition: background-color 0.2s ease-in-out,opacity 0.2s ease-in-out;
+  }
+
+  .c0 .k-DashboardLayout .k-DashboardLayout__mainWrapper .k-DashboardLayout__main:not(.k-DashboardLayout__main--fullHeight) {
+    padding-top: 5rem;
+    padding-bottom: 5rem;
+  }
+
+  .c0 .k-DashboardLayout .k-DashboardLayout__mainWrapper .k-DashboardLayout__main > *:not(.k-DashboardLayout__fullWidth) {
+    margin-left: var(--DashboardLayout-main-margin);
+    margin-right: var(--DashboardLayout-main-margin);
+  }
+}
+
+@media (max-width:39.9375rem) {
+  .c0 .k-DashboardLayout {
+    --DashboardLayout-main-margin: 1.25rem;
+    width: calc(200vw - 3.25rem);
+    grid-template-columns: calc(100vw - 3.125rem) calc( 100vw + 0.125rem );
+    -webkit-transform: translateX(calc(-100vw + 3rem));
+    -ms-transform: translateX(calc(-100vw + 3rem));
+    transform: translateX(calc(-100vw + 3rem));
+  }
+
+  .c0 .k-DashboardLayout .k-DashboardLayout__sideWrapper {
+    padding: 1.25rem;
+  }
+
+  .c0 .k-DashboardLayout .k-DashboardLayout__mainWrapper .k-DashboardLayout__heading {
+    padding-left: 1.25rem;
+    padding-right: 1.25rem;
+  }
+
+  .c0 .k-DashboardLayout .k-DashboardLayout__mainWrapper .k-DashboardLayout__main:not(.k-DashboardLayout__main--fullHeight) {
+    padding-top: 3.125rem;
+    padding-bottom: 3.125rem;
+  }
+}
+
+@media (min-width:67.5rem) {
+  .c0 .k-DashboardLayout {
+    --DashboardLayout-main-margin: 7.5vw;
+    grid-template-columns: 25vw 1fr;
+  }
+
+  .c0 .k-DashboardLayout .k-DashboardLayout__sideWrapper {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    height: calc(100vh - var(--dashboardLayout-siteHeaderHeight));
+    position: -webkit-sticky;
+    position: sticky;
+    top: var(--dashboardLayout-siteHeaderHeight);
+    overflow: scroll;
+    padding: 1.875rem;
+  }
+
+  .c0 .k-DashboardLayout .k-DashboardLayout__sideWrapper >:not(:last-child) {
+    margin-bottom: 1.875rem;
+  }
+
+  .c0 .k-DashboardLayout .k-DashboardLayout__sideWrapper .k-DashboardLayout__heading {
+    -webkit-flex: 0 1 auto;
+    -ms-flex: 0 1 auto;
+    flex: 0 1 auto;
+  }
+
+  .c0 .k-DashboardLayout .k-DashboardLayout__sideWrapper .k-DashboardLayout__navigation {
+    -webkit-flex: 1 1 100%;
+    -ms-flex: 1 1 100%;
+    flex: 1 1 100%;
+  }
+
+  .c0 .k-DashboardLayout .k-DashboardLayout__sideWrapper .k-DashboardLayout__footer {
+    -webkit-flex: 0 1 auto;
+    -ms-flex: 0 1 auto;
+    flex: 0 1 auto;
+  }
+
+  .c0 .k-DashboardLayout .k-DashboardLayout__mainWrapper {
+    background-color: #fff;
+  }
+
+  .c0 .k-DashboardLayout .k-DashboardLayout__mainWrapper .k-DashboardLayout__heading {
+    display: none;
+  }
+
+  .c0 .k-DashboardLayout .k-DashboardLayout__mainWrapper .k-DashboardLayout__main:not(.k-DashboardLayout__main--fullHeight) {
+    padding-top: 5rem;
+    padding-bottom: 5rem;
+  }
+
+  .c0 .k-DashboardLayout .k-DashboardLayout__mainWrapper .k-DashboardLayout__main > *:not(.k-DashboardLayout__fullWidth) {
+    margin-left: var(--DashboardLayout-main-margin);
+    margin-right: var(--DashboardLayout-main-margin);
+  }
+}
+
+@media (min-width:90rem) {
+  .c0 .k-DashboardLayout {
+    grid-template-columns: 24.0625rem 1fr;
+  }
+}
+
+<div
+  className="c0 k-DashboardLayout__wrapper"
+>
+  <div
+    className="k-DashboardLayout__siteHeader"
+  >
+    Header content
+  </div>
+  <a
+    className="k-DashboardLayout__quickAccessLink"
+    href="#main"
+  >
+    Custom quick access link text
+  </a>
+  <div
+    className="k-DashboardLayout"
+  >
+    <div
+      aria-hidden={true}
+      className="k-DashboardLayout__sideWrapper"
+      tabIndex={-1}
+    >
+      <a
+        className="k-DashboardLayout__backLink"
+        href="#"
+      >
+        <svg
+          aria-hidden={true}
+          className=""
+          fill="#fff"
+          height="5.64"
+          style={
+            Object {
+              "transform": "rotate(-90deg)",
+            }
+          }
+          viewBox="0 0 8.48 5.64"
+          width="8.48"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          
+          <path
+            d="M0 4.24 L4.24,0 L8.48,4.24 L7.08,5.64 L4.24,2.77 L1.4,5.6 z"
+          />
+        </svg>
+        <span
+          className="k-DashboardLayout__backLink__text"
+        >
+          Custom backLink text
+        </span>
+      </a>
+      <header
+        className="k-DashboardLayout__heading"
+      >
+        Header content
+      </header>
+      <section
+        className="k-DashboardLayout__navigation"
+      >
+        Side content
+      </section>
+      <footer
+        className="k-DashboardLayout__footer"
+      >
+        Side footer
+      </footer>
+    </div>
+    <div
+      className="k-DashboardLayout__mainWrapper"
+      tabIndex={-1}
+    >
+      <header
+        className="k-DashboardLayout__heading"
+      >
+        <div
+          className="k-DashboardLayout__heading__buttonWrapper"
+        >
+          <button
+            aria-expanded={null}
+            className="k-DashboardLayout__heading__button k-u-reset-button"
+            onClick={[Function]}
+          >
+            <svg
+              aria-label={null}
+              className="c1"
+              height={10}
+              role="img"
+              viewBox="0 0 12 10"
+              width={12}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <rect
+                className="k-BurgerIcon__bun"
+                height="2"
+                width="12"
+                y="0"
+              />
+              <rect
+                className="k-BurgerIcon__patty"
+                height="2"
+                width="12"
+                y="4"
+              />
+              <rect
+                className="k-BurgerIcon__bun"
+                height="2"
+                width="12"
+                y="8"
+              />
+            </svg>
+            <span
+              className="k-DashboardLayout__heading__button__text"
+            >
+              Custom open label
+            </span>
+          </button>
+        </div>
+        Header content
+      </header>
+      <div
+        className="c2 k-Alert k-DashboardLayout__alert k-DashboardLayout__fullWidth"
+        role="alert"
+      >
+        <div
+          className="k-Alert__text"
+        >
+          Alert!
+        </div>
+      </div>
+      <main
+        className="k-DashboardLayout__main"
+        id="main"
+      >
+        <p>
+          Main content
+        </p>
+      </main>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`<DashboardLayout /> with default props matches with snapshot 1`] = `
 .c1 {
   overflow: visible;

--- a/assets/javascripts/kitten/components/layout/dashboard-layout/index.js
+++ b/assets/javascripts/kitten/components/layout/dashboard-layout/index.js
@@ -19,6 +19,7 @@ import {
 
 import { BurgerIcon } from '../../../components/icons/burger-icon'
 import { ArrowIcon } from '../../../components/icons/arrow-icon'
+import { Alert as AlertComponent } from '../../../components/notifications/alert'
 
 import { Flow } from './flow'
 
@@ -224,6 +225,12 @@ export const DashboardLayout = ({
             },
           )}
 
+          {renderComponentChildrenArray(
+            getReactElementsByType({
+              children: children,
+              type: Alert,
+            }))}
+
           <main
             className={classNames('k-DashboardLayout__main', {
               'k-DashboardLayout__main--fullHeight': fullHeightContent,
@@ -233,7 +240,7 @@ export const DashboardLayout = ({
             {renderComponentArray(
               getReactElementsWithoutTypeArray({
                 children,
-                typeArray: [SiteHeader, Header, SideContent, SideFooter],
+                typeArray: [SiteHeader, Header, SideContent, SideFooter, Alert],
               }),
             )}
           </main>
@@ -308,6 +315,17 @@ const SideFooter = ({ className, ...props }) => (
   />
 )
 
+const Alert = ({ className, ...props }) => (
+  <AlertComponent
+    className={classNames(
+      'k-DashboardLayout__alert',
+      'k-DashboardLayout__fullWidth',
+      className
+    )}
+    {...props}
+  />
+)
+
 DashboardLayout.propTypes = {
   backLinkProps: PropTypes.object,
   buttonProps: PropTypes.shape({
@@ -332,3 +350,4 @@ DashboardLayout.Header = Header
 DashboardLayout.SideContent = SideContent
 DashboardLayout.SideFooter = SideFooter
 DashboardLayout.Flow = Flow
+DashboardLayout.Alert = Alert

--- a/assets/javascripts/kitten/components/layout/dashboard-layout/stories.js
+++ b/assets/javascripts/kitten/components/layout/dashboard-layout/stories.js
@@ -35,6 +35,7 @@ import {
   LinkedinIcon,
   InstagramIcon,
   YoutubeIcon,
+  Alert,
 } from '../../..'
 
 const options = [
@@ -311,6 +312,12 @@ export const Default = () => {
           <span>Voir ma page projet</span>
         </Button>
       </DashboardLayout.SideFooter>
+
+      {boolean('Display Alert', false) && (
+        <DashboardLayout.Alert closeButton error>
+          Voilà une alerte
+        </DashboardLayout.Alert>
+      )}
 
       {selectedView === 'flow' && <FlowExample />}
       {selectedView === 'dashboard' && <DashExample />}

--- a/assets/javascripts/kitten/components/layout/dashboard-layout/test.js
+++ b/assets/javascripts/kitten/components/layout/dashboard-layout/test.js
@@ -40,6 +40,42 @@ describe('<DashboardLayout />', () => {
     })
   })
 
+  describe('with Header and Alert', () => {
+    beforeEach(() => {
+      component = renderer
+        .create(
+          <DashboardLayout
+            backLinkProps={{
+              href: '#',
+              children: 'Custom backLink text',
+            }}
+            buttonProps={{
+              openLabel: 'Custom open label',
+              closeLabel: 'Custom close label',
+            }}
+            quickAccessLinkText="Custom quick access link text"
+          >
+            <DashboardLayout.SiteHeader>
+              Header content
+            </DashboardLayout.SiteHeader>
+            <DashboardLayout.Header>Header content</DashboardLayout.Header>
+            <DashboardLayout.SideContent>
+              Side content
+            </DashboardLayout.SideContent>
+            <DashboardLayout.SideFooter>Side footer</DashboardLayout.SideFooter>
+            <DashboardLayout.Alert>Alert!</DashboardLayout.Alert>
+
+            <p>Main content</p>
+          </DashboardLayout>,
+        )
+        .toJSON()
+    })
+
+    it('matches with snapshot', () => {
+      expect(component).toMatchSnapshot()
+    })
+  })
+
   describe('<DefaultLayout.Flow />', () => {
     beforeEach(() => {
       component = renderer


### PR DESCRIPTION
Closes #.

Vercel link:

- https://kitten-git-dashboard-layout-add-alerts-kisskissbankbank.vercel.app/?path=/story/layout-dashboardlayout--default < Knob "Display Alert"


Screenshot:
![image](https://user-images.githubusercontent.com/1781070/119505572-60ea8800-bd6d-11eb-92bf-3aed5a4f0291.png)


TODO:

- [x] Tests
- [x] Changelog
- [x] A11Y
- [ ] Stories / Docs
- [ ] BrowserStack (IE11, Chrome & Firefox on Windows 10)
- [ ] New component added to `assets/javascripts/kitten/index.js`
