### PR TITLE
[DocumentsDropUploader] Hide files with errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fix: `HorizontalCrowdfundingCard`: Fix mobile style for `progress`.
 - Feature: Change `XXS`/`XS` boundary to 400px, from 480px.
-- Feature: `DocumentsDropUploader` Hide files with errors.
+- Feature: `DocumentsDropUploader`: Hide files with errors.
+- Feature: `DocumentsDropUploader`: New `managerInfo` prop.
 
 ## [4.1.0] - 2021-08-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fix: `HorizontalCrowdfundingCard`: Fix mobile style for `progress`.
 - Feature: Change `XXS`/`XS` boundary to 400px, from 480px.
+- Feature: `DocumentsDropUploader` Hide files with errors.
 
 ## [4.1.0] - 2021-08-02
 

--- a/assets/javascripts/kitten/components/molecules/upload/documents-drop-uploader/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/molecules/upload/documents-drop-uploader/__snapshots__/test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<DocumentsDropUploader /> should match snapshot 1`] = `
 <div
-  className="sc-bwzfXH bcpVPl k-DocumentsDropUploader k-DocumentsDropUploader--ready"
+  className="sc-bwzfXH cgMRjw k-DocumentsDropUploader k-DocumentsDropUploader--ready"
   onDragEnter={[Function]}
   onDragLeave={[Function]}
   onDragOver={[Function]}
@@ -64,7 +64,7 @@ exports[`<DocumentsDropUploader /> should match snapshot 1`] = `
 
 exports[`<DocumentsDropUploader /> should match snapshot disabled 1`] = `
 <div
-  className="sc-bwzfXH bcpVPl k-DocumentsDropUploader k-DocumentsDropUploader--ready k-DocumentsDropUploader--disabled"
+  className="sc-bwzfXH cgMRjw k-DocumentsDropUploader k-DocumentsDropUploader--ready k-DocumentsDropUploader--disabled"
   onDragEnter={[Function]}
   onDragLeave={[Function]}
   onDragOver={[Function]}
@@ -126,7 +126,7 @@ exports[`<DocumentsDropUploader /> should match snapshot disabled 1`] = `
 
 exports[`<DocumentsDropUploader /> should match snapshot disabled 2`] = `
 <div
-  className="sc-bwzfXH bcpVPl k-DocumentsDropUploader k-DocumentsDropUploader--ready k-DocumentsDropUploader--disabled"
+  className="sc-bwzfXH cgMRjw k-DocumentsDropUploader k-DocumentsDropUploader--ready k-DocumentsDropUploader--disabled"
   onDragEnter={[Function]}
   onDragLeave={[Function]}
   onDragOver={[Function]}
@@ -192,7 +192,7 @@ exports[`<DocumentsDropUploader /> should match snapshot disabled 2`] = `
 exports[`<DocumentsDropUploader /> should match snapshot with error 1`] = `
 Array [
   <div
-    className="sc-bwzfXH bcpVPl k-DocumentsDropUploader k-DocumentsDropUploader--error"
+    className="sc-bwzfXH cgMRjw k-DocumentsDropUploader k-DocumentsDropUploader--error"
     onDragEnter={[Function]}
     onDragLeave={[Function]}
     onDragOver={[Function]}
@@ -296,7 +296,7 @@ Array [
 
 exports[`<DocumentsDropUploader /> should match snapshot with many props 1`] = `
 <div
-  className="sc-bwzfXH bcpVPl k-DocumentsDropUploader k-DocumentsDropUploader--ready"
+  className="sc-bwzfXH cgMRjw k-DocumentsDropUploader k-DocumentsDropUploader--ready"
   onDragEnter={[Function]}
   onDragLeave={[Function]}
   onDragOver={[Function]}
@@ -391,7 +391,7 @@ exports[`<DocumentsDropUploader /> should match snapshot with many props 1`] = `
 
 exports[`<DocumentsDropUploader /> should match snapshot without props 1`] = `
 <div
-  className="sc-bwzfXH bcpVPl k-DocumentsDropUploader k-DocumentsDropUploader--ready"
+  className="sc-bwzfXH cgMRjw k-DocumentsDropUploader k-DocumentsDropUploader--ready"
   onDragEnter={[Function]}
   onDragLeave={[Function]}
   onDragOver={[Function]}

--- a/assets/javascripts/kitten/components/molecules/upload/documents-drop-uploader/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/molecules/upload/documents-drop-uploader/__snapshots__/test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<DocumentsDropUploader /> should match snapshot 1`] = `
 <div
-  className="sc-bwzfXH fJRRrS k-DocumentsDropUploader k-DocumentsDropUploader--ready"
+  className="sc-bwzfXH douyUy k-DocumentsDropUploader k-DocumentsDropUploader--ready"
   onDragEnter={[Function]}
   onDragLeave={[Function]}
   onDragOver={[Function]}
@@ -38,6 +38,11 @@ exports[`<DocumentsDropUploader /> should match snapshot 1`] = `
     >
       
     </div>
+    <div
+      className="k-DocumentsDropUploader__info"
+    >
+      
+    </div>
     <input
       accept=""
       aria-describedby={null}
@@ -59,7 +64,7 @@ exports[`<DocumentsDropUploader /> should match snapshot 1`] = `
 
 exports[`<DocumentsDropUploader /> should match snapshot disabled 1`] = `
 <div
-  className="sc-bwzfXH fJRRrS k-DocumentsDropUploader k-DocumentsDropUploader--ready k-DocumentsDropUploader--disabled"
+  className="sc-bwzfXH douyUy k-DocumentsDropUploader k-DocumentsDropUploader--ready k-DocumentsDropUploader--disabled"
   onDragEnter={[Function]}
   onDragLeave={[Function]}
   onDragOver={[Function]}
@@ -95,6 +100,11 @@ exports[`<DocumentsDropUploader /> should match snapshot disabled 1`] = `
     >
       Nullam quis risus eget urna mollis ornare vel eu leo. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.
     </div>
+    <div
+      className="k-DocumentsDropUploader__info"
+    >
+      
+    </div>
     <input
       accept=""
       aria-describedby={null}
@@ -116,7 +126,7 @@ exports[`<DocumentsDropUploader /> should match snapshot disabled 1`] = `
 
 exports[`<DocumentsDropUploader /> should match snapshot disabled 2`] = `
 <div
-  className="sc-bwzfXH fJRRrS k-DocumentsDropUploader k-DocumentsDropUploader--manage k-DocumentsDropUploader--disabled"
+  className="sc-bwzfXH douyUy k-DocumentsDropUploader k-DocumentsDropUploader--ready k-DocumentsDropUploader--disabled"
   onDragEnter={[Function]}
   onDragLeave={[Function]}
   onDragOver={[Function]}
@@ -182,7 +192,7 @@ exports[`<DocumentsDropUploader /> should match snapshot disabled 2`] = `
 exports[`<DocumentsDropUploader /> should match snapshot with error 1`] = `
 Array [
   <div
-    className="sc-bwzfXH fJRRrS k-DocumentsDropUploader k-DocumentsDropUploader--error"
+    className="sc-bwzfXH douyUy k-DocumentsDropUploader k-DocumentsDropUploader--error"
     onDragEnter={[Function]}
     onDragLeave={[Function]}
     onDragOver={[Function]}
@@ -213,11 +223,44 @@ Array [
       >
         Upload your ID documents
       </div>
-      <div
-        className="k-DocumentsDropUploader__text"
+      <ul
+        className="k-DocumentsDropUploader__fileList"
       >
-        Nullam quis risus eget urna mollis ornare vel eu leo. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.
-      </div>
+        <li
+          className="sc-bdVaJa lajXQg k-Tag k-DocumentsDropUploader__file k-Tag--info"
+        >
+          <span
+            className="k-DocumentsDropUploader__file__text"
+          >
+            kitten.jpg
+          </span>
+          <button
+            className="k-DocumentsDropUploader__file__button k-u-reset-button"
+            onClick={[Function]}
+            type="button"
+          >
+            <span
+              className="k-u-a11y-visuallyHidden"
+            >
+              Remove kitten.jpg from the list
+            </span>
+            <svg
+              fill="currentColor"
+              height={8}
+              viewBox="0 0 8 8"
+              width={8}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M.464 6.12L6.12.465 7.537 1.88 1.88 7.535z"
+              />
+              <path
+                d="M1.88.464L7.535 6.12 6.12 7.537.465 1.88z"
+              />
+            </svg>
+          </button>
+        </li>
+      </ul>
       <input
         accept=""
         aria-describedby="DocumentsDropUploader-error-description"
@@ -253,7 +296,7 @@ Array [
 
 exports[`<DocumentsDropUploader /> should match snapshot with many props 1`] = `
 <div
-  className="sc-bwzfXH fJRRrS k-DocumentsDropUploader k-DocumentsDropUploader--manage"
+  className="sc-bwzfXH douyUy k-DocumentsDropUploader k-DocumentsDropUploader--ready"
   onDragEnter={[Function]}
   onDragLeave={[Function]}
   onDragOver={[Function]}
@@ -348,7 +391,7 @@ exports[`<DocumentsDropUploader /> should match snapshot with many props 1`] = `
 
 exports[`<DocumentsDropUploader /> should match snapshot without props 1`] = `
 <div
-  className="sc-bwzfXH fJRRrS k-DocumentsDropUploader k-DocumentsDropUploader--ready"
+  className="sc-bwzfXH douyUy k-DocumentsDropUploader k-DocumentsDropUploader--ready"
   onDragEnter={[Function]}
   onDragLeave={[Function]}
   onDragOver={[Function]}
@@ -381,6 +424,11 @@ exports[`<DocumentsDropUploader /> should match snapshot without props 1`] = `
     </div>
     <div
       className="k-DocumentsDropUploader__text"
+    >
+      
+    </div>
+    <div
+      className="k-DocumentsDropUploader__info"
     >
       
     </div>

--- a/assets/javascripts/kitten/components/molecules/upload/documents-drop-uploader/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/molecules/upload/documents-drop-uploader/__snapshots__/test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<DocumentsDropUploader /> should match snapshot 1`] = `
 <div
-  className="sc-bwzfXH douyUy k-DocumentsDropUploader k-DocumentsDropUploader--ready"
+  className="sc-bwzfXH kxjbuR k-DocumentsDropUploader k-DocumentsDropUploader--ready"
   onDragEnter={[Function]}
   onDragLeave={[Function]}
   onDragOver={[Function]}
@@ -64,7 +64,7 @@ exports[`<DocumentsDropUploader /> should match snapshot 1`] = `
 
 exports[`<DocumentsDropUploader /> should match snapshot disabled 1`] = `
 <div
-  className="sc-bwzfXH douyUy k-DocumentsDropUploader k-DocumentsDropUploader--ready k-DocumentsDropUploader--disabled"
+  className="sc-bwzfXH kxjbuR k-DocumentsDropUploader k-DocumentsDropUploader--ready k-DocumentsDropUploader--disabled"
   onDragEnter={[Function]}
   onDragLeave={[Function]}
   onDragOver={[Function]}
@@ -126,7 +126,7 @@ exports[`<DocumentsDropUploader /> should match snapshot disabled 1`] = `
 
 exports[`<DocumentsDropUploader /> should match snapshot disabled 2`] = `
 <div
-  className="sc-bwzfXH douyUy k-DocumentsDropUploader k-DocumentsDropUploader--ready k-DocumentsDropUploader--disabled"
+  className="sc-bwzfXH kxjbuR k-DocumentsDropUploader k-DocumentsDropUploader--ready k-DocumentsDropUploader--disabled"
   onDragEnter={[Function]}
   onDragLeave={[Function]}
   onDragOver={[Function]}
@@ -192,7 +192,7 @@ exports[`<DocumentsDropUploader /> should match snapshot disabled 2`] = `
 exports[`<DocumentsDropUploader /> should match snapshot with error 1`] = `
 Array [
   <div
-    className="sc-bwzfXH douyUy k-DocumentsDropUploader k-DocumentsDropUploader--error"
+    className="sc-bwzfXH kxjbuR k-DocumentsDropUploader k-DocumentsDropUploader--error"
     onDragEnter={[Function]}
     onDragLeave={[Function]}
     onDragOver={[Function]}
@@ -296,7 +296,7 @@ Array [
 
 exports[`<DocumentsDropUploader /> should match snapshot with many props 1`] = `
 <div
-  className="sc-bwzfXH douyUy k-DocumentsDropUploader k-DocumentsDropUploader--ready"
+  className="sc-bwzfXH kxjbuR k-DocumentsDropUploader k-DocumentsDropUploader--ready"
   onDragEnter={[Function]}
   onDragLeave={[Function]}
   onDragOver={[Function]}
@@ -391,7 +391,7 @@ exports[`<DocumentsDropUploader /> should match snapshot with many props 1`] = `
 
 exports[`<DocumentsDropUploader /> should match snapshot without props 1`] = `
 <div
-  className="sc-bwzfXH douyUy k-DocumentsDropUploader k-DocumentsDropUploader--ready"
+  className="sc-bwzfXH kxjbuR k-DocumentsDropUploader k-DocumentsDropUploader--ready"
   onDragEnter={[Function]}
   onDragLeave={[Function]}
   onDragOver={[Function]}

--- a/assets/javascripts/kitten/components/molecules/upload/documents-drop-uploader/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/molecules/upload/documents-drop-uploader/__snapshots__/test.js.snap
@@ -218,44 +218,6 @@ Array [
       >
         Nullam quis risus eget urna mollis ornare vel eu leo. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.
       </div>
-      <ul
-        className="k-DocumentsDropUploader__fileList"
-      >
-        <li
-          className="sc-bdVaJa lajXQg k-Tag k-DocumentsDropUploader__file k-Tag--info"
-        >
-          <span
-            className="k-DocumentsDropUploader__file__text"
-          >
-            kitten.jpg
-          </span>
-          <button
-            className="k-DocumentsDropUploader__file__button k-u-reset-button"
-            onClick={[Function]}
-            type="button"
-          >
-            <span
-              className="k-u-a11y-visuallyHidden"
-            >
-              Remove kitten.jpg from the list
-            </span>
-            <svg
-              fill="currentColor"
-              height={8}
-              viewBox="0 0 8 8"
-              width={8}
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M.464 6.12L6.12.465 7.537 1.88 1.88 7.535z"
-              />
-              <path
-                d="M1.88.464L7.535 6.12 6.12 7.537.465 1.88z"
-              />
-            </svg>
-          </button>
-        </li>
-      </ul>
       <input
         accept=""
         aria-describedby="DocumentsDropUploader-error-description"

--- a/assets/javascripts/kitten/components/molecules/upload/documents-drop-uploader/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/molecules/upload/documents-drop-uploader/__snapshots__/test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<DocumentsDropUploader /> should match snapshot 1`] = `
 <div
-  className="sc-bwzfXH kxjbuR k-DocumentsDropUploader k-DocumentsDropUploader--ready"
+  className="sc-bwzfXH bcpVPl k-DocumentsDropUploader k-DocumentsDropUploader--ready"
   onDragEnter={[Function]}
   onDragLeave={[Function]}
   onDragOver={[Function]}
@@ -64,7 +64,7 @@ exports[`<DocumentsDropUploader /> should match snapshot 1`] = `
 
 exports[`<DocumentsDropUploader /> should match snapshot disabled 1`] = `
 <div
-  className="sc-bwzfXH kxjbuR k-DocumentsDropUploader k-DocumentsDropUploader--ready k-DocumentsDropUploader--disabled"
+  className="sc-bwzfXH bcpVPl k-DocumentsDropUploader k-DocumentsDropUploader--ready k-DocumentsDropUploader--disabled"
   onDragEnter={[Function]}
   onDragLeave={[Function]}
   onDragOver={[Function]}
@@ -126,7 +126,7 @@ exports[`<DocumentsDropUploader /> should match snapshot disabled 1`] = `
 
 exports[`<DocumentsDropUploader /> should match snapshot disabled 2`] = `
 <div
-  className="sc-bwzfXH kxjbuR k-DocumentsDropUploader k-DocumentsDropUploader--ready k-DocumentsDropUploader--disabled"
+  className="sc-bwzfXH bcpVPl k-DocumentsDropUploader k-DocumentsDropUploader--ready k-DocumentsDropUploader--disabled"
   onDragEnter={[Function]}
   onDragLeave={[Function]}
   onDragOver={[Function]}
@@ -192,7 +192,7 @@ exports[`<DocumentsDropUploader /> should match snapshot disabled 2`] = `
 exports[`<DocumentsDropUploader /> should match snapshot with error 1`] = `
 Array [
   <div
-    className="sc-bwzfXH kxjbuR k-DocumentsDropUploader k-DocumentsDropUploader--error"
+    className="sc-bwzfXH bcpVPl k-DocumentsDropUploader k-DocumentsDropUploader--error"
     onDragEnter={[Function]}
     onDragLeave={[Function]}
     onDragOver={[Function]}
@@ -296,7 +296,7 @@ Array [
 
 exports[`<DocumentsDropUploader /> should match snapshot with many props 1`] = `
 <div
-  className="sc-bwzfXH kxjbuR k-DocumentsDropUploader k-DocumentsDropUploader--ready"
+  className="sc-bwzfXH bcpVPl k-DocumentsDropUploader k-DocumentsDropUploader--ready"
   onDragEnter={[Function]}
   onDragLeave={[Function]}
   onDragOver={[Function]}
@@ -391,7 +391,7 @@ exports[`<DocumentsDropUploader /> should match snapshot with many props 1`] = `
 
 exports[`<DocumentsDropUploader /> should match snapshot without props 1`] = `
 <div
-  className="sc-bwzfXH kxjbuR k-DocumentsDropUploader k-DocumentsDropUploader--ready"
+  className="sc-bwzfXH bcpVPl k-DocumentsDropUploader k-DocumentsDropUploader--ready"
   onDragEnter={[Function]}
   onDragLeave={[Function]}
   onDragOver={[Function]}

--- a/assets/javascripts/kitten/components/molecules/upload/documents-drop-uploader/index.js
+++ b/assets/javascripts/kitten/components/molecules/upload/documents-drop-uploader/index.js
@@ -102,11 +102,13 @@ const StyledDocumentsDropUploader = styled.div`
   .k-DocumentsDropUploader__title {
     ${TYPOGRAPHY.fontStyles.regular}
     font-size: ${stepToRem(-1)};
+    line-height: 1;
   }
   .k-DocumentsDropUploader__text,
   .k-DocumentsDropUploader__info {
     ${TYPOGRAPHY.fontStyles.light}
     font-size: ${stepToRem(-2)};
+    line-height: ${pxToRem(16)};
 
     &:empty {
       display: none;

--- a/assets/javascripts/kitten/components/molecules/upload/documents-drop-uploader/index.js
+++ b/assets/javascripts/kitten/components/molecules/upload/documents-drop-uploader/index.js
@@ -288,9 +288,7 @@ export const DocumentsDropUploader = ({
   }, [errorList])
 
   useEffect(() => {
-    if (fileList.length !== fileListWithoutErrors.length) return
-
-    onChange(fileList)
+    onChange(fileListWithoutErrors)
   }, [fileListWithoutErrors])
 
   const removeFilesFromList = file => {

--- a/assets/javascripts/kitten/components/molecules/upload/documents-drop-uploader/index.js
+++ b/assets/javascripts/kitten/components/molecules/upload/documents-drop-uploader/index.js
@@ -72,7 +72,7 @@ const StyledDocumentsDropUploader = styled.div`
   }
 
   &.k-DocumentsDropUploader--error {
-    border-color: ${COLORS.error2};
+    border-color: ${COLORS.error3};
   }
 
   &.k-DocumentsDropUploader--disabled {

--- a/assets/javascripts/kitten/components/molecules/upload/documents-drop-uploader/index.js
+++ b/assets/javascripts/kitten/components/molecules/upload/documents-drop-uploader/index.js
@@ -107,6 +107,10 @@ const StyledDocumentsDropUploader = styled.div`
   .k-DocumentsDropUploader__info {
     ${TYPOGRAPHY.fontStyles.light}
     font-size: ${stepToRem(-2)};
+
+    &:empty {
+      display: none;
+    }
   }
   .k-DocumentsDropUploader__info {
     color: ${COLORS.grey1};

--- a/assets/javascripts/kitten/components/molecules/upload/documents-drop-uploader/index.js
+++ b/assets/javascripts/kitten/components/molecules/upload/documents-drop-uploader/index.js
@@ -9,6 +9,7 @@ import { UploadIcon } from '../../../../components/graphics/icons/upload-icon'
 import { CrossIcon } from '../../../../components/graphics/icons/cross-icon'
 import { Text } from '../../../../components/atoms/typography/text'
 import { Tag } from '../../../../components/atoms/tag'
+import difference from 'lodash/fp/difference'
 
 const StyledDocumentsDropUploader = styled.div`
   border-radius: ${pxToRem(8)};
@@ -186,6 +187,7 @@ export const DocumentsDropUploader = ({
   const [isDraggingOver, setDraggingOver] = useState(false)
   const [fileList, setFileList] = useState(initialValue)
   const [errorList, setErrorList] = useState([])
+  const [fileListWithoutErrors, setFileListWithoutErrors] = useState([])
   const [internalErrorMessageList, setErrorMessageList] = useState([
     errorMessageList,
   ])
@@ -273,14 +275,23 @@ export const DocumentsDropUploader = ({
         }
       }
     })
-    if (isValid) onChange(fileList)
   }, [fileList])
 
   useEffect(() => {
+    setFileListWithoutErrors(
+      difference(fileList)(errorList.map(error => error.file))
+    )
+
     if (errorList.length === 0) return
 
     onError(errorList)
   }, [errorList])
+
+  useEffect(() => {
+    if (fileList.length !== fileListWithoutErrors.length) return
+
+    onChange(fileList)
+  }, [fileListWithoutErrors])
 
   const removeFilesFromList = file => {
     setFileList(currentList => currentList.filter(item => item !== file))
@@ -331,11 +342,11 @@ export const DocumentsDropUploader = ({
             <div className="k-DocumentsDropUploader__text">{managerText}</div>
           )}
 
-          {fileList.length > 0 && (
+          {fileListWithoutErrors.length > 0 && (
             <ul className="k-DocumentsDropUploader__fileList">
               {['error', 'manage'].includes(internalStatus) && (
                 <>
-                  {fileList.map((file, index) => (
+                  {fileListWithoutErrors.map((file, index) => (
                     <Tag
                       key={file.name + index}
                       as="li"
@@ -406,9 +417,9 @@ export const DocumentsDropUploader = ({
             className="k-DocumentsDropUploader__errorList"
             id={`${id}-error-description`}
           >
-            {internalErrorMessageList.map(errorMsg => (
+            {internalErrorMessageList.map((errorMsg, index) => (
               <Text
-                key={errorMsg}
+                key={errorMsg + index}
                 as="li"
                 size="micro"
                 color="error"

--- a/assets/javascripts/kitten/components/molecules/upload/documents-drop-uploader/stories.js
+++ b/assets/javascripts/kitten/components/molecules/upload/documents-drop-uploader/stories.js
@@ -14,6 +14,7 @@ export const Default = () => (
     labelText="Add a document"
     managerTitle="Upload your ID documents"
     managerText="Nullam quis risus eget urna mollis ornare vel eu leo. Morbi leo risus, porta ac consectetur ac, vestibulum at eros."
+    managerInfo="(Max: 1MB, Formats: JPG, PNG, SVG)"
     onChange={action('onChange')}
     onError={action('onError')}
     disabled={boolean('Disabled?', false)}
@@ -33,21 +34,13 @@ export const Manage = () => (
     labelText="Add a document"
     managerTitle="Upload your ID documents"
     managerText="Nullam quis risus eget urna mollis ornare vel eu leo. Morbi leo risus, porta ac consectetur ac, vestibulum at eros."
+    managerInfo="(Max: 1MB, Formats: JPG, PNG, SVG)"
     initialValue={[{ name: 'kitten.jpg' }]}
     onChange={action('onChange')}
     onError={action('onError')}
     disabled={boolean('Disabled?', false)}
     status={
-      boolean('Error?', false)
-        ? 'error'
-        : select('Status', [
-            'ready',
-            'manage',
-            'wait',
-            'accepted',
-            'denied',
-            'error',
-          ])
+      boolean('Error?', false) ? 'error' : select('Status', ['ready', 'error'])
     }
     errorMessageMessage={text('ErrorMessage', null)}
     typeErrorText={e => `File ${e} is not the right file type`}

--- a/assets/javascripts/kitten/components/molecules/upload/documents-drop-uploader/stories.js
+++ b/assets/javascripts/kitten/components/molecules/upload/documents-drop-uploader/stories.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { DocumentsDropUploader } from './index'
 import { boolean, text, select } from '@storybook/addon-knobs'
+import { action } from '@storybook/addon-actions'
 
 export default {
   component: DocumentsDropUploader,
@@ -13,16 +14,16 @@ export const Default = () => (
     labelText="Add a document"
     managerTitle="Upload your ID documents"
     managerText="Nullam quis risus eget urna mollis ornare vel eu leo. Morbi leo risus, porta ac consectetur ac, vestibulum at eros."
-    onChange={e => console.warn('onChange', e)}
-    onError={e => console.warn('onError', e)}
+    onChange={action('onChange')}
+    onError={action('onError')}
     disabled={boolean('Disabled?', false)}
     status={select('Status', ['ready', 'manage', 'error'], 'ready')}
     errorMessage={text('ErrorMessage', null)}
     typeErrorText={e => `File ${e} is not the right file type`}
     sizeErrorText={e => `File ${e} is too large`}
     removeActionMessage={e => `Click to remove ${e}`}
-    acceptedMimeTypes={['image/jpeg', 'image/png']}
     acceptedFileSize={1 * 1024 * 1024}
+    acceptedMimeTypes={['image/jpeg', 'image/png', 'image/svg+xml']}
   />
 )
 
@@ -33,8 +34,8 @@ export const Manage = () => (
     managerTitle="Upload your ID documents"
     managerText="Nullam quis risus eget urna mollis ornare vel eu leo. Morbi leo risus, porta ac consectetur ac, vestibulum at eros."
     initialValue={[{ name: 'kitten.jpg' }]}
-    onChange={e => console.warn('onChange', e)}
-    onError={e => console.warn('onError', e)}
+    onChange={action('onChange')}
+    onError={action('onError')}
     disabled={boolean('Disabled?', false)}
     status={
       boolean('Error?', false)


### PR DESCRIPTION
Closes #.

Vercel link:

- https://kitten-git-documents-drop-uploader-hide-e71861-kisskissbankbank.vercel.app/?path=/story/molecules-upload-documentsdropuploader--default

Screenshot:


TODO:

- [x] Tests
- [x] Changelog
- [x] A11Y
- [x] Stories / Docs
- [ ] BrowserStack (IE11, Chrome & Firefox on Windows 10)
- [ ] New component added to `assets/javascripts/kitten/index.js`
