### PR TITLE
Sanitize html by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Feature: `parseHtml`: We sanitize by default the markup with an option `parseHtml(value, { sanitize: false })` to disable it.
+
 ## [3.24.0] - 2021-07-08
 
 Feature:

--- a/assets/javascripts/kitten/helpers/utils/parser.js
+++ b/assets/javascripts/kitten/helpers/utils/parser.js
@@ -1,13 +1,16 @@
 import HtmlToReact from 'html-to-react'
+import DOMPurify from 'dompurify'
 
 // We add a span to make parseHtml works with strings.
-export const parseHtml = value => {
+export const parseHtml = (value, options = { sanitize: true }) => {
   if (!value) return
 
   // We need to escape "<3" common emoji
-  const encodedValue =
-    typeof value === 'string' ? value.replace('<3', '&lt;3') : value
+  let clean = typeof value === 'string' ? value.replace('<3', '&lt;3') : value
 
-  return new HtmlToReact.Parser().parse(`<span>${encodedValue}</span>`).props
-    .children
+  if (options.sanitize) {
+    clean = DOMPurify.sanitize(clean)
+  }
+
+  return new HtmlToReact.Parser().parse(`<span>${clean}</span>`).props.children
 }

--- a/assets/javascripts/kitten/helpers/utils/parser.test.js
+++ b/assets/javascripts/kitten/helpers/utils/parser.test.js
@@ -23,4 +23,18 @@ describe('parseHtml()', () => {
 
     expect(parsedHtml).toBe('FooBar <3')
   })
+
+  it('sanitize HTML by default', () => {
+    const html = "<iframe/src='javascript:alert(document.cookie)'>"
+    const parsedHtml = parseHtml(html)
+
+    expect(parsedHtml).toBeUndefined()
+  })
+
+  it('not sanitize HTML if options set to false', () => {
+    const html = "<iframe/src='javascript:alert(document.cookie)'>"
+    const parsedHtml = parseHtml(html, { sanitize: false })
+
+    expect(parsedHtml).not.toBeUndefined()
+  })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -9853,6 +9853,11 @@
         "domelementtype": "^2.0.1"
       }
     },
+    "dompurify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.0.tgz",
+      "integrity": "sha512-VV5C6Kr53YVHGOBKO/F86OYX6/iLTw2yVSI721gKetxpHCK/V5TaLEf9ODjRgl1KLSWRMY6cUhAbv/c+IUnwQw=="
+    },
     "domutils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.5.0.tgz",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "classnames": "^2.2.6",
     "credit-card-type": "^9.1.0",
     "details-element-polyfill": "^2.4.0",
+    "dompurify": "2.3.0",
     "downshift": "^6.1.1",
     "html-to-react": "^1.4.5",
     "is-string-a-number": "^2.0.2",


### PR DESCRIPTION
On sanitize le `parsehtml`par défaut pour éviter les attaques XSS,
je mets quand même la possibilité de ne pas sanitize dans le cas de nos trads (qu'on maitrise, ça serait balo qu'on s'auto xss) pour gagner un poil en perfs