### PR TITLE
[ModalNext] Fix modal content height for decrepit versions of Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: `Modal/Next`: Fix modal content height for decrepit versions of Safari.
+
 ## [3.20.0] - 2021-06-17
 
 Features:

--- a/assets/javascripts/kitten/components/modals/next/index.js
+++ b/assets/javascripts/kitten/components/modals/next/index.js
@@ -52,6 +52,7 @@ const GlobalStyle = createGlobalStyle`
     --Modal-contentMargin: 1;
     --Modal-headerHeight: 0px;
 
+    flex: 1 0 auto;
     position: relative;
     background-color: ${COLORS.background1};
     box-sizing: border-box;


### PR DESCRIPTION
ಠ_ಠ @bjlaa 

Closes #.

Vercel link:

- https://kitten-git-modal-next-fix-content-heigh-ddb640-kisskissbankbank.vercel.app/?path=/story/modals-modal-next--complex-with-orion
-  **OLD**: https://kitten.vercel.app/?path=/story/modals-modal-next--complex-with-orion

Screenshot:


TODO:

- [ ] Tests
- [ ] Changelog
- [ ] A11Y
- [ ] Stories / Docs
- [ ] BrowserStack (IE11, Chrome & Firefox on Windows 10)
- [ ] New component added to `assets/javascripts/kitten/index.js`
