### PR TITLE
[DashboardMenu] Add size prop to Expandable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Feature: `DashboardMenu`: Add `size` prop to `DashboardMenu.Expandable`, defaults to `default`.
+- Fix: `DashboardMenu`: Style fixes.
+
 ## [6.1.0] - 2021-11-15
 
 Features:

--- a/assets/javascripts/kitten/components/layout/dashboard-layout/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/layout/dashboard-layout/__snapshots__/test.js.snap
@@ -758,6 +758,10 @@ button:focus .c1.k-BurgerIcon--isAnimatedOnHover .k-BurgerIcon__patty {
   display: none;
 }
 
+.c0 .k-DashboardLayout__mainWrapper:focus {
+  outline-offset: 0.125rem;
+}
+
 .c0 .k-DashboardLayout {
   min-height: calc(100vh - var(--dashboardLayout-siteHeaderHeight));
   min-height: -webkit-fill-available;
@@ -1389,6 +1393,10 @@ button:focus .c1.k-BurgerIcon--isAnimatedOnHover .k-BurgerIcon__patty {
 .c0 .k-DashboardLayout__siteHeader,
 .c0 .k-DashboardLayout__siteHeader ~ .k-DashboardLayout__quickAccessLink {
   display: none;
+}
+
+.c0 .k-DashboardLayout__mainWrapper:focus {
+  outline-offset: 0.125rem;
 }
 
 .c0 .k-DashboardLayout {

--- a/assets/javascripts/kitten/components/layout/dashboard-layout/stories/menu.js
+++ b/assets/javascripts/kitten/components/layout/dashboard-layout/stories/menu.js
@@ -381,13 +381,19 @@ export const StoryMultiMenu = () => (
       >
         Actualités
       </DashboardMenu.Item>
-      <DashboardMenu.Item
+      <DashboardMenu.Expandable
+        title="Admin"
         size="small"
-        href="https://www.kisskissbankbank.com"
         icon={<CheckedShieldIconNext color="currentColor" />}
       >
-        Admin
-      </DashboardMenu.Item>
+        <DashboardMenu.Item href="#">Destinataire des fonds</DashboardMenu.Item>
+        <DashboardMenu.Item href="#">
+          Confirmation d'identité
+        </DashboardMenu.Item>
+        <DashboardMenu.Item href="#">
+          Documents justificatifs
+        </DashboardMenu.Item>
+      </DashboardMenu.Expandable>
       <DashboardMenu.Item
         size="small"
         href="https://www.kisskissbankbank.com"

--- a/assets/javascripts/kitten/components/layout/dashboard-layout/styles.js
+++ b/assets/javascripts/kitten/components/layout/dashboard-layout/styles.js
@@ -34,6 +34,9 @@ export const StyledDashboard = styled.div`
       display: none;
     }
   }
+  .k-DashboardLayout__mainWrapper:focus {
+    outline-offset: ${pxToRem(2)};
+  }
 
   @media (min-width: ${pxToRem(ScreenConfig.L.min)}) {
     .k-DashboardLayout__siteHeader {

--- a/assets/javascripts/kitten/components/organisms/dashboard-menu/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/organisms/dashboard-menu/__snapshots__/test.js.snap
@@ -444,7 +444,7 @@ exports[`<DashboardMenu /> with default props matches with snapshot 1`] = `
       className="k-DashboardMenu__expandableWrapper"
     >
       <details
-        className="k-DashboardMenu__expandable k-DashboardMenu__expandable--undefined"
+        className="k-DashboardMenu__expandable k-DashboardMenu__expandable--default"
         open={null}
       >
         <summary>

--- a/assets/javascripts/kitten/components/organisms/dashboard-menu/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/organisms/dashboard-menu/__snapshots__/test.js.snap
@@ -100,6 +100,7 @@ exports[`<DashboardMenu /> with default props matches with snapshot 1`] = `
   -webkit-flex: 1 0 0;
   -ms-flex: 1 0 0;
   flex: 1 0 0;
+  line-height: 1.4;
 }
 
 .c0 .k-DashboardMenu__selectorButton__text,
@@ -130,6 +131,10 @@ exports[`<DashboardMenu /> with default props matches with snapshot 1`] = `
   gap: 0.625rem;
 }
 
+.c0 .k-DashboardMenu__expandable.k-DashboardMenu__expandable--small .k-DashboardMenu__expandable__list {
+  padding: 0 0.625rem 1.25rem 3.125rem;
+}
+
 .c0 .k-DashboardMenu__list {
   display: -webkit-box;
   display: -webkit-flex;
@@ -158,6 +163,7 @@ exports[`<DashboardMenu /> with default props matches with snapshot 1`] = `
   border-radius: 0.25rem;
 }
 
+.c0 .k-DashboardMenu__list > li > .k-DashboardMenu__expandable--small .k-DashboardMenu__expandable__title,
 .c0 .k-DashboardMenu__list > li > .k-DashboardMenu__item--small {
   height: 2.5rem;
 }
@@ -188,6 +194,11 @@ exports[`<DashboardMenu /> with default props matches with snapshot 1`] = `
   font-family: Maax,Helvetica,Arial,sans-serif;
   font-weight: 400;
   line-height: 1.125rem;
+  max-width: 100%;
+  display: inline-block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .c0 .k-DashboardMenu__expandable__list > li > .k-DashboardMenu__item:hover,
@@ -433,7 +444,7 @@ exports[`<DashboardMenu /> with default props matches with snapshot 1`] = `
       className="k-DashboardMenu__expandableWrapper"
     >
       <details
-        className="k-DashboardMenu__expandable"
+        className="k-DashboardMenu__expandable k-DashboardMenu__expandable--undefined"
         open={null}
       >
         <summary>

--- a/assets/javascripts/kitten/components/organisms/dashboard-menu/index.js
+++ b/assets/javascripts/kitten/components/organisms/dashboard-menu/index.js
@@ -122,6 +122,7 @@ const StyledDashboardMenu = styled.nav`
   .k-DashboardMenu__item .k-DashboardMenu__item__text,
   .k-DashboardMenu__expandable .k-DashboardMenu__expandable__title__text {
     flex: 1 0 0;
+    line-height: 1.4;
 
     &,
     * {
@@ -140,6 +141,10 @@ const StyledDashboardMenu = styled.nav`
       display: flex;
       flex-direction: column;
       gap: ${pxToRem(10)};
+    }
+
+    &.k-DashboardMenu__expandable--small .k-DashboardMenu__expandable__list {
+      padding: 0 ${pxToRem(10)} ${pxToRem(20)} ${pxToRem(50)};
     }
   }
 
@@ -163,6 +168,10 @@ const StyledDashboardMenu = styled.nav`
     border-radius: ${pxToRem(4)};
   }
 
+  .k-DashboardMenu__list
+    > li
+    > .k-DashboardMenu__expandable--small
+    .k-DashboardMenu__expandable__title,
   .k-DashboardMenu__list > li > .k-DashboardMenu__item--small {
     height: ${pxToRem(40)};
   }
@@ -190,6 +199,11 @@ const StyledDashboardMenu = styled.nav`
   .k-DashboardMenu__expandable__list > li > .k-DashboardMenu__item {
     ${TYPOGRAPHY.fontStyles.light}
     line-height: ${pxToRem(18)};
+    max-width: 100%;
+    display: inline-block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 
     &:hover,
     &:focus,
@@ -400,7 +414,14 @@ const Item = ({
   </li>
 )
 
-const Expandable = ({ className, children, icon, title, ...props }) => {
+const Expandable = ({
+  className,
+  children,
+  icon,
+  title,
+  size = 'default',
+  ...props
+}) => {
   const [hasActiveInside, setActiveInside] = useState(false)
 
   useEffect(() => {
@@ -412,9 +433,14 @@ const Expandable = ({ className, children, icon, title, ...props }) => {
   return (
     <li className="k-DashboardMenu__expandableWrapper">
       <details
-        className={classNames('k-DashboardMenu__expandable', className, {
-          'k-DashboardMenu__expandable--hasActiveInside': hasActiveInside,
-        })}
+        className={classNames(
+          'k-DashboardMenu__expandable',
+          className,
+          `k-DashboardMenu__expandable--${size}`,
+          {
+            'k-DashboardMenu__expandable--hasActiveInside': hasActiveInside,
+          },
+        )}
         open={hasActiveInside ? hasActiveInside : null}
         {...props}
       >
@@ -585,6 +611,7 @@ Item.proptypes = {
 Expandable.proptypes = {
   icon: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
   title: PropTypes.node,
+  size: PropTypes.oneOf(['default', 'small']),
 }
 
 Selector.propTypes = {

--- a/assets/javascripts/kitten/components/organisms/dashboard-menu/stories.js
+++ b/assets/javascripts/kitten/components/organisms/dashboard-menu/stories.js
@@ -537,13 +537,22 @@ export const MultiMenu = () => (
       >
         Actualités
       </DashboardMenu.Item>
-      <DashboardMenu.Item
+      <DashboardMenu.Expandable
+        title="Admin"
         size="small"
-        href="https://www.kisskissbankbank.com"
         icon={<CheckedShieldIconNext color="currentColor" />}
       >
-        Admin
-      </DashboardMenu.Item>
+        <DashboardMenu.Item href="#">Destinataire des fonds</DashboardMenu.Item>
+        <DashboardMenu.Item href="#">
+          Confirmation d'identité
+        </DashboardMenu.Item>
+        <DashboardMenu.Item href="#">
+          Sed posuere consectetur est at lobortis. Fusce dapibus, tellus ac
+          cursus commodo, tortor mauris condimentum nibh, ut fermentum massa
+          justo sit amet risus. Duis mollis, est non commodo luctus, nisi erat
+          porttitor ligula, eget lacinia odio sem nec elit.
+        </DashboardMenu.Item>
+      </DashboardMenu.Expandable>
       <DashboardMenu.Item
         size="small"
         href="https://www.kisskissbankbank.com"


### PR DESCRIPTION
Closes #.

Vercel link:

- https://kitten-git-dashboard-menu-fix-expandable-size-kisskissbankbank.vercel.app/?path=/story/layout-dashboardlayout--default&args=multiMenu:true

Screenshot:


TODO:

- [x] Tests
- [x] Changelog
- [ ] A11Y
- [ ] Stories / Docs
- [ ] BrowserStack (IE11, Chrome & Firefox on Windows 10)
- [ ] New component added to `assets/javascripts/kitten/index.js`
