### PR TITLE
[DashboardLayout] Fix `Flow.Nav` single button mobile width with new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Feature: Change `XXS`/`XS` boundary to 400px, from 480px.
 - Feature: `DocumentsDropUploader`: Hide files with errors.
 - Feature: `DocumentsDropUploader`: New `managerInfo` prop.
+- Feature: `DashboardLayout.Flow.Nav`: Add `twoButtons` prop, defaults to false.
 
 ## [4.1.0] - 2021-08-02
 

--- a/assets/javascripts/kitten/components/layout/dashboard-layout/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/layout/dashboard-layout/__snapshots__/test.js.snap
@@ -102,23 +102,19 @@ exports[`<DashboardLayout /> <DefaultLayout.Flow /> matches with snapshot 1`] = 
 
 .c0 .k-DashboardLayout__flow__nav__actionsContainer {
   display: grid;
-  margin: 1.25rem 0;
-  gap: 1.25rem;
   grid-template-columns: repeat(2,1fr);
+  gap: 1.25rem;
+  margin: 1.25rem 0;
 }
 
-.c0 .k-DashboardLayout__flow__nav__actionsContainer > * {
+.c0 .k-DashboardLayout__flow__nav__actionsContainer > .k-Button {
   min-width: 0 !important;
   max-width: 11.25rem;
   width: 100%;
 }
 
-.c0 .k-DashboardLayout__flow__nav__actionsContainer > *:last-child {
+.c0 .k-DashboardLayout__flow__nav__actionsContainer > .k-Button:last-child {
   justify-self: end;
-}
-
-.c0 .k-DashboardLayout__flow__nav__actionsContainer > *:first-child:last-child {
-  grid-column: 1 / span 2;
 }
 
 .c0 .k-DashboardLayout__flow__aside__content {
@@ -208,8 +204,16 @@ exports[`<DashboardLayout /> <DefaultLayout.Flow /> matches with snapshot 1`] = 
 
 @media (min-width:67.5rem) {
   .c0 .k-DashboardLayout__flow__nav__actionsContainer {
-    margin: 1.25rem 0 1.875rem;
     gap: 2.5rem;
+    margin: 1.25rem 0 1.875rem;
+  }
+}
+
+@media (max-width:39.9375rem) {
+  .c0 .k-DashboardLayout__flow__nav:not(.k-DashboardLayout__flow__nav--twoButtons) .k-DashboardLayout__flow__nav__actionsContainer > .k-Button {
+    grid-column: 1 / span 2;
+    justify-self: stretch;
+    max-width: 100%;
   }
 }
 
@@ -442,23 +446,19 @@ exports[`<DashboardLayout /> <DefaultLayout.Flow loading /> matches with snapsho
 
 .c0 .k-DashboardLayout__flow__nav__actionsContainer {
   display: grid;
-  margin: 1.25rem 0;
-  gap: 1.25rem;
   grid-template-columns: repeat(2,1fr);
+  gap: 1.25rem;
+  margin: 1.25rem 0;
 }
 
-.c0 .k-DashboardLayout__flow__nav__actionsContainer > * {
+.c0 .k-DashboardLayout__flow__nav__actionsContainer > .k-Button {
   min-width: 0 !important;
   max-width: 11.25rem;
   width: 100%;
 }
 
-.c0 .k-DashboardLayout__flow__nav__actionsContainer > *:last-child {
+.c0 .k-DashboardLayout__flow__nav__actionsContainer > .k-Button:last-child {
   justify-self: end;
-}
-
-.c0 .k-DashboardLayout__flow__nav__actionsContainer > *:first-child:last-child {
-  grid-column: 1 / span 2;
 }
 
 .c0 .k-DashboardLayout__flow__aside__content {
@@ -548,8 +548,16 @@ exports[`<DashboardLayout /> <DefaultLayout.Flow loading /> matches with snapsho
 
 @media (min-width:67.5rem) {
   .c0 .k-DashboardLayout__flow__nav__actionsContainer {
-    margin: 1.25rem 0 1.875rem;
     gap: 2.5rem;
+    margin: 1.25rem 0 1.875rem;
+  }
+}
+
+@media (max-width:39.9375rem) {
+  .c0 .k-DashboardLayout__flow__nav:not(.k-DashboardLayout__flow__nav--twoButtons) .k-DashboardLayout__flow__nav__actionsContainer > .k-Button {
+    grid-column: 1 / span 2;
+    justify-self: stretch;
+    max-width: 100%;
   }
 }
 

--- a/assets/javascripts/kitten/components/layout/dashboard-layout/flow/index.js
+++ b/assets/javascripts/kitten/components/layout/dashboard-layout/flow/index.js
@@ -88,25 +88,33 @@ const StyledFlow = styled.div`
 
   .k-DashboardLayout__flow__nav__actionsContainer {
     display: grid;
-    margin: ${pxToRem(20)} 0;
-    gap: ${pxToRem(20)};
     grid-template-columns: repeat(2, 1fr);
+    gap: ${pxToRem(20)};
+    margin: ${pxToRem(20)} 0;
 
     @media (min-width: ${pxToRem(ScreenConfig.L.min)}) {
-      margin: ${pxToRem(20)} 0 ${pxToRem(30)};
       gap: ${pxToRem(40)};
+      margin: ${pxToRem(20)} 0 ${pxToRem(30)};
     }
 
-    & > * {
+    & > .k-Button {
       min-width: 0 !important;
       max-width: ${pxToRem(180)};
       width: 100%;
+
+      &:last-child {
+        justify-self: end;
+      }
     }
-    & > *:last-child {
-      justify-self: end;
-    }
-    & > *:first-child:last-child {
-      grid-column: 1 / span 2;
+  }
+
+  .k-DashboardLayout__flow__nav:not(.k-DashboardLayout__flow__nav--twoButtons) {
+    .k-DashboardLayout__flow__nav__actionsContainer > .k-Button {
+      @media (max-width: ${pxToRem(ScreenConfig.XS.max)}) {
+        grid-column: 1 / span 2;
+        justify-self: stretch;
+        max-width: 100%;
+      }
     }
   }
 
@@ -146,11 +154,13 @@ const Content = ({ className, ...props }) => {
   )
 }
 
-const Nav = ({ className, children, ...props }) => {
+const Nav = ({ className, children, twoButtons = false, ...props }) => {
   return (
     <nav
       {...props}
-      className={classNames('k-DashboardLayout__flow__nav', className)}
+      className={classNames('k-DashboardLayout__flow__nav', className, {
+        'k-DashboardLayout__flow__nav--twoButtons': twoButtons,
+      })}
     >
       <div className="k-DashboardLayout__flow__nav__actionsContainer">
         {children}

--- a/assets/javascripts/kitten/components/layout/dashboard-layout/stories.js
+++ b/assets/javascripts/kitten/components/layout/dashboard-layout/stories.js
@@ -477,22 +477,24 @@ const FlowExample = () => (
         </DashboardLayout.Flow.AsideCard.List>
       </DashboardLayout.Flow.AsideCard>
     </DashboardLayout.Flow.Aside>
-    <DashboardLayout.Flow.Nav>
-      {boolean('Show 2 buttons', true) && (
+    <DashboardLayout.Flow.Nav twoButtons={boolean('Show 2 buttons', false)}>
+      {boolean('Show 2 buttons', false) ? (
         <Button
           modifier="hydrogen"
           variant="orion"
-          size="big"
           type="button"
           disabled={boolean('loading', false)}
         >
           Back
         </Button>
+      ) : (
+        <Text weight="light" className="k-u-hidden@xs-down" style={{ alignSelf: 'center'}}>
+          Message
+        </Text>
       )}
       <Button
         modifier="helium"
         variant="orion"
-        size="big"
         type="button"
         disabled={boolean('loading', false)}
       >

--- a/assets/javascripts/kitten/components/molecules/upload/documents-status-box/index.js
+++ b/assets/javascripts/kitten/components/molecules/upload/documents-status-box/index.js
@@ -93,7 +93,7 @@ export const DocumentsStatusBox = ({
           className="k-DocumentsStatusBox__title k-u-margin-top-none k-u-margin-bottom-noneHalf"
           weight="regular"
           size="tiny"
-          lineHeight={1}
+          lineHeight="1"
         >
           {title}
         </Text>


### PR DESCRIPTION
Closes #.

Vercel link:

- https://kitten-git-…

Screenshot:


TODO:

- [ ] Tests
- [ ] Changelog
- [ ] A11Y
- [ ] Stories / Docs
- [ ] BrowserStack (IE11, Chrome & Firefox on Windows 10)
- [ ] New component added to `assets/javascripts/kitten/index.js`
