### PR TITLE
[DashboardLayout] Replace `Alerts` subcomponent with `Alerts` wrapper…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Feature: `DashboardLayout`: Replace `Alert` subcomponent with `Alerts` wrapper.
 - Fix: `ButtonIcon`: Fix `tag` transmission.
 - Fix: `TeamCard`: Fix buttons sizes.
 

--- a/assets/javascripts/kitten/components/layout/dashboard-layout/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/layout/dashboard-layout/__snapshots__/test.js.snap
@@ -1017,91 +1017,6 @@ button:hover .c1 {
   transition: transform 0.2s ease-out,fill 0.15s;
 }
 
-.c2 {
-  font-family: Maax,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  position: relative;
-  overflow: hidden;
-  background-color: #e8f7fe;
-  color: #19b4fa;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-}
-
-.c2 .k-Alert__text {
-  padding: 0.8125rem 1.25rem;
-  -webkit-flex: 1 0 0;
-  -ms-flex: 1 0 0;
-  flex: 1 0 0;
-  font-size: 0.8888888888888888rem;
-}
-
-.c2 .k-Alert__button {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  -webkit-transition: all 0.2s ease;
-  transition: all 0.2s ease;
-}
-
-.c2 .k-Alert__button svg,
-.c2 .k-Alert__button svg path {
-  -webkit-transition: fill 0.2s ease;
-  transition: fill 0.2s ease;
-}
-
-.c2 .k-Alert__button:focus {
-  outline: #fff solid 0.125rem;
-  outline-offset: -0.25rem;
-}
-
-.c2 .k-Alert__button:focus:not(:focus-visible) {
-  outline-color: transparent;
-}
-
-.c2 .k-Alert__button:focus-visible {
-  outline-color: #bae8fd;
-}
-
-.c2 a {
-  font-family: Maax,Helvetica,Arial,sans-serif;
-  -webkit-letter-spacing: .01rem;
-  -moz-letter-spacing: .01rem;
-  -ms-letter-spacing: .01rem;
-  letter-spacing: .01rem;
-  font-weight: 600;
-  color: inherit;
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.c2.k-Alert--success {
-  color: #61d079;
-  background-color: #effaf1;
-}
-
-.c2.k-Alert--error {
-  color: #ff0046;
-  background-color: #ffe5ec;
-}
-
-.c2.k-Alert--warning {
-  color: #8a6d3b;
-  background-color: #fcf8e3;
-}
-
-.c2.k-Alert--shouldHide {
-  pointer-events: none;
-  -webkit-animation: ggXszE 0.4s cubic-bezier(0.895,0.03,0.685,0.22) forwards;
-  animation: ggXszE 0.4s cubic-bezier(0.895,0.03,0.685,0.22) forwards;
-}
-
 .c0 {
   --dashboardLayout-siteHeaderHeight: 0px;
   position: relative;
@@ -1216,18 +1131,6 @@ button:hover .c1 {
 
 .c0 .k-DashboardLayout__backLink .k-DashboardLayout__backLink__text {
   margin-left: 0.9375rem;
-}
-
-@media (min-width:40rem) {
-  .c2 .k-Alert__text {
-    text-align: center;
-  }
-}
-
-@media (min-width:40rem) {
-  .c2.k-Alert--hasCloseButton .k-Alert__text {
-    margin-left: 3.125rem;
-  }
 }
 
 @media (min-width:67.5rem) {
@@ -1627,14 +1530,9 @@ button:hover .c1 {
         Header content
       </header>
       <div
-        className="c2 k-Alert k-DashboardLayout__alert k-DashboardLayout__fullWidth"
-        role="alert"
+        className="k-DashboardLayout__alerts k-DashboardLayout__fullWidth"
       >
-        <div
-          className="k-Alert__text"
-        >
-          Alert!
-        </div>
+        Alert!
       </div>
       <main
         className="k-DashboardLayout__main"

--- a/assets/javascripts/kitten/components/layout/dashboard-layout/index.js
+++ b/assets/javascripts/kitten/components/layout/dashboard-layout/index.js
@@ -19,7 +19,6 @@ import {
 
 import { BurgerIcon } from '../../../components/icons/burger-icon'
 import { ArrowIcon } from '../../../components/icons/arrow-icon'
-import { Alert as AlertComponent } from '../../../components/notifications/alert'
 
 import { Flow } from './flow'
 
@@ -228,7 +227,7 @@ export const DashboardLayout = ({
           {renderComponentChildrenArray(
             getReactElementsByType({
               children: children,
-              type: Alert,
+              type: Alerts,
             }))}
 
           <main
@@ -240,7 +239,7 @@ export const DashboardLayout = ({
             {renderComponentArray(
               getReactElementsWithoutTypeArray({
                 children,
-                typeArray: [SiteHeader, Header, SideContent, SideFooter, Alert],
+                typeArray: [SiteHeader, Header, SideContent, SideFooter, Alerts],
               }),
             )}
           </main>
@@ -315,10 +314,10 @@ const SideFooter = ({ className, ...props }) => (
   />
 )
 
-const Alert = ({ className, ...props }) => (
-  <AlertComponent
+const Alerts = ({ className, ...props }) => (
+  <div
     className={classNames(
-      'k-DashboardLayout__alert',
+      'k-DashboardLayout__alerts',
       'k-DashboardLayout__fullWidth',
       className
     )}
@@ -350,4 +349,4 @@ DashboardLayout.Header = Header
 DashboardLayout.SideContent = SideContent
 DashboardLayout.SideFooter = SideFooter
 DashboardLayout.Flow = Flow
-DashboardLayout.Alert = Alert
+DashboardLayout.Alerts = Alerts

--- a/assets/javascripts/kitten/components/layout/dashboard-layout/stories.js
+++ b/assets/javascripts/kitten/components/layout/dashboard-layout/stories.js
@@ -313,10 +313,15 @@ export const Default = () => {
         </Button>
       </DashboardLayout.SideFooter>
 
-      {boolean('Display Alert', false) && (
-        <DashboardLayout.Alert closeButton error>
-          Voilà une alerte
-        </DashboardLayout.Alert>
+      {boolean('Display Alerts', false) && (
+        <DashboardLayout.Alerts>
+          <Alert closeButton info>
+            Voilà une info
+          </Alert>
+          <Alert closeButton error>
+            Voilà une alerte
+          </Alert>
+        </DashboardLayout.Alerts>
       )}
 
       {selectedView === 'flow' && <FlowExample />}

--- a/assets/javascripts/kitten/components/layout/dashboard-layout/test.js
+++ b/assets/javascripts/kitten/components/layout/dashboard-layout/test.js
@@ -63,7 +63,7 @@ describe('<DashboardLayout />', () => {
               Side content
             </DashboardLayout.SideContent>
             <DashboardLayout.SideFooter>Side footer</DashboardLayout.SideFooter>
-            <DashboardLayout.Alert>Alert!</DashboardLayout.Alert>
+            <DashboardLayout.Alerts>Alert!</DashboardLayout.Alerts>
 
             <p>Main content</p>
           </DashboardLayout>,


### PR DESCRIPTION
… subcomponent.

Closes #.

Vercel link:

- https://kitten-git-…

Screenshot:


TODO:

- [x] Tests
- [x] Changelog
- [ ] A11Y
- [ ] Stories / Docs
- [ ] BrowserStack (IE11, Chrome & Firefox on Windows 10)
- [ ] New component added to `assets/javascripts/kitten/index.js`
