### PR TITLE
[DashboardMenu] Fix list items spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: `DashboardMenu`: Fix list items spacing.
 - Feature: `DropdownSelectWithInput`: Add `size` prop, defaults to `normal`, inherited by `DropdownPhoneSelect`.
 - Feature: `Icons`: Add the following icons:
   - `LockOutlineIcon`

--- a/assets/javascripts/kitten/components/menus/dashboard-menu/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/menus/dashboard-menu/__snapshots__/test.js.snap
@@ -97,6 +97,10 @@ exports[`<DashboardMenu /> with default props matches with snapshot 1`] = `
   margin-bottom: 0.625rem;
 }
 
+.c0 .k-DashboardMenu__list >:not(:last-child) {
+  margin-bottom: 0.125rem;
+}
+
 .c0 .k-DashboardMenu__list > li > .k-DashboardMenu__expandable .k-DashboardMenu__expandable__title,
 .c0 .k-DashboardMenu__list > li > .k-DashboardMenu__item {
   display: -webkit-box;

--- a/assets/javascripts/kitten/components/menus/dashboard-menu/index.js
+++ b/assets/javascripts/kitten/components/menus/dashboard-menu/index.js
@@ -89,6 +89,10 @@ const StyledDashboardMenu = styled.nav`
     }
   }
 
+  .k-DashboardMenu__list > :not(:last-child) {
+    margin-bottom: ${pxToRem(2)};
+  }
+
   .k-DashboardMenu__list
     > li
     > .k-DashboardMenu__expandable


### PR DESCRIPTION
Closes #.

Vercel link:

- https://kitten-git-…

Screenshot:


TODO:

- [x] Tests
- [x] Changelog
- [ ] A11Y
- [ ] Stories / Docs
- [ ] BrowserStack (IE11, Chrome & Firefox on Windows 10)
- [ ] New component added to `assets/javascripts/kitten/index.js`
