### PR TITLE
[TextInputWithUnit] Fix `variant` propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: `TextInputWithUnit`: Fix `variant` propagation.
+
 ## [3.17.2] - 2021-06-03
 
 Fix:

--- a/assets/javascripts/kitten/components/form/field/field.examples.js
+++ b/assets/javascripts/kitten/components/form/field/field.examples.js
@@ -37,8 +37,9 @@ export const FieldInputExample = ({
   errorMessage,
   limit,
   unit,
-  tiny,
+  size,
   noMargin,
+  variant,
 }) => (
   <FieldBase
     id={id}
@@ -51,13 +52,14 @@ export const FieldInputExample = ({
   >
     <Field.Input
       id={id}
-      tiny={tiny}
+      size={size}
       limit={limit}
       unit={unit}
       name="field"
       placeholder={placeholder}
       error={error}
       noMargin={noMargin}
+      variant={variant}
     />
   </FieldBase>
 )
@@ -71,7 +73,8 @@ export const FieldPasswordExample = ({
   placeholder,
   error,
   errorMessage,
-  tiny,
+  variant,
+  size,
 }) => (
   <FieldBase
     id={id}
@@ -84,12 +87,13 @@ export const FieldPasswordExample = ({
   >
     <Field.Password
       id={id}
-      tiny={tiny}
+      size={size}
       name="field"
       iconLabel="Show password"
       hiddenIconLabel="Hide password"
       placeholder={placeholder}
       error={error}
+      variant={variant}
     />
   </FieldBase>
 )
@@ -103,6 +107,7 @@ export const FieldRadioButtonSetExample = ({
   items,
   error,
   errorMessage,
+  variant,
 }) => (
   <FieldBase
     id={id}
@@ -113,7 +118,9 @@ export const FieldRadioButtonSetExample = ({
     error={error}
     errorMessage={errorMessage}
   >
-    <Field.RadioButtonSet name="radio" items={items} error={error} />
+    <Field.RadioButtonSet name="radio" items={items} error={error}
+      variant={variant}
+    />
   </FieldBase>
 )
 
@@ -127,7 +134,8 @@ export const FieldAutocompleteExample = ({
   error,
   errorMessage,
   items,
-  tiny,
+  size,
+  variant,
 }) => (
   <FieldBase
     id={id}
@@ -140,11 +148,12 @@ export const FieldAutocompleteExample = ({
   >
     <Field.Autocomplete
       id={id}
-      tiny={tiny}
+      size={size}
       name="field"
       placeholder={placeholder}
       error={error}
       items={items}
+      variant={variant}
     />
   </FieldBase>
 )

--- a/assets/javascripts/kitten/components/form/field/field.stories.js
+++ b/assets/javascripts/kitten/components/form/field/field.stories.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { text, number, boolean } from '@storybook/addon-knobs'
+import { text, number, boolean, select } from '@storybook/addon-knobs'
 import {
   FieldInputExample,
   FieldPasswordExample,
@@ -42,6 +42,7 @@ export const WithInput = () => {
         limit={number('Limit', undefined)}
         unit={text('Unit', undefined)}
         noMargin={boolean('No margin only on Input', false)}
+        variant={select('Variant', ['andromeda', 'orion'], 'andromeda')}
       />
     </StoryGrid>
   )
@@ -60,6 +61,7 @@ export const WithPassword = () => {
         placeholder={text('Placeholder', 'Placeholder…')}
         error={boolean('Error?', false)}
         errorMessage={text('Error', 'Error message…')}
+        variant={select('Variant', ['andromeda', 'orion'], 'andromeda')}
       />
     </StoryGrid>
   )
@@ -92,6 +94,7 @@ export const WithRadioButtons = () => {
         ]}
         error={boolean('Error?', false)}
         errorMessage={text('Error', 'Error message…')}
+        variant={select('Variant', ['andromeda', 'orion'], 'andromeda')}
       />
     </StoryGrid>
   )
@@ -122,6 +125,7 @@ export const WithAutocomplete = () => {
         ]}
         error={boolean('Error?', false)}
         errorMessage={text('Error', 'Error message…')}
+        variant={select('Variant', ['andromeda', 'orion'], 'andromeda')}
       />
     </StoryGrid>
   )

--- a/assets/javascripts/kitten/components/form/text-input-with-unit/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/form/text-input-with-unit/__snapshots__/test.js.snap
@@ -115,7 +115,7 @@ exports[`<TextInputWithUnit /> with variant prop matches with snapshot 1`] = `
   className="sc-htpNat lblaZj k-Form-TextInputWithUnit k-Form-TextInputWithUnit--orion"
 >
   <input
-    className="sc-bdVaJa cjAhxx k-Form-TextInput k-Form-TextInputWithUnit__input k-Form-TextInput--andromeda k-Form-TextInput--regular"
+    className="sc-bdVaJa cjAhxx k-Form-TextInput k-Form-TextInputWithUnit__input k-Form-TextInput--orion k-Form-TextInput--regular"
     disabled={false}
     name="text"
     type="number"

--- a/assets/javascripts/kitten/components/form/text-input-with-unit/index.js
+++ b/assets/javascripts/kitten/components/form/text-input-with-unit/index.js
@@ -125,6 +125,7 @@ export const TextInputWithUnit = ({
         {...others}
         size={size}
         className={classNames('k-Form-TextInputWithUnit__input', className)}
+        variant={variant}
       />
       <span
         className={classNames(


### PR DESCRIPTION
Closes #.

Vercel link:

- https://kitten-git-…

Screenshot:


TODO:

- [x] Tests
- [x] Changelog
- [ ] A11Y
- [ ] Stories / Docs
- [ ] BrowserStack (IE11, Chrome & Firefox on Windows 10)
- [ ] New component added to `assets/javascripts/kitten/index.js`
