### PR TITLE
[useResizeObserver] Fix use condition for older browsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: `useResizeObserver`: Fix use condition for older browsers.
+
 ## [5.7.0] - 2021-11-02
 
 Features:

--- a/assets/javascripts/kitten/components/molecules/cards/reward-summary-card/hooks/use-resize-observer.js
+++ b/assets/javascripts/kitten/components/molecules/cards/reward-summary-card/hooks/use-resize-observer.js
@@ -3,7 +3,7 @@ import { domElementHelper } from '../../../../../helpers/dom/element-helper'
 
 // https://gist.github.com/DominicTobias/c8579667e8a8bd7817c1b4d5b274eb4c
 export const useResizeObserver = () => {
-  if (!domElementHelper.canUseDom() && !'ResizeObserver' in window) {
+  if (!domElementHelper.canUseDom() || !('ResizeObserver' in window)) {
     return {}
   }
 


### PR DESCRIPTION
Closes #.

Vercel link:

- https://kitten-git-…

Screenshot:


TODO:

- [ ] Tests
- [ ] Changelog
- [ ] A11Y
- [ ] Stories / Docs
- [ ] BrowserStack (IE11, Chrome & Firefox on Windows 10)
- [ ] New component added to `assets/javascripts/kitten/index.js`
