### PR TITLE
[Modal/Next] Add `headerMessage` prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Feature: Change `XXS`/`XS` boundary to 400px, from 480px.
 - Feature: `DocumentsDropUploader`: Hide files with errors.
 - Feature: `DocumentsDropUploader`: New `managerInfo` prop.
+- Feature: `Modal/Next`: Add `headerMessage` prop, with empty defaults.
 
 ## [4.1.0] - 2021-08-02
 

--- a/assets/javascripts/kitten/components/molecules/modal-next/Modal.stories.js
+++ b/assets/javascripts/kitten/components/molecules/modal-next/Modal.stories.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { text, boolean, number, select } from '@storybook/addon-knobs'
 import { Modal } from './index'
-import { Button, Text, SaveIcon } from '../../..'
+import { Button, Text, SaveIcon, COLORS } from '../../..'
 
 const paragraphContainer = `
   Sed ut perspiciatis unde omnis iste natus error sit voluptatem
@@ -159,15 +159,6 @@ export const FullSize = () => (
   </Modal>
 )
 
-const OrionHeaderTitle = () => {
-  return (
-    <p>
-      <strong>Hello world !</strong>
-      <br />
-      Hey
-    </p>
-  )
-}
 const OrionHeaderActions = ({ close }) => (
   <>
     <Button
@@ -200,8 +191,13 @@ export const ComplexWithOrion = () => (
   <Modal
     trigger={<Button modifier="helium">Open</Button>}
     variant="orion"
-    headerTitle={<OrionHeaderTitle />}
+    headerTitle={<Text weight="bold" size="giant">Modal title</Text>}
     headerActions={OrionHeaderActions}
+    headerMessage={
+      <Text size="micro" weight="light" cssColor={COLORS.grey1}>
+        {text('headerMessage', '')}
+      </Text>
+    }
     size={select('Size', ['regular', 'big', 'huge', 'giant'], 'giant')}
   >
     {() => (

--- a/assets/javascripts/kitten/components/molecules/modal-next/index.js
+++ b/assets/javascripts/kitten/components/molecules/modal-next/index.js
@@ -165,6 +165,23 @@ const GlobalStyle = createGlobalStyle`
         min-width: ${pxToRem(40)};
         text-align: right;
       }
+
+      .k-ModalNext__header__message {
+        position: absolute;
+        top: 0;
+        height: 100%;
+        display: flex;
+        align-items: center;
+        left: ${pxToRem(CONTAINER_PADDING_THIN + 40 + 35)};
+
+        &:empty {
+          display: none;
+        }
+
+        @media (min-width: ${pxToRem(ScreenConfig.S.min)}) {
+          left: ${pxToRem(CONTAINER_PADDING + 40 + 35)};
+        }
+      }
     }
 
     .k-ModalNext__closeButton {
@@ -641,6 +658,7 @@ const InnerModal = ({
   variant,
   headerTitle,
   headerActions,
+  headerMessage,
   contentCols,
   headerZIndex,
   ...others
@@ -734,6 +752,7 @@ const InnerModal = ({
                     variant={variant}
                     size={variant === 'orion' ? 'regular' : 'micro'}
                     closeButtonLabel={closeButtonLabel}
+                    aria-labelledby={!!headerMessage ? 'ModalHeaderMessage' : null}
                   />
                 )}
               </div>
@@ -747,6 +766,12 @@ const InnerModal = ({
                   </Text>
                 )}
               </div>
+
+              {!!headerMessage && (
+                <div className="k-ModalNext__header__message" id="ModalHeaderMessage">
+                  {headerMessage}
+                </div>
+              )}
 
               <div className="k-ModalNext__header__actions">
                 {headerActions &&
@@ -823,6 +848,7 @@ Modal.propTypes = {
   variant: PropTypes.oneOf(['andromeda', 'orion']),
   headerTitle: PropTypes.node,
   headerActions: PropTypes.func,
+  headerMessage: PropTypes.node,
   contentCols: PropTypes.object,
   headerZIndex: PropTypes.number,
 }
@@ -842,6 +868,7 @@ Modal.defaultProps = {
   variant: 'andromeda',
   headerTitle: null,
   headerActions: null,
+  headerMessage: null,
   contentCols: {},
   headerZIndex: 10,
 }


### PR DESCRIPTION
Closes #.

Vercel link:

- [https://kitten-git-modal-next-add-header-message-prop-kisskissbankbank.vercel.app/iframe.html?id=molecules-modal-next--complex-with-orion&args=&knob-headerMessage=This%20is%20a%20new%20message&knob-Size=giant&knob-content=…?&viewMode=story](https://kitten-git-modal-next-add-header-message-prop-kisskissbankbank.vercel.app/iframe.html?id=molecules-modal-next--complex-with-orion&args=&knob-headerMessage=This%20is%20a%20new%20message&knob-Size=giant&knob-content=%20%20Sed%20ut%20perspiciatis%20unde%20omnis%20iste%20natus%20error%20sit%20voluptatem%20%20accusantium%20doloremque%20laudantium,%20totam%20rem%20aperiam,%20eaque%20ipsa%20%20quae%20ab%20illo%20inventore%20veritatis%20et%20quasi%20architecto%20beatae%20vitae%20%20dicta%20sunt%20explicabo.%20Nemo%20enim%20ipsam%20voluptatem%20quia%20voluptas%20sit%20%20aspernatur%20aut%20odit%20aut%20fugit,%20sed%20quia%20consequuntur%20magni%20dolores%20%20eos%20qui%20ratione%20voluptatem%20sequi%20nesciunt.%20Neque%20porro%20quisquam%20est,%20%20qui%20dolorem%20ipsum%20quia%20dolor%20sit%20amet,%20consectetur,%20adipisci%20velit,%20%20sed%20quia%20non%20numquam%20eius%20modi%20tempora%20incidunt%20ut%20labore%20et%20dolore%20%20magnam%20aliquam%20quaerat%20voluptatem.%20Ut%20enim%20ad%20minima%20veniam,%20quis%20%20nostrum%20exercitationem%20ullam%20corporis%20suscipit%20laboriosam,%20nisi%20ut%20%20aliquid%20ex%20ea%20commodi%20consequatur?%20Quis%20autem%20vel%20eum%20iure%20%20reprehenderit%20qui%20in%20ea%20voluptate%20velit%20esse%20quam%20nihil%20molestiae%20%20consequatur,%20vel%20illum%20qui%20dolorem%20eum%20fugiat%20quo%20voluptas%20nulla%20%20pariatur?%20Sed%20ut%20perspiciatis%20unde%20omnis%20iste%20natus%20error%20sit%20%20voluptatem%20accusantium%20doloremque%20laudantium,%20totam%20rem%20aperiam,%20%20eaque%20ipsa%20quae%20ab%20illo%20inventore%20veritatis%20et%20quasi%20architecto%20%20beatae%20vitae%20dicta%20sunt%20explicabo.%20Nemo%20enim%20ipsam%20voluptatem%20quia%20%20voluptas%20sit%20aspernatur%20aut%20odit%20aut%20fugit,%20sed%20quia%20consequuntur%20%20magni%20dolores%20eos%20qui%20ratione%20voluptatem%20sequi%20nesciunt.%20Neque%20porro%20%20quisquam%20est,%20qui%20dolorem%20ipsum%20quia%20dolor%20sit%20amet,%20consectetur,%20%20adipisci%20velit,%20sed%20quia%20non%20numquam%20eius%20modi%20tempora%20incidunt%20ut%20%20labore%20et%20dolore%20magnam%20aliquam%20quaerat%20voluptatem.%20Ut%20enim%20ad%20%20minima%20veniam,%20quis%20nostrum%20exercitationem%20ullam%20corporis%20suscipit%20%20laboriosam,%20nisi%20ut%20aliquid%20ex%20ea%20commodi%20consequatur?%20Quis%20autem%20%20vel%20eum%20iure%20reprehenderit%20qui%20in%20ea%20voluptate%20velit%20esse%20quam%20nihil%20%20molestiae%20consequatur,%20vel%20illum%20qui%20dolorem%20eum%20fugiat%20quo%20voluptas%20%20nulla%20pariatur?&viewMode=story)

Screenshot:

![image](https://user-images.githubusercontent.com/1781070/128498007-826e524b-8cd2-4705-96fc-2aafdc3f3b05.png)

TODO:

- [ ] Tests
- [ ] Changelog
- [ ] A11Y
- [ ] Stories / Docs
- [ ] BrowserStack (IE11, Chrome & Firefox on Windows 10)
- [ ] New component added to `assets/javascripts/kitten/index.js`
