### PR TITLE
Fix removing object item on TagInput

### DIFF
--- a/assets/javascripts/kitten/components/form/tag-input/index.js
+++ b/assets/javascripts/kitten/components/form/tag-input/index.js
@@ -348,7 +348,7 @@ export const TagInput = ({
         aria-relevant="additions removals"
       >
         {itemsList.map(item => {
-          const itemValue = item?.value ?? item
+          const itemValue = item?.value || item
           return <li key={`visuallyHidden-${itemValue}`}>{itemValue}</li>
         })}
       </ul>


### PR DESCRIPTION
### Corrige un souci pour supprimer un item quand celui-ci est un objet.

et petit refacto pour se passer de `isObject`