### PR TITLE
[ImageCropper] Use default Label size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: `ImageCropper`: Use default Label size.
+
 ## [3.17.1] - 2021-06-03
 
 Fixes:

--- a/assets/javascripts/kitten/components/images/image-cropper/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/images/image-cropper/__snapshots__/test.js.snap
@@ -5,7 +5,7 @@ exports[`<ImageCropper /> matches with snapshot 1`] = `
   className="sc-gzVnrw czXvaz k-UploadAndCropper"
 >
   <label
-    className="sc-bdVaJa cioPrE k-Label k-u-margin-bottom-singleHalf k-Label--tiny"
+    className="sc-bdVaJa cioPrE k-Label k-u-margin-bottom-singleHalf k-Label--normal"
     htmlFor="cropper"
     onClick={[Function]}
   >

--- a/assets/javascripts/kitten/components/images/image-cropper/index.js
+++ b/assets/javascripts/kitten/components/images/image-cropper/index.js
@@ -95,7 +95,6 @@ export const ImageCropper = ({
   return (
     <StyledCropper className={classNames('k-UploadAndCropper', className)}>
       <Label
-        size="tiny"
         htmlFor={name}
         className="k-u-margin-bottom-singleHalf"
       >


### PR DESCRIPTION
Closes #.

Vercel link:

- https://kitten-git-…

Screenshot:


TODO:

- [x] Tests
- [x] Changelog
- [ ] A11Y
- [ ] Stories / Docs
- [ ] BrowserStack (IE11, Chrome & Firefox on Windows 10)
- [ ] New component added to `assets/javascripts/kitten/index.js`
