### PR TITLE
[HeaderNav] Add `cursor` to `onClick`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: `HeaderNav.Button`: Add `cursor` to `onClick`. 
+
 ## [4.8.0] - 2021-09-22
 
 Features: 

--- a/assets/javascripts/kitten/components/organisms/header-nav/styles.js
+++ b/assets/javascripts/kitten/components/organisms/header-nav/styles.js
@@ -398,6 +398,7 @@ export const StyledHeader = styled.header`
     .k-Dropdown__button,
     .k-HeaderNav__Button {
       min-width: ${pxToRem(MOBILE_HEADER_HEIGHT)};
+      cursor: pointer;
     }
 
     .k-HeaderNav__Button--hasText {
@@ -441,6 +442,7 @@ export const StyledHeader = styled.header`
     .k-Dropdown__button,
     .k-HeaderNav__Button {
       min-width: ${pxToRem(MOBILE_HEADER_HEIGHT)};
+      cursor: pointer;
 
       @media (min-width: ${ScreenConfig.S.min}px) {
         min-width: ${pxToRem(TABLET_HEADER_HEIGHT)};


### PR DESCRIPTION
Closes #.

Vercel link:

- https://kitten-git-…

Screenshot:


TODO:

- [ ] Tests
- [ ] Changelog
- [ ] A11Y
- [ ] Stories / Docs
- [ ] BrowserStack (IE11, Chrome & Firefox on Windows 10)
- [ ] New component added to `assets/javascripts/kitten/index.js`
