### PR TITLE
[TextInputWithUnit] Fix disabled state and unitWord styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: `TextInputWithUnit`: Fix disabled state and `unitWord` styles.
+
 ## [3.19.0] - 2021-06-11
 
 Features:

--- a/assets/javascripts/kitten/components/date-picker/__snapshots__/date-picker.test.js.snap
+++ b/assets/javascripts/kitten/components/date-picker/__snapshots__/date-picker.test.js.snap
@@ -8,7 +8,7 @@ exports[`<DatePicker /> by default matches with snapshot 1`] = `
     className="DayPickerInput"
   >
     <div
-      className="sc-htpNat hVSsXl k-Form-TextInputWithUnit k-Form-TextInputWithUnit--andromeda"
+      className="sc-htpNat bdJakE k-Form-TextInputWithUnit k-Form-TextInputWithUnit--andromeda"
     >
       <input
         autoComplete="off"

--- a/assets/javascripts/kitten/components/form/field/__snapshots__/field.test.js.snap
+++ b/assets/javascripts/kitten/components/form/field/__snapshots__/field.test.js.snap
@@ -407,7 +407,7 @@ Array [
     className="k-FieldInput k-u-margin-top-single"
   >
     <div
-      className="sc-bZQynM jSbTiA k-Form-TextInputWithUnit k-Form-TextInputWithUnit--andromeda"
+      className="sc-bZQynM kZGvAY k-Form-TextInputWithUnit k-Form-TextInputWithUnit--andromeda"
     >
       <input
         className="sc-bxivhb eXmlvj k-Form-TextInput k-Form-TextInputWithUnit__input k-Form-TextInput--andromeda k-Form-TextInput--regular"

--- a/assets/javascripts/kitten/components/form/text-input-with-unit/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/form/text-input-with-unit/__snapshots__/test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<TextInputWithUnit /> by default matches with snapshot 1`] = `
 <div
-  className="sc-htpNat hVSsXl k-Form-TextInputWithUnit k-Form-TextInputWithUnit--andromeda"
+  className="sc-htpNat bdJakE k-Form-TextInputWithUnit k-Form-TextInputWithUnit--andromeda"
 >
   <input
     className="sc-bdVaJa gynXzG k-Form-TextInput k-Form-TextInputWithUnit__input k-Form-TextInput--andromeda k-Form-TextInput--regular"
@@ -20,11 +20,11 @@ exports[`<TextInputWithUnit /> by default matches with snapshot 1`] = `
 
 exports[`<TextInputWithUnit /> with disabled prop matches with snapshot 1`] = `
 <div
-  className="sc-htpNat hVSsXl k-Form-TextInputWithUnit k-Form-TextInputWithUnit--andromeda"
+  className="sc-htpNat bdJakE k-Form-TextInputWithUnit k-Form-TextInputWithUnit--andromeda"
 >
   <input
-    className="sc-bdVaJa gynXzG k-Form-TextInput k-Form-TextInputWithUnit__input k-Form-TextInput--andromeda k-Form-TextInput--regular"
-    disabled={false}
+    className="sc-bdVaJa gynXzG k-Form-TextInput k-Form-TextInputWithUnit__input k-Form-TextInput--andromeda k-Form-TextInput--regular k-Form-TextInput--disabled"
+    disabled={true}
     name="text"
     type="number"
   />
@@ -38,10 +38,10 @@ exports[`<TextInputWithUnit /> with disabled prop matches with snapshot 1`] = `
 
 exports[`<TextInputWithUnit /> with error prop matches with snapshot 1`] = `
 <div
-  className="sc-htpNat hVSsXl k-Form-TextInputWithUnit k-Form-TextInputWithUnit--andromeda"
+  className="sc-htpNat bdJakE k-Form-TextInputWithUnit k-Form-TextInputWithUnit--andromeda"
 >
   <input
-    className="sc-bdVaJa gynXzG k-Form-TextInput k-Form-TextInputWithUnit__input k-Form-TextInput--andromeda k-Form-TextInput--regular"
+    className="sc-bdVaJa gynXzG k-Form-TextInput k-Form-TextInputWithUnit__input k-Form-TextInput--andromeda k-Form-TextInput--regular k-Form-TextInput--error"
     disabled={false}
     name="text"
     type="number"
@@ -56,7 +56,7 @@ exports[`<TextInputWithUnit /> with error prop matches with snapshot 1`] = `
 
 exports[`<TextInputWithUnit /> with size prop matches with snapshot 1`] = `
 <div
-  className="sc-htpNat hVSsXl k-Form-TextInputWithUnit k-Form-TextInputWithUnit--andromeda"
+  className="sc-htpNat bdJakE k-Form-TextInputWithUnit k-Form-TextInputWithUnit--andromeda"
 >
   <input
     className="sc-bdVaJa gynXzG k-Form-TextInput k-Form-TextInputWithUnit__input k-Form-TextInput--andromeda k-Form-TextInput--big"
@@ -74,7 +74,7 @@ exports[`<TextInputWithUnit /> with size prop matches with snapshot 1`] = `
 
 exports[`<TextInputWithUnit /> with unit matches with snapshot 1`] = `
 <div
-  className="sc-htpNat hVSsXl k-Form-TextInputWithUnit k-Form-TextInputWithUnit--andromeda"
+  className="sc-htpNat bdJakE k-Form-TextInputWithUnit k-Form-TextInputWithUnit--andromeda"
 >
   <input
     className="sc-bdVaJa gynXzG k-Form-TextInput k-Form-TextInputWithUnit__input k-Form-TextInput--andromeda k-Form-TextInput--regular"
@@ -94,10 +94,10 @@ exports[`<TextInputWithUnit /> with unit matches with snapshot 1`] = `
 
 exports[`<TextInputWithUnit /> with valid prop matches with snapshot 1`] = `
 <div
-  className="sc-htpNat hVSsXl k-Form-TextInputWithUnit k-Form-TextInputWithUnit--andromeda"
+  className="sc-htpNat bdJakE k-Form-TextInputWithUnit k-Form-TextInputWithUnit--andromeda"
 >
   <input
-    className="sc-bdVaJa gynXzG k-Form-TextInput k-Form-TextInputWithUnit__input k-Form-TextInput--andromeda k-Form-TextInput--regular"
+    className="sc-bdVaJa gynXzG k-Form-TextInput k-Form-TextInputWithUnit__input k-Form-TextInput--andromeda k-Form-TextInput--regular k-Form-TextInput--valid"
     disabled={false}
     name="text"
     type="number"
@@ -112,7 +112,7 @@ exports[`<TextInputWithUnit /> with valid prop matches with snapshot 1`] = `
 
 exports[`<TextInputWithUnit /> with variant prop matches with snapshot 1`] = `
 <div
-  className="sc-htpNat hVSsXl k-Form-TextInputWithUnit k-Form-TextInputWithUnit--orion"
+  className="sc-htpNat bdJakE k-Form-TextInputWithUnit k-Form-TextInputWithUnit--orion"
 >
   <input
     className="sc-bdVaJa gynXzG k-Form-TextInput k-Form-TextInputWithUnit__input k-Form-TextInput--orion k-Form-TextInput--regular"

--- a/assets/javascripts/kitten/components/form/text-input-with-unit/index.js
+++ b/assets/javascripts/kitten/components/form/text-input-with-unit/index.js
@@ -17,7 +17,7 @@ const StyledTextInputWithUnit = styled.div`
 
   .k-Form-TextInputWithUnit__input {
     padding-right: ${pxToRem(50)};
-  
+
     &[type='number'] {
       appearance: textfield;
 
@@ -33,10 +33,10 @@ const StyledTextInputWithUnit = styled.div`
     display: flex;
     z-index: 1;
     position: absolute;
-    right: 0;
-    top: 0;
-    width: ${pxToRem(42)};
-    height: 100%;
+    right: ${pxToRem(2)};
+    top: ${pxToRem(2)};
+    bottom: ${pxToRem(2)};
+    min-width: ${pxToRem(42)};
     align-items: center;
     justify-content: center;
     border-left: ${pxToRem(2)} solid ${COLORS.line1};
@@ -47,6 +47,7 @@ const StyledTextInputWithUnit = styled.div`
     transition: all 0.2s;
     font-size: ${stepToRem(0)};
     ${TYPOGRAPHY.fontStyles.regular};
+    background-color: ${COLORS.background1};
 
     &.k-Form-TextInputWithUnit__unit--valid {
       border-color: ${COLORS.tertiary2};
@@ -93,7 +94,6 @@ const StyledTextInputWithUnit = styled.div`
     }
     .k-Form-TextInputWithUnit__unit {
       border: none;
-      padding: 0;
     }
   }
 `
@@ -115,7 +115,7 @@ export const TextInputWithUnit = ({
 
   return (
     <StyledTextInputWithUnit
-      {...wrapperProps}  
+      {...wrapperProps}
       className={classNames(
         'k-Form-TextInputWithUnit',
         `k-Form-TextInputWithUnit--${variant}`,
@@ -128,6 +128,9 @@ export const TextInputWithUnit = ({
       <TextInput
         ref={input}
         {...others}
+        valid={valid}
+        error={error}
+        disabled={disabled}
         size={size}
         className={classNames('k-Form-TextInputWithUnit__input', className)}
         variant={variant}
@@ -140,7 +143,7 @@ export const TextInputWithUnit = ({
             'k-Form-TextInputWithUnit__unit--valid': valid,
             'k-Form-TextInputWithUnit__unit--error': error,
             'k-Form-TextInputWithUnit__unit--disabled': disabled,
-            'k-Form-TextInputWithUnit__unit--hasUnitWord': !!unitWord,
+            'k-Form-TextInputWithUnit__unit--hasUnitWord': !unit && !!unitWord,
           },
         )}
       >


### PR DESCRIPTION
Closes #.

Vercel link:

- https://kitten-git-text-input-with-unit-fix-reg-8eafca-kisskissbankbank.vercel.app/?path=/story/form-textinputwithunit--default

Screenshot:


TODO:

- [ ] Tests
- [ ] Changelog
- [ ] A11Y
- [ ] Stories / Docs
- [ ] BrowserStack (IE11, Chrome & Firefox on Windows 10)
- [ ] New component added to `assets/javascripts/kitten/index.js`
