### PR TITLE
[DashboardMenu] Fix expandable list padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: `DashboardMenu`: Fix expandable list padding.
+
 ## [3.17.0] - 2021-05-31
 
 Feature:

--- a/assets/javascripts/kitten/components/menus/dashboard-menu/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/menus/dashboard-menu/__snapshots__/test.js.snap
@@ -83,7 +83,7 @@ exports[`<DashboardMenu /> with default props matches with snapshot 1`] = `
 }
 
 .c0 .k-DashboardMenu__expandable .k-DashboardMenu__expandable__list {
-  padding: 0 2.5rem 1.25rem 3.75rem;
+  padding: 0 0.625rem 1.25rem 3.75rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;

--- a/assets/javascripts/kitten/components/menus/dashboard-menu/index.js
+++ b/assets/javascripts/kitten/components/menus/dashboard-menu/index.js
@@ -79,7 +79,7 @@ const StyledDashboardMenu = styled.nav`
     background-color: ${COLORS.line3};
 
     .k-DashboardMenu__expandable__list {
-      padding: 0 ${pxToRem(40)} ${pxToRem(20)} ${pxToRem(60)};
+      padding: 0 ${pxToRem(10)} ${pxToRem(20)} ${pxToRem(60)};
       display: flex;
       flex-direction: column;
 


### PR DESCRIPTION
Closes #.

Vercel link:

- https://kitten-git-…

Screenshot:


TODO:

- [x] Tests
- [x] Changelog
- [ ] A11Y
- [ ] Stories / Docs
- [ ] BrowserStack (IE11, Chrome & Firefox on Windows 10)
- [ ] New component added to `assets/javascripts/kitten/index.js`
