### PR TITLE
[ImageCropper] Several fixes on Cropper + add onUpload prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,20 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+Features:
+
+- `ImageCropper`: Add `onUpload` prop, called when uploading a new file.
+
+Fixes:
+
 - Fix: `DashboardLayout`: Remove horizontal scroll between 1440px and 1550px.
+- Fix: `ImageCropper`: Fix behaviour of component, breaking when uploading a file.
 
 ## [3.18.1] - 2021-06-10
 
 Fix:
 
 - Add `TextInputWithIcon` to ESM exports.
-
 ## [3.18.0] - 2021-06-10
 
 Features:

--- a/assets/javascripts/kitten/components/images/image-cropper/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/images/image-cropper/__snapshots__/test.js.snap
@@ -123,7 +123,28 @@ exports[`<ImageCropper /> matches with snapshot with imageSrc 1`] = `
   >
     <div
       className="k-Cropper__wrapper__cropper"
-    />
+    >
+      <div
+        className="k-Cropper"
+        style={
+          Object {
+            "height": 0,
+            "width": 0,
+          }
+        }
+      >
+        <img
+          alt="picture"
+          src="/kitten.jpg"
+          style={
+            Object {
+              "maxWidth": "100%",
+              "opacity": 0,
+            }
+          }
+        />
+      </div>
+    </div>
     <div
       className="k-Cropper__wrapper__slider"
     >


### PR DESCRIPTION
Correctifs sur Cropper : 
* suppression d'une boucle infinie générée par un `useEffect`
* `.reset()` de la `cropperInstance` à chaque nouvel upload
* ajout de la prop `onUpload`