### PR TITLE
[Range] When value is present the range is controlled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
-- Fix: `RangeSlider` : Turn to be controlled when `value` prop is passed.
+- Fix: `RangeSlider`: Turn to be controlled when `value` prop is passed.
 
 ## [4.5.0] - 2021-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: `RangeSlider` : Turn to be controlled when `value` prop is passed.
+
 ## [4.5.0] - 2021-09-02
 
 Features:

--- a/assets/javascripts/kitten/components/form/range-slider/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/form/range-slider/__snapshots__/test.js.snap
@@ -41,3 +41,25 @@ exports[`<RangeSlider /> should match its snapshot with props 1`] = `
   />
 </div>
 `;
+
+exports[`<RangeSlider /> should set unbounded values when contolled with value 1`] = `
+<div
+  className="sc-bdVaJa eOaogP k-RangeSlider"
+  style={
+    Object {
+      "--range-input-ratio": 0,
+    }
+  }
+>
+  <input
+    disabled={false}
+    max={10}
+    min={1}
+    name="test-slider-input"
+    onChange={[Function]}
+    step={1}
+    type="range"
+    value={20}
+  />
+</div>
+`;

--- a/assets/javascripts/kitten/components/form/range-slider/index.js
+++ b/assets/javascripts/kitten/components/form/range-slider/index.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import styled from 'styled-components'
+import isUndefined from 'lodash/fp/isUndefined'
 import { pxToRem, stepToRem } from '../../../helpers/utils/typography'
 import COLORS from '../../../constants/colors-config'
 import TYPOGRAPHY from '../../../constants/typography-config'
@@ -226,13 +227,23 @@ export const RangeSlider = ({
   wrapperProps,
   rangeThumbText,
   rangeThumbPosition,
+  value,
   ...props
 }) => {
   const [inputRatio, setInputRatio] = useState(0)
   const inputEl = useRef(null)
   const changeEvent = createEvent('change')
+  const isControlled = !isUndefined(value)
+  const addProps = isControlled ? { value } : {}
 
   useEffect(() => {
+    if (isControlled) {
+      setInputRatio(getRatioFrom(value))
+    }
+  }, [])
+
+  useEffect(() => {
+    if (isControlled) return
     inputEl?.current &&
       nativeInputValueSetter &&
       nativeInputValueSetter.call(inputEl.current, initialValue)
@@ -242,7 +253,7 @@ export const RangeSlider = ({
 
   const getRatioFrom = value => {
     const { min, max } = props
-    return (value - min) / (max - min)
+    return Math.min(1, (value - min) / (max - min))
   }
 
   const handleChange = event => {
@@ -268,6 +279,7 @@ export const RangeSlider = ({
         type="range"
         onChange={handleChange}
         {...props}
+        {...addProps}
       />
       {rangeThumbText && (
         <span className="k-RangeSlider__rangeThumbText">{rangeThumbText}</span>

--- a/assets/javascripts/kitten/components/form/range-slider/stories.js
+++ b/assets/javascripts/kitten/components/form/range-slider/stories.js
@@ -79,3 +79,16 @@ export const WithRangeThumbText = args => {
     />
   )
 }
+
+export const Controlled = args => {
+  const [value, setValue] = useState(40)
+  return (
+    <RangeSlider
+      {...args}
+      max={20}
+      min={1}
+      value={value}
+      onChange={event => setValue(event.target.value)}
+    />
+  )
+}

--- a/assets/javascripts/kitten/components/form/range-slider/test.js
+++ b/assets/javascripts/kitten/components/form/range-slider/test.js
@@ -36,4 +36,20 @@ describe('<RangeSlider />', () => {
 
     expect(tree).toMatchSnapshot()
   })
+
+  it('should set unbounded values when contolled with value', () => {
+    const tree = renderer
+      .create(
+        <RangeSlider
+          name="test-slider-input"
+          value={20}
+          min={1}
+          max={10}
+          step={1}
+        />,
+      )
+      .toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
 })


### PR DESCRIPTION
Ça permet de gérer (entre autre) les cas où on veut mettre une `value` qui sort du `min`/`max`.
Car faire `nativeInputValueSetter.call(inputEl.current, 40)` quand le `max=20` ne fonctionne pas.