### PR TITLE
[TextCopy] Fix WebKit sizing bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: `TextCopy`: Fix WebKit sizing bug.
+
 ## [4.0.1] - 2021-07-23
 
 - `ContributionCard`: Various fixes.

--- a/assets/javascripts/kitten/components/layout/dashboard-layout/stories.js
+++ b/assets/javascripts/kitten/components/layout/dashboard-layout/stories.js
@@ -38,6 +38,7 @@ import {
   Alert,
   useWindowWidth,
   useDeepCompareEffect,
+  TextCopy,
 } from '../../..'
 
 import { Default as Table } from '../../organisms/tables/list-table/list-table.stories.js'
@@ -399,6 +400,13 @@ const FlowExample = () => (
         varius blandit sit amet non magna. Etiam porta sem malesuada magna
         mollis euismod. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
       </p>
+      <TextCopy
+        variant="orion"
+        buttonText="Copier l’URL"
+        textToCopy="https://www.kisskissbankbank.com/fr/projects/test-de-campagne-par-joachim/?secret-reward=hileo6"
+      >
+        https://www.kisskissbankbank.com/fr/projects/test-de-campagne-par-joachim/?secret-reward=hileo6
+      </TextCopy>
       <p className="k-u-weight-light">
         Donec ullamcorper nulla non metus auctor fringilla. Cras justo odio,
         dapibus ac facilisis in, egestas eget quam. Praesent commodo cursus

--- a/assets/javascripts/kitten/components/molecules/cards/contribution-card/contribution-card.stories.js
+++ b/assets/javascripts/kitten/components/molecules/cards/contribution-card/contribution-card.stories.js
@@ -70,7 +70,7 @@ const args = {
 
 export default {
   component: ContributionCard,
-  title: 'Cards/ContributionCard',
+  title: 'Molecules/Cards/ContributionCard',
   parameters: {
     component: ContributionCard,
   },

--- a/assets/javascripts/kitten/components/molecules/text-copy/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/molecules/text-copy/__snapshots__/test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<TextCopy /> should match snapshot 1`] = `
 <button
-  className="sc-ifAKCX cpsqXZ k-TextCopy k-u-reset-button k-TextCopy--undefined"
+  className="sc-ifAKCX eeGAAj k-TextCopy k-u-reset-button k-TextCopy--undefined"
   onClick={[Function]}
   type="button"
 >
@@ -42,7 +42,7 @@ exports[`<TextCopy /> should match snapshot 1`] = `
 
 exports[`<TextCopy /> should match snapshot with button text 1`] = `
 <button
-  className="sc-ifAKCX cpsqXZ k-TextCopy k-u-reset-button k-TextCopy--undefined"
+  className="sc-ifAKCX eeGAAj k-TextCopy k-u-reset-button k-TextCopy--undefined"
   onClick={[Function]}
   type="button"
 >
@@ -76,7 +76,7 @@ exports[`<TextCopy /> should match snapshot with button text 1`] = `
 
 exports[`<TextCopy /> should match snapshot with description 1`] = `
 <button
-  className="sc-ifAKCX cpsqXZ k-TextCopy k-u-reset-button k-TextCopy--undefined"
+  className="sc-ifAKCX eeGAAj k-TextCopy k-u-reset-button k-TextCopy--undefined"
   onClick={[Function]}
   type="button"
 >
@@ -121,7 +121,7 @@ exports[`<TextCopy /> should match snapshot with description 1`] = `
 
 exports[`<TextCopy /> should match snapshot with one line forced 1`] = `
 <button
-  className="sc-ifAKCX cpsqXZ k-TextCopy k-u-reset-button k-TextCopy--undefined"
+  className="sc-ifAKCX eeGAAj k-TextCopy k-u-reset-button k-TextCopy--undefined"
   onClick={[Function]}
   type="button"
 >
@@ -166,7 +166,7 @@ exports[`<TextCopy /> should match snapshot with one line forced 1`] = `
 
 exports[`<TextCopy /> should match snapshot with variant etc. 1`] = `
 <button
-  className="sc-ifAKCX cpsqXZ k-TextCopy k-u-reset-button k-TextCopy--orion"
+  className="sc-ifAKCX eeGAAj k-TextCopy k-u-reset-button k-TextCopy--orion"
   onClick={[Function]}
   type="button"
 >

--- a/assets/javascripts/kitten/components/molecules/text-copy/index.js
+++ b/assets/javascripts/kitten/components/molecules/text-copy/index.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import styled, { keyframes } from 'styled-components'
 import COLORS from '../../../constants/colors-config'
 import { ScreenConfig } from '../../../constants/screen-config'
-import { pxToRem } from '../../../helpers/utils/typography'
+import { pxToRem, stepToRem } from '../../../helpers/utils/typography'
 import { CopyIcon } from '../../graphics/icons/copy-icon'
 import { ArrowContainer } from '../../molecules/boxes/arrow-container'
 import { Text } from '../../atoms/typography/text'
@@ -30,23 +30,19 @@ const Wrapper = styled.button`
     display: flex;
     align-items: center;
     justify-content: flex-start;
-    line-height: 1.2;
+    line-height: calc(1.15 * ${stepToRem(-1)});
     text-align: left;
+    overflow: hidden;
 
     span {
-      max-height: calc(2 * 1.2 * 1em);
+      max-width: 100%;
+      max-height: calc(2 * 1.15 * ${stepToRem(-1)});
       overflow: hidden;
       text-overflow: ellipsis;
     }
 
-    &.k-TextCopy__text--forceOneLine {
-      overflow: hidden;
-
-      span {
-        max-width: 100%;
-        white-space: nowrap;
-        text-overflow: ellipsis;
-      }
+    &.k-TextCopy__text--forceOneLine span {
+      white-space: nowrap;
     }
   }
 


### PR DESCRIPTION
Closes #.

Vercel link:

- https://kitten-git-text-copy-fix-webkit-sizing-bug-kisskissbankbank.vercel.app/?path=/story/layout-dashboardlayout--default

Screenshot:


TODO:

- [x] Tests
- [x] Changelog
- [ ] A11Y
- [x] Stories / Docs
- [ ] BrowserStack (IE11, Chrome & Firefox on Windows 10)
- [ ] New component added to `assets/javascripts/kitten/index.js`
