### PR TITLE
[DocumentDropUploader]improve onChange and onError events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fix: `TextCopy`: Fix WebKit sizing bug.
 - Fix: `RadioButtonSet`: Fix dimensions.
+- Fix: `DocumentsDropUploader`: Fix onChange and onError event.
 
 ## [4.0.1] - 2021-07-23
 

--- a/assets/javascripts/kitten/components/molecules/upload/documents-drop-uploader/index.js
+++ b/assets/javascripts/kitten/components/molecules/upload/documents-drop-uploader/index.js
@@ -233,9 +233,9 @@ export const DocumentsDropUploader = ({
   }
 
   useEffect(() => {
+    let isValid = true
     setErrorMessageList([])
     setErrorList([])
-    onChange(fileList)
 
     if (fileList.length === 0) return setInternalStatus(status)
 
@@ -256,6 +256,7 @@ export const DocumentsDropUploader = ({
               error: typeErrorText(file.name),
             },
           ])
+          isValid = false
         }
 
         if (!!acceptedFileSize && file.size > acceptedFileSize) {
@@ -265,16 +266,18 @@ export const DocumentsDropUploader = ({
             ...current,
             {
               file,
-              error: typeErrorText(file.name),
+              error: sizeErrorText(file.name),
             },
           ])
+          isValid = false
         }
       }
     })
+    if (isValid) onChange(fileList)
   }, [fileList])
 
   useEffect(() => {
-    if (!errorList) return
+    if (errorList.length === 0) return
 
     onError(errorList)
   }, [errorList])

--- a/assets/javascripts/kitten/components/molecules/upload/documents-drop-uploader/stories.js
+++ b/assets/javascripts/kitten/components/molecules/upload/documents-drop-uploader/stories.js
@@ -21,7 +21,7 @@ export const Default = () => (
     typeErrorText={e => `File ${e} is not the right file type`}
     sizeErrorText={e => `File ${e} is too large`}
     removeActionMessage={e => `Click to remove ${e}`}
-    acceptedMimeTypes={['image/jpeg']}
+    acceptedMimeTypes={['image/jpeg', 'image/png']}
     acceptedFileSize={1 * 1024 * 1024}
   />
 )


### PR DESCRIPTION
Actuellement l'event onChange est déclenché même en cas d'erreur, j'ai ajouté un flag pour ne pas le déclencher.
Le onError était aussi déclenché systématiquement, je vérifie maintenant si le tableau d'erreur contient au moins une erreur


TODO:

- [x] Tests
- [x] Changelog
