### PR TITLE
[AvatarWithTextAndBadge] Add `border` on the avatar image.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: `AvatarWithTextAndBadge`: Add `border` on the avatar image.
+
 ## [6.14.0] - 2022-01-03
 
 Features:

--- a/assets/javascripts/kitten/components/atoms/avatar-with-text-and-badge/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/atoms/avatar-with-text-and-badge/__snapshots__/test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<AvatarWithTextAndBadge /> with multiple lines and badge should match with snapshot 1`] = `
 <div
-  className="sc-bwzfXH cjrqaU k-Avatar__wrapper"
+  className="sc-bwzfXH iqPZjd k-Avatar__wrapper"
 >
   <div
     className="k-Avatar k-Avatar--big"
@@ -56,7 +56,7 @@ exports[`<AvatarWithTextAndBadge /> with multiple lines and badge should match w
 
 exports[`<AvatarWithTextAndBadge /> with simple props and avatar should match with snapshot 1`] = `
 <div
-  className="sc-bwzfXH cjrqaU k-Avatar__wrapper"
+  className="sc-bwzfXH iqPZjd k-Avatar__wrapper"
 >
   <div
     className="k-Avatar k-Avatar--regular"
@@ -89,7 +89,7 @@ exports[`<AvatarWithTextAndBadge /> with simple props and avatar should match wi
 
 exports[`<AvatarWithTextAndBadge /> with simple props and no avatar image should match with snapshot 1`] = `
 <div
-  className="sc-bwzfXH cjrqaU k-Avatar__wrapper"
+  className="sc-bwzfXH iqPZjd k-Avatar__wrapper"
 >
   <div
     className="k-Avatar k-Avatar--regular"

--- a/assets/javascripts/kitten/components/atoms/avatar-with-text-and-badge/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/atoms/avatar-with-text-and-badge/__snapshots__/test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<AvatarWithTextAndBadge /> with multiple lines and badge should match with snapshot 1`] = `
 <div
-  className="sc-bwzfXH iqPZjd k-Avatar__wrapper"
+  className="sc-bwzfXH eJucXg k-Avatar__wrapper"
 >
   <div
     className="k-Avatar k-Avatar--big"
@@ -56,7 +56,7 @@ exports[`<AvatarWithTextAndBadge /> with multiple lines and badge should match w
 
 exports[`<AvatarWithTextAndBadge /> with simple props and avatar should match with snapshot 1`] = `
 <div
-  className="sc-bwzfXH iqPZjd k-Avatar__wrapper"
+  className="sc-bwzfXH eJucXg k-Avatar__wrapper"
 >
   <div
     className="k-Avatar k-Avatar--regular"
@@ -89,7 +89,7 @@ exports[`<AvatarWithTextAndBadge /> with simple props and avatar should match wi
 
 exports[`<AvatarWithTextAndBadge /> with simple props and no avatar image should match with snapshot 1`] = `
 <div
-  className="sc-bwzfXH iqPZjd k-Avatar__wrapper"
+  className="sc-bwzfXH eJucXg k-Avatar__wrapper"
 >
   <div
     className="k-Avatar k-Avatar--regular"

--- a/assets/javascripts/kitten/components/atoms/avatar-with-text-and-badge/index.js
+++ b/assets/javascripts/kitten/components/atoms/avatar-with-text-and-badge/index.js
@@ -122,6 +122,7 @@ const StyledWrapper = styled.div`
     &:hover .k-Avatar,
     &:focus .k-Avatar {
       opacity: 0.8;
+      border: var(--border-hover);
     }
   }
 `

--- a/assets/javascripts/kitten/components/atoms/avatar-with-text-and-badge/index.js
+++ b/assets/javascripts/kitten/components/atoms/avatar-with-text-and-badge/index.js
@@ -30,7 +30,7 @@ const StyledWrapper = styled.div`
     box-sizing: border-box;
     display: flex;
     overflow: hidden;
-    border: 0;
+    border: var(--border-width) solid var(--color-grey-300);
     padding: 0;
 
     color: var(--k-Avatar-color);


### PR DESCRIPTION
Closes #.

Vercel link:

https://kitten-git-fix-avatar-img-kisskissbankbank.vercel.app/?path=/story/atoms-avatarwithtextandbadge--default

Screenshot:


TODO:

- [x] Tests
- [x] Changelog
- [ ] A11Y
- [ ] Stories / Docs
- [ ] New component added to `assets/javascripts/kitten/index.js`
