### PR TITLE
[Storybook] Add addon measure

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -55,5 +55,6 @@ module.exports = {
     '@storybook/addon-a11y',
     '@storybook/addon-viewport',
     '@storybook/addon-docs',
+    '@storybook/addon-measure',
   ],
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2570,6 +2570,12 @@
         "ts-dedent": "^2.0.0"
       }
     },
+    "@storybook/addon-measure": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-measure/-/addon-measure-1.2.4.tgz",
+      "integrity": "sha512-pxAo7QcETdiienZYMjAhX/3BqPnYTuH0ZSjmJzsr+yCBvZmZUciq1h3WvyUN59rT0ewFwLTKsmZG/wVZj+aN+Q==",
+      "dev": true
+    },
     "@storybook/addon-viewport": {
       "version": "6.2.8",
       "resolved": "https://registry.npmjs.org/@storybook/addon-viewport/-/addon-viewport-6.2.8.tgz",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@storybook/addon-docs": "6.2.8",
     "@storybook/addon-knobs": "6.2.8",
     "@storybook/addon-links": "6.2.8",
+    "@storybook/addon-measure": "1.2.4",
     "@storybook/addon-viewport": "6.2.8",
     "@storybook/addons": "6.2.8",
     "@storybook/builder-webpack5": "6.2.8",


### PR DESCRIPTION
Add storybook addon measure, for debug css

https://user-images.githubusercontent.com/11648042/122576397-f10cac00-d051-11eb-84e1-c7f297987a4d.mov


TODO:

- [ ] Tests
- [ ] Changelog
- [ ] A11Y
- [ ] Stories / Docs
- [ ] BrowserStack (IE11, Chrome & Firefox on Windows 10)
- [ ] New component added to `assets/javascripts/kitten/index.js`

