### PR TITLE
[TextInputWithUnit] Fix `variant` propagation (leftovers)

### DIFF
--- a/assets/javascripts/kitten/components/date-picker/__snapshots__/date-picker.test.js.snap
+++ b/assets/javascripts/kitten/components/date-picker/__snapshots__/date-picker.test.js.snap
@@ -12,7 +12,7 @@ exports[`<DatePicker /> by default matches with snapshot 1`] = `
     >
       <input
         autoComplete="off"
-        className="sc-bdVaJa cjAhxx k-Form-TextInput k-Form-TextInputWithUnit__input k-Form-TextInput--andromeda k-Form-TextInput--regular"
+        className="sc-bdVaJa gynXzG k-Form-TextInput k-Form-TextInputWithUnit__input k-Form-TextInput--andromeda k-Form-TextInput--regular"
         disabled={false}
         name="text"
         onBlur={[Function]}

--- a/assets/javascripts/kitten/components/form/credit-card-form/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/form/credit-card-form/__snapshots__/test.js.snap
@@ -34,7 +34,7 @@ Array [
     >
       <input
         autoComplete="cc-number"
-        className="sc-ifAKCX kUohBD k-Form-TextInput k-Form-TextInput--andromeda k-Form-TextInput--regular"
+        className="sc-ifAKCX bjFCOa k-Form-TextInput k-Form-TextInput--andromeda k-Form-TextInput--regular"
         disabled={false}
         id="frmCCNum"
         inputMode="numeric"
@@ -82,7 +82,7 @@ Array [
     >
       <input
         autoComplete="cc-exp"
-        className="sc-ifAKCX kUohBD k-Form-TextInput k-Form-TextInput-hasDigits k-Form-TextInput-hasDigits_6 k-Form-TextInput--andromeda k-Form-TextInput--regular"
+        className="sc-ifAKCX bjFCOa k-Form-TextInput k-Form-TextInput-hasDigits k-Form-TextInput-hasDigits_6 k-Form-TextInput--andromeda k-Form-TextInput--regular"
         disabled={false}
         id="frmCCExp"
         inputMode="numeric"
@@ -135,7 +135,7 @@ Array [
     >
       <input
         autoComplete="cc-csc"
-        className="sc-ifAKCX kUohBD k-Form-TextInput k-Form-TextInput-hasDigits k-Form-TextInput-hasDigits_6 k-Form-TextInput--andromeda k-Form-TextInput--regular"
+        className="sc-ifAKCX bjFCOa k-Form-TextInput k-Form-TextInput-hasDigits k-Form-TextInput-hasDigits_6 k-Form-TextInput--andromeda k-Form-TextInput--regular"
         disabled={false}
         id="frmCCCVC"
         inputMode="numeric"

--- a/assets/javascripts/kitten/components/form/field/__snapshots__/field.test.js.snap
+++ b/assets/javascripts/kitten/components/form/field/__snapshots__/field.test.js.snap
@@ -127,7 +127,7 @@ Array [
     className="k-FieldInput k-u-margin-top-single"
   >
     <input
-      className="sc-bxivhb hmOsQm k-Form-TextInput k-Form-TextInput--andromeda k-Form-TextInput--regular k-Form-TextInput--error"
+      className="sc-bxivhb eXmlvj k-Form-TextInput k-Form-TextInput--andromeda k-Form-TextInput--regular k-Form-TextInput--error"
       disabled={false}
       id="input"
       name="field"
@@ -226,7 +226,7 @@ Array [
     className="k-FieldInput k-u-margin-top-single"
   >
     <input
-      className="sc-bxivhb hmOsQm k-Form-TextInput k-Form-TextInput--andromeda k-Form-TextInput--regular"
+      className="sc-bxivhb eXmlvj k-Form-TextInput k-Form-TextInput--andromeda k-Form-TextInput--regular"
       disabled={false}
       id="input"
       name="field"
@@ -314,7 +314,7 @@ Array [
       className="sc-EHOje iVlWKE k-Form-TextInputWithLimit"
     >
       <input
-        className="sc-bxivhb hmOsQm k-Form-TextInput k-Form-TextInputWithLimit__input k-Form-TextInput--andromeda k-Form-TextInput--regular"
+        className="sc-bxivhb eXmlvj k-Form-TextInput k-Form-TextInputWithLimit__input k-Form-TextInput--andromeda k-Form-TextInput--regular"
         defaultValue=""
         disabled={false}
         id="input"
@@ -410,7 +410,7 @@ Array [
       className="sc-bZQynM eODkLs k-Form-TextInputWithUnit k-Form-TextInputWithUnit--andromeda"
     >
       <input
-        className="sc-bxivhb hmOsQm k-Form-TextInput k-Form-TextInputWithUnit__input k-Form-TextInput--andromeda k-Form-TextInput--regular"
+        className="sc-bxivhb eXmlvj k-Form-TextInput k-Form-TextInputWithUnit__input k-Form-TextInput--andromeda k-Form-TextInput--regular"
         disabled={false}
         id="input"
         name="field"
@@ -505,7 +505,7 @@ Array [
       className="sc-gZMcBi fLBnrA k-Form-PasswordInput"
     >
       <input
-        className="sc-bxivhb hmOsQm k-Form-TextInput k-Form-PasswordInput__input k-Form-TextInput--andromeda k-Form-TextInput--regular k-Form-TextInput--error"
+        className="sc-bxivhb eXmlvj k-Form-TextInput k-Form-PasswordInput__input k-Form-TextInput--andromeda k-Form-TextInput--regular k-Form-TextInput--error"
         disabled={false}
         id="input"
         name="field"
@@ -633,7 +633,7 @@ Array [
       className="sc-gZMcBi fLBnrA k-Form-PasswordInput"
     >
       <input
-        className="sc-bxivhb hmOsQm k-Form-TextInput k-Form-PasswordInput__input k-Form-TextInput--andromeda k-Form-TextInput--regular"
+        className="sc-bxivhb eXmlvj k-Form-TextInput k-Form-PasswordInput__input k-Form-TextInput--andromeda k-Form-TextInput--regular"
         disabled={false}
         id="input"
         name="field"

--- a/assets/javascripts/kitten/components/form/field/field.stories.js
+++ b/assets/javascripts/kitten/components/form/field/field.stories.js
@@ -31,7 +31,7 @@ export const WithInput = () => {
     <StoryGrid>
       <FieldInputExample
         id={text('ID', 'input')}
-        size={boolean('Tiny', false) ? 'tiny' : null}
+        size={select('Size', ['tiny', 'regular', 'big', 'huge', 'giant'], 'regular')}
         label={text('Label', 'Label')}
         tooltip={text('Tooltip', null)}
         tooltipProps={{ actionLabel: 'Learn more' }}

--- a/assets/javascripts/kitten/components/form/password-input/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/form/password-input/__snapshots__/test.js.snap
@@ -5,7 +5,7 @@ exports[`<PasswordInput /> should match its empty snapshot 1`] = `
   className="sc-htpNat hXioPL k-Form-PasswordInput"
 >
   <input
-    className="sc-bdVaJa cjAhxx k-Form-TextInput k-Form-PasswordInput__input k-Form-TextInput--andromeda k-Form-TextInput--regular"
+    className="sc-bdVaJa gynXzG k-Form-TextInput k-Form-PasswordInput__input k-Form-TextInput--andromeda k-Form-TextInput--regular"
     disabled={false}
     id="password"
     name="password"

--- a/assets/javascripts/kitten/components/form/text-input-with-button/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/form/text-input-with-button/__snapshots__/test.js.snap
@@ -5,7 +5,7 @@ exports[`<TextInputWithButton /> by default matches with snapshot 1`] = `
   className="sc-htpNat gTjkEn k-Form-TextInputWithButton"
 >
   <input
-    className="sc-bdVaJa cjAhxx k-Form-TextInput k-Form-TextInputWithButton__input k-Form-TextInput--andromeda k-Form-TextInput--regular"
+    className="sc-bdVaJa gynXzG k-Form-TextInput k-Form-TextInputWithButton__input k-Form-TextInput--andromeda k-Form-TextInput--regular"
     disabled={false}
     name="text"
   />
@@ -24,7 +24,7 @@ exports[`<TextInputWithButton /> with buttonProps prop matches with snapshot 1`]
   className="sc-htpNat gTjkEn k-Form-TextInputWithButton"
 >
   <input
-    className="sc-bdVaJa cjAhxx k-Form-TextInput k-Form-TextInputWithButton__input k-Form-TextInput--andromeda k-Form-TextInput--regular"
+    className="sc-bdVaJa gynXzG k-Form-TextInput k-Form-TextInputWithButton__input k-Form-TextInput--andromeda k-Form-TextInput--regular"
     disabled={false}
     name="text"
   />
@@ -44,7 +44,7 @@ exports[`<TextInputWithButton /> with component inside button value matches with
   className="sc-htpNat gTjkEn k-Form-TextInputWithButton"
 >
   <input
-    className="sc-bdVaJa cjAhxx k-Form-TextInput k-Form-TextInputWithButton__input k-Form-TextInput--andromeda k-Form-TextInput--regular"
+    className="sc-bdVaJa gynXzG k-Form-TextInput k-Form-TextInputWithButton__input k-Form-TextInput--andromeda k-Form-TextInput--regular"
     disabled={false}
     name="text"
     placeholder="Les props sont transmises"
@@ -103,7 +103,7 @@ exports[`<TextInputWithButton /> with disabled prop matches with snapshot 1`] = 
   className="sc-htpNat gTjkEn k-Form-TextInputWithButton"
 >
   <input
-    className="sc-bdVaJa cjAhxx k-Form-TextInput k-Form-TextInputWithButton__input k-Form-TextInput--andromeda k-Form-TextInput--regular k-Form-TextInput--disabled"
+    className="sc-bdVaJa gynXzG k-Form-TextInput k-Form-TextInputWithButton__input k-Form-TextInput--andromeda k-Form-TextInput--regular k-Form-TextInput--disabled"
     disabled={true}
     name="text"
   />
@@ -122,7 +122,7 @@ exports[`<TextInputWithButton /> with error prop matches with snapshot 1`] = `
   className="sc-htpNat gTjkEn k-Form-TextInputWithButton"
 >
   <input
-    className="sc-bdVaJa cjAhxx k-Form-TextInput k-Form-TextInputWithButton__input k-Form-TextInput--andromeda k-Form-TextInput--regular k-Form-TextInput--error"
+    className="sc-bdVaJa gynXzG k-Form-TextInput k-Form-TextInputWithButton__input k-Form-TextInput--andromeda k-Form-TextInput--regular k-Form-TextInput--error"
     disabled={false}
     name="text"
   />
@@ -141,7 +141,7 @@ exports[`<TextInputWithButton /> with props matches with snapshot 1`] = `
   className="sc-htpNat gTjkEn k-Form-TextInputWithButton"
 >
   <input
-    className="sc-bdVaJa cjAhxx k-Form-TextInput k-Form-TextInputWithButton__input k-Form-TextInput--andromeda k-Form-TextInput--regular"
+    className="sc-bdVaJa gynXzG k-Form-TextInput k-Form-TextInputWithButton__input k-Form-TextInput--andromeda k-Form-TextInput--regular"
     disabled={false}
     name="text"
     placeholder="Les props sont transmises"
@@ -162,7 +162,7 @@ exports[`<TextInputWithButton /> with size prop matches with snapshot 1`] = `
   className="sc-htpNat gTjkEn k-Form-TextInputWithButton"
 >
   <input
-    className="sc-bdVaJa cjAhxx k-Form-TextInput k-Form-TextInputWithButton__input k-Form-TextInput--andromeda k-Form-TextInput--tiny"
+    className="sc-bdVaJa gynXzG k-Form-TextInput k-Form-TextInputWithButton__input k-Form-TextInput--andromeda k-Form-TextInput--tiny"
     disabled={false}
     name="text"
   />
@@ -181,7 +181,7 @@ exports[`<TextInputWithButton /> with valid prop matches with snapshot 1`] = `
   className="sc-htpNat gTjkEn k-Form-TextInputWithButton"
 >
   <input
-    className="sc-bdVaJa cjAhxx k-Form-TextInput k-Form-TextInputWithButton__input k-Form-TextInput--andromeda k-Form-TextInput--regular k-Form-TextInput--valid"
+    className="sc-bdVaJa gynXzG k-Form-TextInput k-Form-TextInputWithButton__input k-Form-TextInput--andromeda k-Form-TextInput--regular k-Form-TextInput--valid"
     disabled={false}
     name="text"
   />

--- a/assets/javascripts/kitten/components/form/text-input-with-icon/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/form/text-input-with-icon/__snapshots__/test.js.snap
@@ -6,7 +6,7 @@ exports[`<TextInputWithIcon /> by default matches with snapshot 1`] = `
 >
   
   <input
-    className="sc-bdVaJa cjAhxx k-Form-TextInput k-Form-TextInputWithIcon__input k-Form-TextInput--andromeda k-Form-TextInput--regular"
+    className="sc-bdVaJa gynXzG k-Form-TextInput k-Form-TextInputWithIcon__input k-Form-TextInput--andromeda k-Form-TextInput--regular"
     disabled={false}
     name="text"
   />
@@ -45,7 +45,7 @@ exports[`<TextInputWithIcon /> with disabled prop matches with snapshot 1`] = `
 >
   
   <input
-    className="sc-bdVaJa cjAhxx k-Form-TextInput k-Form-TextInputWithIcon__input k-Form-TextInput--andromeda k-Form-TextInput--regular k-Form-TextInput--disabled"
+    className="sc-bdVaJa gynXzG k-Form-TextInput k-Form-TextInputWithIcon__input k-Form-TextInput--andromeda k-Form-TextInput--regular k-Form-TextInput--disabled"
     disabled={true}
     name="text"
   />
@@ -84,7 +84,7 @@ exports[`<TextInputWithIcon /> with props matches with snapshot 1`] = `
 >
   
   <input
-    className="sc-bdVaJa cjAhxx k-Form-TextInput k-Form-TextInputWithIcon__input k-Form-TextInput--andromeda k-Form-TextInput--regular"
+    className="sc-bdVaJa gynXzG k-Form-TextInput k-Form-TextInputWithIcon__input k-Form-TextInput--andromeda k-Form-TextInput--regular"
     disabled={false}
     name="text"
     placeholder="Les props sont transmises"

--- a/assets/javascripts/kitten/components/form/text-input-with-limit/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/form/text-input-with-limit/__snapshots__/test.js.snap
@@ -5,7 +5,7 @@ exports[`<TextInputWithLimit /> by default matches with snapshot 1`] = `
   className="sc-htpNat jYlDxq k-Form-TextInputWithLimit"
 >
   <input
-    className="sc-bdVaJa cjAhxx k-Form-TextInput k-Form-TextInputWithLimit__input k-Form-TextInput--andromeda k-Form-TextInput--regular"
+    className="sc-bdVaJa gynXzG k-Form-TextInput k-Form-TextInputWithLimit__input k-Form-TextInput--andromeda k-Form-TextInput--regular"
     defaultValue=""
     disabled={false}
     name="text"
@@ -24,7 +24,7 @@ exports[`<TextInputWithLimit /> with \`disabled\` prop matches with snapshot 1`]
   className="sc-htpNat jYlDxq k-Form-TextInputWithLimit"
 >
   <input
-    className="sc-bdVaJa cjAhxx k-Form-TextInput k-Form-TextInputWithLimit__input k-Form-TextInput--andromeda k-Form-TextInput--regular k-Form-TextInput--disabled"
+    className="sc-bdVaJa gynXzG k-Form-TextInput k-Form-TextInputWithLimit__input k-Form-TextInput--andromeda k-Form-TextInput--regular k-Form-TextInput--disabled"
     defaultValue=""
     disabled={true}
     name="text"
@@ -43,7 +43,7 @@ exports[`<TextInputWithLimit /> with \`error\` prop matches with snapshot 1`] = 
   className="sc-htpNat jYlDxq k-Form-TextInputWithLimit"
 >
   <input
-    className="sc-bdVaJa cjAhxx k-Form-TextInput k-Form-TextInputWithLimit__input k-Form-TextInput--andromeda k-Form-TextInput--regular k-Form-TextInput--error"
+    className="sc-bdVaJa gynXzG k-Form-TextInput k-Form-TextInputWithLimit__input k-Form-TextInput--andromeda k-Form-TextInput--regular k-Form-TextInput--error"
     defaultValue=""
     disabled={false}
     name="text"
@@ -62,7 +62,7 @@ exports[`<TextInputWithLimit /> with \`size\` prop matches with snapshot 1`] = `
   className="sc-htpNat jYlDxq k-Form-TextInputWithLimit"
 >
   <input
-    className="sc-bdVaJa cjAhxx k-Form-TextInput k-Form-TextInputWithLimit__input k-Form-TextInput--andromeda k-Form-TextInput--tiny"
+    className="sc-bdVaJa gynXzG k-Form-TextInput k-Form-TextInputWithLimit__input k-Form-TextInput--andromeda k-Form-TextInput--tiny"
     defaultValue=""
     disabled={false}
     name="text"

--- a/assets/javascripts/kitten/components/form/text-input-with-unit/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/form/text-input-with-unit/__snapshots__/test.js.snap
@@ -5,7 +5,7 @@ exports[`<TextInputWithUnit /> by default matches with snapshot 1`] = `
   className="sc-htpNat lblaZj k-Form-TextInputWithUnit k-Form-TextInputWithUnit--andromeda"
 >
   <input
-    className="sc-bdVaJa cjAhxx k-Form-TextInput k-Form-TextInputWithUnit__input k-Form-TextInput--andromeda k-Form-TextInput--regular"
+    className="sc-bdVaJa gynXzG k-Form-TextInput k-Form-TextInputWithUnit__input k-Form-TextInput--andromeda k-Form-TextInput--regular"
     disabled={false}
     name="text"
     type="number"
@@ -23,7 +23,7 @@ exports[`<TextInputWithUnit /> with disabled prop matches with snapshot 1`] = `
   className="sc-htpNat lblaZj k-Form-TextInputWithUnit k-Form-TextInputWithUnit--andromeda"
 >
   <input
-    className="sc-bdVaJa cjAhxx k-Form-TextInput k-Form-TextInputWithUnit__input k-Form-TextInput--andromeda k-Form-TextInput--regular"
+    className="sc-bdVaJa gynXzG k-Form-TextInput k-Form-TextInputWithUnit__input k-Form-TextInput--andromeda k-Form-TextInput--regular"
     disabled={false}
     name="text"
     type="number"
@@ -41,7 +41,7 @@ exports[`<TextInputWithUnit /> with error prop matches with snapshot 1`] = `
   className="sc-htpNat lblaZj k-Form-TextInputWithUnit k-Form-TextInputWithUnit--andromeda"
 >
   <input
-    className="sc-bdVaJa cjAhxx k-Form-TextInput k-Form-TextInputWithUnit__input k-Form-TextInput--andromeda k-Form-TextInput--regular"
+    className="sc-bdVaJa gynXzG k-Form-TextInput k-Form-TextInputWithUnit__input k-Form-TextInput--andromeda k-Form-TextInput--regular"
     disabled={false}
     name="text"
     type="number"
@@ -59,7 +59,7 @@ exports[`<TextInputWithUnit /> with size prop matches with snapshot 1`] = `
   className="sc-htpNat lblaZj k-Form-TextInputWithUnit k-Form-TextInputWithUnit--andromeda"
 >
   <input
-    className="sc-bdVaJa cjAhxx k-Form-TextInput k-Form-TextInputWithUnit__input k-Form-TextInput--andromeda k-Form-TextInput--big"
+    className="sc-bdVaJa gynXzG k-Form-TextInput k-Form-TextInputWithUnit__input k-Form-TextInput--andromeda k-Form-TextInput--big"
     disabled={false}
     name="text"
     type="number"
@@ -77,7 +77,7 @@ exports[`<TextInputWithUnit /> with unit matches with snapshot 1`] = `
   className="sc-htpNat lblaZj k-Form-TextInputWithUnit k-Form-TextInputWithUnit--andromeda"
 >
   <input
-    className="sc-bdVaJa cjAhxx k-Form-TextInput k-Form-TextInputWithUnit__input k-Form-TextInput--andromeda k-Form-TextInput--regular"
+    className="sc-bdVaJa gynXzG k-Form-TextInput k-Form-TextInputWithUnit__input k-Form-TextInput--andromeda k-Form-TextInput--regular"
     disabled={false}
     name="text"
     type="number"
@@ -97,7 +97,7 @@ exports[`<TextInputWithUnit /> with valid prop matches with snapshot 1`] = `
   className="sc-htpNat lblaZj k-Form-TextInputWithUnit k-Form-TextInputWithUnit--andromeda"
 >
   <input
-    className="sc-bdVaJa cjAhxx k-Form-TextInput k-Form-TextInputWithUnit__input k-Form-TextInput--andromeda k-Form-TextInput--regular"
+    className="sc-bdVaJa gynXzG k-Form-TextInput k-Form-TextInputWithUnit__input k-Form-TextInput--andromeda k-Form-TextInput--regular"
     disabled={false}
     name="text"
     type="number"
@@ -115,7 +115,7 @@ exports[`<TextInputWithUnit /> with variant prop matches with snapshot 1`] = `
   className="sc-htpNat lblaZj k-Form-TextInputWithUnit k-Form-TextInputWithUnit--orion"
 >
   <input
-    className="sc-bdVaJa cjAhxx k-Form-TextInput k-Form-TextInputWithUnit__input k-Form-TextInput--orion k-Form-TextInput--regular"
+    className="sc-bdVaJa gynXzG k-Form-TextInput k-Form-TextInputWithUnit__input k-Form-TextInput--orion k-Form-TextInput--regular"
     disabled={false}
     name="text"
     type="number"

--- a/assets/javascripts/kitten/components/form/text-input/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/form/text-input/__snapshots__/test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<TextInput /> with \`center\` prop matches with snapshot 1`] = `
 <input
-  className="sc-bdVaJa cjAhxx k-Form-TextInput k-Form-TextInput--andromeda k-Form-TextInput--regular k-Form-TextInput--alignCenter"
+  className="sc-bdVaJa gynXzG k-Form-TextInput k-Form-TextInput--andromeda k-Form-TextInput--regular k-Form-TextInput--alignCenter"
   disabled={false}
   name="text"
 />
@@ -10,7 +10,7 @@ exports[`<TextInput /> with \`center\` prop matches with snapshot 1`] = `
 
 exports[`<TextInput /> with \`digits\` prop matches with snapshot 1`] = `
 <input
-  className="sc-bdVaJa cjAhxx k-Form-TextInput k-Form-TextInput-hasDigits k-Form-TextInput-hasDigits_12 k-Form-TextInput--andromeda k-Form-TextInput--regular"
+  className="sc-bdVaJa gynXzG k-Form-TextInput k-Form-TextInput-hasDigits k-Form-TextInput-hasDigits_12 k-Form-TextInput--andromeda k-Form-TextInput--regular"
   disabled={false}
   name="text"
   style={
@@ -23,7 +23,7 @@ exports[`<TextInput /> with \`digits\` prop matches with snapshot 1`] = `
 
 exports[`<TextInput /> with \`disabled\` prop matches with snapshot 1`] = `
 <input
-  className="sc-bdVaJa cjAhxx k-Form-TextInput k-Form-TextInput--andromeda k-Form-TextInput--regular k-Form-TextInput--disabled"
+  className="sc-bdVaJa gynXzG k-Form-TextInput k-Form-TextInput--andromeda k-Form-TextInput--regular k-Form-TextInput--disabled"
   disabled={true}
   name="text"
 />
@@ -31,7 +31,7 @@ exports[`<TextInput /> with \`disabled\` prop matches with snapshot 1`] = `
 
 exports[`<TextInput /> with \`error\` prop matches with snapshot 1`] = `
 <input
-  className="sc-bdVaJa cjAhxx k-Form-TextInput k-Form-TextInput--andromeda k-Form-TextInput--regular k-Form-TextInput--error"
+  className="sc-bdVaJa gynXzG k-Form-TextInput k-Form-TextInput--andromeda k-Form-TextInput--regular k-Form-TextInput--error"
   disabled={false}
   name="text"
 />
@@ -39,7 +39,7 @@ exports[`<TextInput /> with \`error\` prop matches with snapshot 1`] = `
 
 exports[`<TextInput /> with \`name\` prop matches with snapshot 1`] = `
 <input
-  className="sc-bdVaJa cjAhxx k-Form-TextInput k-Form-TextInput--andromeda k-Form-TextInput--regular"
+  className="sc-bdVaJa gynXzG k-Form-TextInput k-Form-TextInput--andromeda k-Form-TextInput--regular"
   disabled={false}
   name="foobar"
 />
@@ -47,7 +47,7 @@ exports[`<TextInput /> with \`name\` prop matches with snapshot 1`] = `
 
 exports[`<TextInput /> with \`size\` prop matches with snapshot 1`] = `
 <input
-  className="sc-bdVaJa cjAhxx k-Form-TextInput k-Form-TextInput--andromeda k-Form-TextInput--regular"
+  className="sc-bdVaJa gynXzG k-Form-TextInput k-Form-TextInput--andromeda k-Form-TextInput--regular"
   disabled={false}
   name="text"
 />
@@ -55,7 +55,7 @@ exports[`<TextInput /> with \`size\` prop matches with snapshot 1`] = `
 
 exports[`<TextInput /> with \`tag\` prop matches with snapshot 1`] = `
 <input
-  className="sc-bdVaJa cjAhxx k-Form-TextInput k-Form-TextInput--andromeda k-Form-TextInput--regular"
+  className="sc-bdVaJa gynXzG k-Form-TextInput k-Form-TextInput--andromeda k-Form-TextInput--regular"
   disabled={false}
   name="text"
 />
@@ -66,7 +66,7 @@ exports[`<TextInput /> with \`textarea\` tag matches with snapshot 1`] = `
   className="sc-bwzfXH gXZxcj k-Form-TextInput__textareaContainer"
 >
   <textarea
-    className="sc-bdVaJa cjAhxx k-Form-TextInput k-Form-TextInput--andromeda k-Form-TextInput--regular"
+    className="sc-bdVaJa gynXzG k-Form-TextInput k-Form-TextInput--andromeda k-Form-TextInput--regular"
     disabled={false}
     name="message"
   />
@@ -78,7 +78,7 @@ exports[`<TextInput /> with \`textarea\` tag matches with snapshot 1`] = `
 
 exports[`<TextInput /> with \`valid\` prop matches with snapshot 1`] = `
 <input
-  className="sc-bdVaJa cjAhxx k-Form-TextInput k-Form-TextInput--andromeda k-Form-TextInput--regular k-Form-TextInput--valid"
+  className="sc-bdVaJa gynXzG k-Form-TextInput k-Form-TextInput--andromeda k-Form-TextInput--regular k-Form-TextInput--valid"
   disabled={false}
   name="text"
 />
@@ -86,7 +86,7 @@ exports[`<TextInput /> with \`valid\` prop matches with snapshot 1`] = `
 
 exports[`<TextInput /> with \`variant\` prop matches with snapshot 1`] = `
 <input
-  className="sc-bdVaJa cjAhxx k-Form-TextInput k-Form-TextInput--orion k-Form-TextInput--regular"
+  className="sc-bdVaJa gynXzG k-Form-TextInput k-Form-TextInput--orion k-Form-TextInput--regular"
   disabled={false}
   name="text"
 />

--- a/assets/javascripts/kitten/components/form/text-input/index.js
+++ b/assets/javascripts/kitten/components/form/text-input/index.js
@@ -80,10 +80,7 @@ const StyledInput = styled.input`
   padding: ${pxToRem(10)} var(--input-padding-horizontal);
 
   &.k-Form-TextInput--orion {
-    &.k-Form-TextInput--tiny,
-    &.k-Form-TextInput--regular {
-      border-radius: ${pxToRem(4)};
-    }
+    border-radius: ${pxToRem(4)};
 
     &.k-Form-TextInput--big,
     &.k-Form-TextInput--huge,


### PR DESCRIPTION
Cette PR complète la dernière PR unreleased (https://github.com/KissKissBankBank/kitten/commit/292a50a090be217b0f268cd1ccf307368237b84f)

Closes #.

Vercel link:

- https://kitten-git-…

Screenshot:


TODO:

- [ ] Tests
- [ ] Changelog
- [ ] A11Y
- [ ] Stories / Docs
- [ ] BrowserStack (IE11, Chrome & Firefox on Windows 10)
- [ ] New component added to `assets/javascripts/kitten/index.js`
