### PR TITLE
[DashboardLayout] Fix header elements dimensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: `DashboardLayout`: Fix header elements dimensions.
+
 - Feature: `HeaderMenu`: Add `position` prop, default to `left`.
 - Fix: `HeaderNav.Button`: Add `cursor` to `onClick`. 
 - Feature: `EngagementCardWithImage`: Add `imgProps` and `textProps` props.

--- a/assets/javascripts/kitten/components/layout/dashboard-layout/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/layout/dashboard-layout/__snapshots__/test.js.snap
@@ -735,6 +735,10 @@ button:hover .c1 {
   background-color: #fff;
 }
 
+.c0 .k-DashboardLayout > * {
+  min-width: 0;
+}
+
 .c0 .k-DashboardLayout .k-DashboardLayout__sideWrapper {
   background-color: #222;
 }
@@ -958,6 +962,7 @@ button:hover .c1 {
     -webkit-align-self: initial;
     -ms-flex-item-align: initial;
     align-self: initial;
+    min-width: 0;
   }
 
   .c0 .k-DashboardLayout .k-DashboardLayout__mainWrapper .k-DashboardLayout__heading__buttonWrapper {
@@ -1267,6 +1272,10 @@ button:hover .c1 {
   background-color: #fff;
 }
 
+.c0 .k-DashboardLayout > * {
+  min-width: 0;
+}
+
 .c0 .k-DashboardLayout .k-DashboardLayout__sideWrapper {
   background-color: #222;
 }
@@ -1490,6 +1499,7 @@ button:hover .c1 {
     -webkit-align-self: initial;
     -ms-flex-item-align: initial;
     align-self: initial;
+    min-width: 0;
   }
 
   .c0 .k-DashboardLayout .k-DashboardLayout__mainWrapper .k-DashboardLayout__heading__buttonWrapper {

--- a/assets/javascripts/kitten/components/layout/dashboard-layout/styles.js
+++ b/assets/javascripts/kitten/components/layout/dashboard-layout/styles.js
@@ -62,6 +62,10 @@ export const StyledDashboard = styled.div`
     display: grid;
     background-color: ${COLORS.background1};
 
+    & > * {
+      min-width: 0;
+    }
+
     .k-DashboardLayout__sideWrapper {
       background-color: ${COLORS.font1};
     }
@@ -155,6 +159,7 @@ export const StyledDashboard = styled.div`
 
           > * {
             align-self: initial;
+            min-width: 0;
           }
         }
 


### PR DESCRIPTION
Closes #.

Vercel link:

- https://kitten-git-dashboard-layout-fix-header-6faa69-kisskissbankbank.vercel.app/iframe.html?id=layout-dashboardlayout--default&args=&globals=backgrounds.grid:false&viewMode=story (voir en mobile)
Screenshot:


TODO:

- [x] Tests
- [x] Changelog
- [ ] A11Y
- [ ] Stories / Docs
- [ ] BrowserStack (IE11, Chrome & Firefox on Windows 10)
- [ ] New component added to `assets/javascripts/kitten/index.js`
