### PR TITLE
[TextCopy] Add `variant` prop, defaults to 'andromeda'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [unreleased]
 
 - Fix: `CrowdfundingCard`: Fix progress when value equals 0.
+- Feature: `TextCopy`: Add `variant` prop, defaults to 'andromeda'.
 
 ## [3.17.3] - 2021-06-07
 

--- a/assets/javascripts/kitten/components/text-copy/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/text-copy/__snapshots__/test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<TextCopy /> should match snapshot 1`] = `
 <button
-  className="sc-EHOje gqElvD k-TextCopy k-u-reset-button k-TextCopy--undefined"
+  className="sc-EHOje hQnwvz k-TextCopy k-u-reset-button k-TextCopy--undefined"
   onClick={[Function]}
   type="button"
 >
@@ -42,7 +42,7 @@ exports[`<TextCopy /> should match snapshot 1`] = `
 
 exports[`<TextCopy /> should match snapshot with button text 1`] = `
 <button
-  className="sc-EHOje gqElvD k-TextCopy k-u-reset-button k-TextCopy--undefined"
+  className="sc-EHOje hQnwvz k-TextCopy k-u-reset-button k-TextCopy--undefined"
   onClick={[Function]}
   type="button"
 >
@@ -76,7 +76,7 @@ exports[`<TextCopy /> should match snapshot with button text 1`] = `
 
 exports[`<TextCopy /> should match snapshot with description 1`] = `
 <button
-  className="sc-EHOje gqElvD k-TextCopy k-u-reset-button k-TextCopy--undefined"
+  className="sc-EHOje hQnwvz k-TextCopy k-u-reset-button k-TextCopy--undefined"
   onClick={[Function]}
   type="button"
 >
@@ -121,7 +121,7 @@ exports[`<TextCopy /> should match snapshot with description 1`] = `
 
 exports[`<TextCopy /> should match snapshot with one line forced 1`] = `
 <button
-  className="sc-EHOje gqElvD k-TextCopy k-u-reset-button k-TextCopy--undefined"
+  className="sc-EHOje hQnwvz k-TextCopy k-u-reset-button k-TextCopy--undefined"
   onClick={[Function]}
   type="button"
 >
@@ -166,7 +166,7 @@ exports[`<TextCopy /> should match snapshot with one line forced 1`] = `
 
 exports[`<TextCopy /> should match snapshot with variant etc. 1`] = `
 <button
-  className="sc-EHOje gqElvD k-TextCopy k-u-reset-button k-TextCopy--orion"
+  className="sc-EHOje hQnwvz k-TextCopy k-u-reset-button k-TextCopy--orion"
   onClick={[Function]}
   type="button"
 >

--- a/assets/javascripts/kitten/components/text-copy/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/text-copy/__snapshots__/test.js.snap
@@ -1,21 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<TextCopy /> should match snapshot 1`] = `
-<div
-  className="sc-bxivhb jnalPG"
+<button
+  className="sc-EHOje gqElvD k-TextCopy k-u-reset-button k-TextCopy--undefined"
+  onClick={[Function]}
+  type="button"
 >
-  <span
-    className="sc-bwzfXH uTxCW k-u-line-height-normal k-u-size-micro k-u-weight-light sc-ifAKCX JcGon"
-    onClick={[Function]}
+  <div
+    className="sc-htpNat eiKyFO k-Form-TextInput k-TextCopy__text k-u-reset-button k-Form-TextInput--andromeda k-Form-TextInput--regular"
+    disabled={false}
+    name="text"
   >
     <span>
       Text To Copy
     </span>
-  </span>
-  <div
-    aria-hidden={true}
-    className="sc-EHOje dwKMm"
-    onClick={[Function]}
+  </div>
+  <span
+    className="sc-ifAKCX dJRJMu k-Button k-TextCopy__buttonTextButton k-Button--regular k-Button--hydrogen k-Button--andromeda k-Button--hasIcon"
+    style={
+      Object {
+        "--border-radius": 0,
+      }
+    }
+    type="button"
   >
     <svg
       height="22"
@@ -29,59 +36,72 @@ exports[`<TextCopy /> should match snapshot 1`] = `
         fill="#000"
       />
     </svg>
-  </div>
-</div>
+  </span>
+</button>
 `;
 
 exports[`<TextCopy /> should match snapshot with button text 1`] = `
-<div
-  className="sc-bxivhb iGiqAw"
+<button
+  className="sc-EHOje gqElvD k-TextCopy k-u-reset-button k-TextCopy--undefined"
+  onClick={[Function]}
+  type="button"
 >
   <span
     className="k-u-a11y-visuallyHidden"
   >
     This is a description
   </span>
-  <span
-    className="sc-bwzfXH uTxCW k-u-line-height-normal k-u-size-micro k-u-weight-light sc-ifAKCX ivCvQq"
-    onClick={[Function]}
+  <div
+    className="sc-htpNat eiKyFO k-Form-TextInput k-TextCopy__text k-u-reset-button k-Form-TextInput--andromeda k-Form-TextInput--regular"
+    disabled={false}
+    name="text"
   >
     <span>
       Text To Copy
     </span>
-  </span>
-  <button
-    aria-label={[Function]}
-    className="sc-htpNat gmIEnJ"
-    onClick={[Function]}
+  </div>
+  <span
+    className="sc-ifAKCX hudtkk k-Button k-TextCopy__buttonTextButton k-Button--regular k-Button--helium k-Button--andromeda"
+    style={
+      Object {
+        "--border-radius": 0,
+      }
+    }
     type="button"
   >
     Button text
-  </button>
-</div>
+  </span>
+</button>
 `;
 
 exports[`<TextCopy /> should match snapshot with description 1`] = `
-<div
-  className="sc-bxivhb jnalPG"
+<button
+  className="sc-EHOje gqElvD k-TextCopy k-u-reset-button k-TextCopy--undefined"
+  onClick={[Function]}
+  type="button"
 >
   <span
     className="k-u-a11y-visuallyHidden"
   >
     This is a description
   </span>
-  <span
-    className="sc-bwzfXH uTxCW k-u-line-height-normal k-u-size-micro k-u-weight-light sc-ifAKCX JcGon"
-    onClick={[Function]}
+  <div
+    className="sc-htpNat eiKyFO k-Form-TextInput k-TextCopy__text k-u-reset-button k-Form-TextInput--andromeda k-Form-TextInput--regular"
+    disabled={false}
+    name="text"
   >
     <span>
       Text To Copy
     </span>
-  </span>
-  <div
-    aria-hidden={true}
-    className="sc-EHOje dwKMm"
-    onClick={[Function]}
+  </div>
+  <span
+    className="sc-ifAKCX dJRJMu k-Button k-TextCopy__buttonTextButton k-Button--regular k-Button--hydrogen k-Button--andromeda k-Button--hasIcon"
+    style={
+      Object {
+        "--border-radius": 0,
+      }
+    }
+    type="button"
   >
     <svg
       height="22"
@@ -95,31 +115,38 @@ exports[`<TextCopy /> should match snapshot with description 1`] = `
         fill="#000"
       />
     </svg>
-  </div>
-</div>
+  </span>
+</button>
 `;
 
 exports[`<TextCopy /> should match snapshot with one line forced 1`] = `
-<div
-  className="sc-bxivhb jnalPG"
+<button
+  className="sc-EHOje gqElvD k-TextCopy k-u-reset-button k-TextCopy--undefined"
+  onClick={[Function]}
+  type="button"
 >
   <span
     className="k-u-a11y-visuallyHidden"
   >
     This is a description
   </span>
-  <span
-    className="sc-bwzfXH uTxCW k-u-line-height-normal k-u-size-micro k-u-weight-light sc-ifAKCX etcZRR"
-    onClick={[Function]}
+  <div
+    className="sc-htpNat eiKyFO k-Form-TextInput k-TextCopy__text k-u-reset-button k-TextCopy__text--forceOneLine k-Form-TextInput--andromeda k-Form-TextInput--regular"
+    disabled={false}
+    name="text"
   >
     <span>
       Text To Copy
     </span>
-  </span>
-  <div
-    aria-hidden={true}
-    className="sc-EHOje dwKMm"
-    onClick={[Function]}
+  </div>
+  <span
+    className="sc-ifAKCX dJRJMu k-Button k-TextCopy__buttonTextButton k-Button--regular k-Button--hydrogen k-Button--andromeda k-Button--hasIcon"
+    style={
+      Object {
+        "--border-radius": 0,
+      }
+    }
+    type="button"
   >
     <svg
       height="22"
@@ -133,6 +160,40 @@ exports[`<TextCopy /> should match snapshot with one line forced 1`] = `
         fill="#000"
       />
     </svg>
+  </span>
+</button>
+`;
+
+exports[`<TextCopy /> should match snapshot with variant etc. 1`] = `
+<button
+  className="sc-EHOje gqElvD k-TextCopy k-u-reset-button k-TextCopy--orion"
+  onClick={[Function]}
+  type="button"
+>
+  <span
+    className="k-u-a11y-visuallyHidden"
+  >
+    This is a description
+  </span>
+  <div
+    className="sc-htpNat eiKyFO k-Form-TextInput k-TextCopy__text k-u-reset-button k-Form-TextInput--orion k-Form-TextInput--regular"
+    disabled={false}
+    name="text"
+  >
+    <span>
+      Text To Copy
+    </span>
   </div>
-</div>
+  <span
+    className="sc-ifAKCX hudtkk k-Button k-TextCopy__buttonTextButton k-Button--regular k-Button--helium k-Button--orion"
+    style={
+      Object {
+        "--border-radius": 0,
+      }
+    }
+    type="button"
+  >
+    Button text
+  </span>
+</button>
 `;

--- a/assets/javascripts/kitten/components/text-copy/index.js
+++ b/assets/javascripts/kitten/components/text-copy/index.js
@@ -1,31 +1,16 @@
 import React, { useRef, useCallback, useState, useEffect } from 'react'
+import classNames from 'classnames'
 import PropTypes from 'prop-types'
-import styled, { keyframes, css } from 'styled-components'
-import TYPOGRAPHY from '../../constants/typography-config'
+import styled, { keyframes } from 'styled-components'
 import COLORS from '../../constants/colors-config'
-import { pxToRem, stepToRem } from '../../helpers/utils/typography'
+import { ScreenConfig } from '../../constants/screen-config'
+import { pxToRem } from '../../helpers/utils/typography'
 import { CopyIcon } from '../icons/copy-icon'
 import { ArrowContainer } from '../layout/arrow-container'
 import { Text } from '../typography/text'
+import { TextInput } from '../form/text-input'
 import { VisuallyHidden } from '../accessibility/visually-hidden'
-import { modifierStyles } from '../../components/buttons/button/helpers/modifier-styles'
-
-const StyledButton = styled(({ buttonModifier, ...others }) => (
-  <button {...others} />
-))`
-  ${TYPOGRAPHY.fontStyles.regular};
-  font-size: ${stepToRem(-1)};
-  line-height: 1.3;
-  flex: 1 0 auto;
-  appearance: none;
-  cursor: pointer;
-  padding: 0 ${pxToRem(30)};
-  border-radius: 0;
-  align-self: stretch;
-  box-sizing: border-box;
-
-  ${({ buttonModifier }) => modifierStyles(buttonModifier)};
-`
+import { Button } from '../../components/buttons/button/'
 
 const fadeInAndOut = keyframes`
   0%, 100% {
@@ -36,61 +21,84 @@ const fadeInAndOut = keyframes`
   }
 `
 
-const Wrapper = styled(({ buttonText, ...others }) => <div {...others} />)`
+const Wrapper = styled.button`
   position: relative;
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-
-  ${({ buttonText }) =>
-    !buttonText &&
-    css`
-      border: ${pxToRem(2)} solid ${COLORS.line1};
-      background-color: ${COLORS.background1};
-    `}
-`
-
-const StyledText = styled(
-  ({ buttonText, forceOneLine, className, children, ...others }) => (
-    <Text className={className} {...others}>
-      {children}
-    </Text>
-  ),
-)`
-  padding: ${pxToRem(10)} ${pxToRem(15)};
   width: 100%;
 
-  ${({ buttonText }) =>
-    buttonText &&
-    css`
-      border: ${pxToRem(2)} solid ${COLORS.line1};
-      background-color: ${COLORS.background1};
-      border-right: 0;
-    `}
+  .k-TextCopy__text {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    line-height: 1.2;
+    text-align: left;
 
-  ${({ forceOneLine }) =>
-    forceOneLine &&
-    css`
+    span {
+      max-height: calc(2 * 1.2 * 1em);
       overflow: hidden;
-      white-space: nowrap;
-    `}
-`
+      text-overflow: ellipsis;
+    }
 
-const IconWrapper = styled.div`
-  display: flex;
-  cursor: pointer;
-  align-items: center;
-  padding: ${pxToRem(10)};
-  border-left: ${pxToRem(2)} solid ${COLORS.line1};
-  align-self: stretch;
-  box-sizing: border-box;
-`
+    &.k-TextCopy__text--forceOneLine {
+      overflow: hidden;
 
-const StyledArrowContainer = styled(ArrowContainer)`
-  position: absolute;
-  left: 0;
-  bottom: -${pxToRem(50)};
-  animation: 3s ${fadeInAndOut} ease-out;
+      span {
+        max-width: 100%;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+      }
+    }
+  }
+
+  .k-TextCopy__buttonTextButton {
+    min-width: 0;
+    flex: 1 0 auto;
+    padding: 0 ${pxToRem(15)};
+    align-self: stretch;
+    box-sizing: border-box;
+  }
+
+  .k-TextCopy__iconButton {
+    display: flex;
+    cursor: pointer;
+    align-items: center;
+    padding: ${pxToRem(10)};
+    border: ${pxToRem(2)} solid ${COLORS.line1};
+    align-self: stretch;
+    box-sizing: border-box;
+  }
+
+  .k-TextCopy__tooltip {
+    position: absolute;
+    left: 0;
+    bottom: -${pxToRem(50)};
+    animation: 3s ${fadeInAndOut} ease-out;
+  }
+
+  &.k-TextCopy--andromeda {
+    .k-TextCopy__text {
+      border-right: 0;
+    }
+  }
+
+  &.k-TextCopy--orion {
+    gap: ${pxToRem(5)};
+
+    &:hover {
+      .k-Button {
+        border-color: ${COLORS.primary3};
+        background-color: ${COLORS.primary3};
+      }
+    }
+
+    @media (max-width: ${pxToRem(ScreenConfig.XS.max)}) {
+      flex-direction: column;
+    }
+
+    .k-Button.k-Button--orion {
+      border-radius: ${pxToRem(4)};
+    }
+  }
 `
 
 export const TextCopy = ({
@@ -101,98 +109,97 @@ export const TextCopy = ({
   forceOneLine,
   buttonText,
   buttonModifier,
+  variant,
 }) => {
-  const [shouldShowMessage, isMessageShown] = useState(false)
-  const textRef = useRef(null)
-  const selectText = useCallback(() => {
-    const range = document.createRange()
-    range.selectNode(textRef.current)
-    window.getSelection().addRange(range)
-  })
+  const [isMessageVisible, setMessageVisibility] = useState(false)
+  const textElement = useRef(null)
+
   useEffect(() => {
     let hideTimeout
-    if (shouldShowMessage) {
-      hideTimeout = setTimeout(() => isMessageShown(false), 3000)
+    if (isMessageVisible) {
+      hideTimeout = setTimeout(() => setMessageVisibility(false), 3000)
     }
     return () => clearTimeout(hideTimeout)
-  }, [shouldShowMessage])
-  const copyText = useCallback(() => {
-    isMessageShown(false)
-    if (textToCopy) {
-      const el = document.createElement('textarea')
-      el.value = textToCopy
-      document.body.appendChild(el)
-      el.select()
-      document.execCommand('copy')
-      document.body.removeChild(el)
-      const range = document.createRange()
-      range.selectNode(textRef.current)
-      window.getSelection().addRange(range)
+  }, [isMessageVisible])
+
+  const copyToClipboard = text => {
+    if (!navigator.clipboard && window.isSecureContext) {
+      return navigator.clipboard.writeText(text)
     } else {
-      selectText()
-      document.execCommand('copy')
+      // IE11
+      const hiddenElement = document.createElement('textarea')
+      hiddenElement.style.position = 'absolute'
+      hiddenElement.style.opacity = 0
+      hiddenElement.value = text
+      document.body.appendChild(hiddenElement)
+      hiddenElement.select()
+      return new Promise((res, rej) => {
+        document.execCommand('copy') ? res() : rej()
+        document.body.removeChild(hiddenElement)
+      })
     }
-    setTimeout(() => isMessageShown(true), 1)
+  }
+
+  const copyText = useCallback(() => {
+    setMessageVisibility(false)
+
+    const copyableText = textToCopy || textElement?.current?.innerText || ''
+
+    copyToClipboard(copyableText).then(() => {
+      setTimeout(() => setMessageVisibility(true), 1)
+    })
+
+    const range = document.createRange()
+    range.selectNode(textElement.current)
+    window.getSelection().addRange(range)
   })
 
-  const Action = ({ copyText, buttonText, buttonModifier, buttonProps }) => (
-    <>
-      {!buttonText && (
-        <IconWrapper aria-hidden={true} onClick={copyText}>
-          <CopyIcon />
-        </IconWrapper>
-      )}
-
-      {buttonText && (
-        <StyledButton
-          type="button"
-          buttonModifier={buttonModifier}
-          onClick={copyText}
-          aria-label={copyText}
-          {...buttonProps}
-        >
-          {buttonText}
-        </StyledButton>
-      )}
-    </>
-  )
-
   return (
-    <>
-      <Wrapper buttonText={buttonText}>
-        {description && <VisuallyHidden>{description}</VisuallyHidden>}
-        <StyledText
-          weight="light"
-          size="micro"
-          lineHeight="normal"
-          forceOneLine={forceOneLine}
-          onClick={selectText}
-          buttonText={buttonText}
+    <Wrapper
+      className={classNames(
+        'k-TextCopy',
+        'k-u-reset-button',
+        `k-TextCopy--${variant}`,
+      )}
+      type="button"
+      onClick={copyText}
+    >
+      {description && <VisuallyHidden>{description}</VisuallyHidden>}
+      <TextInput
+        as="div"
+        className={classNames('k-TextCopy__text', 'k-u-reset-button', {
+          'k-TextCopy__text--forceOneLine': forceOneLine,
+        })}
+        variant={variant}
+      >
+        <span ref={textElement}>{children}</span>
+      </TextInput>
+
+      <Button
+        as="span"
+        modifier={!!buttonText ? buttonModifier : 'hydrogen'}
+        className="k-TextCopy__buttonTextButton"
+        variant={variant}
+        icon={!buttonText}
+      >
+        {!!buttonText ? buttonText : <CopyIcon />}
+      </Button>
+
+      {alertMessage && isMessageVisible && (
+        <ArrowContainer
+          color={COLORS.primary1}
+          position="top"
+          padding={10}
+          centered
+          role="alert"
+          className="k-TextCopy__tooltip"
         >
-          <span ref={textRef}>{children}</span>
-        </StyledText>
-
-        <Action
-          copyText={copyText}
-          buttonText={buttonText}
-          buttonModifier={buttonModifier}
-        />
-
-        {alertMessage && shouldShowMessage && (
-          <StyledArrowContainer
-            color={COLORS.primary1}
-            position="top"
-            padding={10}
-            centered
-            role="alert"
-          >
-            <Text color="background1" weight="light" size="micro">
-              {alertMessage}
-            </Text>
-          </StyledArrowContainer>
-        )}
-      </Wrapper>
-    </>
+          <Text color="background1" weight="light" size="micro">
+            {alertMessage}
+          </Text>
+        </ArrowContainer>
+      )}
+    </Wrapper>
   )
 }
 

--- a/assets/javascripts/kitten/components/text-copy/index.js
+++ b/assets/javascripts/kitten/components/text-copy/index.js
@@ -86,6 +86,13 @@ const Wrapper = styled.button`
 
     &:hover {
       .k-Button {
+        border-color: ${COLORS.primary2};
+        background-color: ${COLORS.primary2};
+      }
+    }
+
+    &:active {
+      .k-Button {
         border-color: ${COLORS.primary3};
         background-color: ${COLORS.primary3};
       }

--- a/assets/javascripts/kitten/components/text-copy/stories.js
+++ b/assets/javascripts/kitten/components/text-copy/stories.js
@@ -1,7 +1,7 @@
 import { Container } from '../grid/container'
 import { Marger } from '../..'
 import React from 'react'
-import { text, boolean } from '@storybook/addon-knobs'
+import { text, boolean, select } from '@storybook/addon-knobs'
 import { TextCopy } from './index'
 
 const StoryContainer = ({ children }) => (
@@ -21,10 +21,11 @@ export const Default = () => {
   return (
     <StoryContainer>
       <TextCopy
-        textToCopy={text('Other text to Copy', undefined)}
-        alertMessage={text('Alert Message', 'Copied link !')}
-        forceOneLine={boolean('Force one line', false)}
-        buttonText={text('button text', 'Je suis button !')}
+        textToCopy={text('textToCopy', undefined)}
+        alertMessage={text('alertMessage', 'Copied link !')}
+        forceOneLine={boolean('forceOneLine', false)}
+        buttonText={text('buttonText', 'Je suis button !')}
+        variant={select('variant', ['andromeda', 'orion'], 'andromeda')}
       >
         {text('Text', 'My text to copy on click')}
       </TextCopy>

--- a/assets/javascripts/kitten/components/text-copy/test.js
+++ b/assets/javascripts/kitten/components/text-copy/test.js
@@ -50,4 +50,19 @@ describe('<TextCopy />', () => {
       .toJSON()
     expect(component).toMatchSnapshot()
   })
+  it('should match snapshot with variant etc.', () => {
+    const component = renderer
+      .create(
+        <TextCopy
+          alertMessage="Text copied!"
+          description="This is a description"
+          buttonText="Button text"
+          variant="orion"
+        >
+          Text To Copy
+        </TextCopy>,
+      )
+      .toJSON()
+    expect(component).toMatchSnapshot()
+  })
 })


### PR DESCRIPTION
Closes #.

Vercel link:

- https://kitten-git-text-copy-refactor-and-variant-kisskissbankbank.vercel.app/iframe.html?id=textcopy-textcopy--default&args=&knob-alertMessage=Copied%20link%20!&knob-buttonText=Je%20suis%20button%20!&knob-variant=orion&knob-Text=My%20text%20to%20copy%20on%20click&viewMode=story

Screenshot:


TODO:

- [x] Tests
- [x] Changelog
- [ ] A11Y
- [x] Stories / Docs
- [ ] BrowserStack (IE11, Chrome & Firefox on Windows 10)
- [ ] New component added to `assets/javascripts/kitten/index.js`
