### PR TITLE
[Carousel] More accessible handling of prev/next click

### DIFF
--- a/.storybook/decorators/dev-grid.js
+++ b/.storybook/decorators/dev-grid.js
@@ -1,9 +1,4 @@
 import React from 'react'
 import { DevGrid } from '../../assets/javascripts/kitten/components/dev/dev-grid'
 
-export const DevGridDecorator = ({ children }) => (
-  <>
-    {children}
-    <DevGrid />
-  </>
-)
+export const DevGridDecorator = () => <DevGrid />

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -60,8 +60,9 @@ export const parameters = {
 
 export const decorators = [
   story => (
-    <DevGridDecorator>
+    <main>
       {story()}
-    </DevGridDecorator>
+      <DevGridDecorator />
+    </main>
   ),
 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fix: `DashboardMenu`: Fix `Selector` scroll on Chrome & Safari.
 - Fix: `HeroLayout`: Keep same padding for all screen sizes.
+- Feature: `Carousel`: More accessible handling of prev/next click.
 
 ## [8.3.1] - 2022-02-10
 

--- a/assets/javascripts/kitten/components/structure/carousels/carousel/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/structure/carousels/carousel/__snapshots__/test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<Carousel /> by default on desktop matches with snapshot 1`] = `
 <div
-  className="sc-dkPtRN bctRfx k-Carousel"
+  className="sc-dkPtRN dKFCpL k-Carousel"
 >
   <div
     className="k-Carousel__inner"
@@ -12,10 +12,7 @@ exports[`<Carousel /> by default on desktop matches with snapshot 1`] = `
     onTouchStart={[Function]}
   >
     <div
-      aria-label="Page 1"
       className="k-Carousel__inner__pageContainer k-Carousel__inner__pageContainer--isActivePage k-Carousel__inner__pageContainer--hasBeenViewed"
-      onClick={[Function]}
-      role="button"
     >
       <div
         className="k-Carousel__page k-Carousel__page--isActivePage k-Carousel__page--hasBeenViewed"
@@ -317,7 +314,7 @@ exports[`<Carousel /> by default on desktop matches with snapshot 1`] = `
 
 exports[`<Carousel /> by default on mobile matches with snapshot 1`] = `
 <div
-  className="sc-dkPtRN bctRfx k-Carousel"
+  className="sc-dkPtRN dKFCpL k-Carousel"
 >
   <div
     className="k-Carousel__inner"
@@ -327,10 +324,7 @@ exports[`<Carousel /> by default on mobile matches with snapshot 1`] = `
     onTouchStart={[Function]}
   >
     <div
-      aria-label="Page 1"
       className="k-Carousel__inner__pageContainer custom-class k-Carousel__inner__pageContainer--isActivePage k-Carousel__inner__pageContainer--hasBeenViewed"
-      onClick={[Function]}
-      role="button"
     >
       <div
         className="k-Carousel__page k-Carousel__page--isActivePage k-Carousel__page--hasBeenViewed"
@@ -634,7 +628,7 @@ exports[`<Carousel /> empty carousel matches with snapshot 1`] = `null`;
 
 exports[`<Carousel /> legacy carousel on desktop matches with snapshot 1`] = `
 <div
-  className="sc-dkPtRN kczqDg k-Carousel k-LegacyCarousel"
+  className="sc-dkPtRN eghNle k-Carousel k-LegacyCarousel"
 >
   <div
     className="sc-gsDKAQ hebEnC k-Grid"
@@ -650,10 +644,7 @@ exports[`<Carousel /> legacy carousel on desktop matches with snapshot 1`] = `
         onTouchStart={[Function]}
       >
         <div
-          aria-label="Page 1"
           className="k-Carousel__inner__pageContainer k-Carousel__inner__pageContainer--isActivePage k-Carousel__inner__pageContainer--hasBeenViewed"
-          onClick={[Function]}
-          role="button"
         >
           <div
             className="k-Carousel__page k-Carousel__page--isActivePage k-Carousel__page--hasBeenViewed"
@@ -753,7 +744,7 @@ exports[`<Carousel /> legacy carousel on desktop matches with snapshot 1`] = `
 
 exports[`<Carousel /> legacy carousel on desktop with withoutLeftOffset={true} matches with snapshot 1`] = `
 <div
-  className="sc-dkPtRN kczqDg k-Carousel k-LegacyCarousel"
+  className="sc-dkPtRN eghNle k-Carousel k-LegacyCarousel"
 >
   <div
     className="sc-gsDKAQ hebEnC k-Grid"
@@ -769,10 +760,7 @@ exports[`<Carousel /> legacy carousel on desktop with withoutLeftOffset={true} m
         onTouchStart={[Function]}
       >
         <div
-          aria-label="Page 1"
           className="k-Carousel__inner__pageContainer k-Carousel__inner__pageContainer--isActivePage k-Carousel__inner__pageContainer--hasBeenViewed"
-          onClick={[Function]}
-          role="button"
         >
           <div
             className="k-Carousel__page k-Carousel__page--isActivePage k-Carousel__page--hasBeenViewed"
@@ -872,7 +860,7 @@ exports[`<Carousel /> legacy carousel on desktop with withoutLeftOffset={true} m
 
 exports[`<Carousel /> legacy carousel on mobile matches with snapshot 1`] = `
 <div
-  className="sc-dkPtRN kczqDg k-Carousel k-LegacyCarousel"
+  className="sc-dkPtRN eghNle k-Carousel k-LegacyCarousel"
 >
   <div
     className="sc-gsDKAQ hebEnC k-Grid"
@@ -888,10 +876,7 @@ exports[`<Carousel /> legacy carousel on mobile matches with snapshot 1`] = `
         onTouchStart={[Function]}
       >
         <div
-          aria-label="Page 1"
           className="k-Carousel__inner__pageContainer k-Carousel__inner__pageContainer--isActivePage k-Carousel__inner__pageContainer--hasBeenViewed"
-          onClick={[Function]}
-          role="button"
         >
           <div
             className="k-Carousel__page k-Carousel__page--isActivePage k-Carousel__page--hasBeenViewed"
@@ -991,7 +976,7 @@ exports[`<Carousel /> legacy carousel on mobile matches with snapshot 1`] = `
 
 exports[`<Carousel /> with exportVisibilityProps prop matches with snapshot 1`] = `
 <div
-  className="sc-dkPtRN bctRfx k-Carousel"
+  className="sc-dkPtRN dKFCpL k-Carousel"
 >
   <div
     className="k-Carousel__inner"
@@ -1001,10 +986,7 @@ exports[`<Carousel /> with exportVisibilityProps prop matches with snapshot 1`] 
     onTouchStart={[Function]}
   >
     <div
-      aria-label="Page 1"
       className="k-Carousel__inner__pageContainer k-Carousel__inner__pageContainer--isActivePage k-Carousel__inner__pageContainer--hasBeenViewed"
-      onClick={[Function]}
-      role="button"
     >
       <div
         className="k-Carousel__page k-Carousel__page--isActivePage k-Carousel__page--hasBeenViewed"
@@ -1306,7 +1288,7 @@ exports[`<Carousel /> with exportVisibilityProps prop matches with snapshot 1`] 
 
 exports[`<Carousel /> with itemsPerPage prop matches with snapshot 1`] = `
 <div
-  className="sc-dkPtRN hhokTj k-Carousel"
+  className="sc-dkPtRN cQFFON k-Carousel"
 >
   <div
     className="k-Carousel__inner"
@@ -1316,10 +1298,7 @@ exports[`<Carousel /> with itemsPerPage prop matches with snapshot 1`] = `
     onTouchStart={[Function]}
   >
     <div
-      aria-label="Page 1"
       className="k-Carousel__inner__pageContainer k-Carousel__inner__pageContainer--isActivePage k-Carousel__inner__pageContainer--hasBeenViewed"
-      onClick={[Function]}
-      role="button"
     >
       <div
         className="k-Carousel__page k-Carousel__page--isActivePage k-Carousel__page--hasBeenViewed"
@@ -1627,7 +1606,7 @@ exports[`<Carousel /> with itemsPerPage prop matches with snapshot 1`] = `
 
 exports[`<Carousel /> with loop prop on desktop matches with snapshot 1`] = `
 <div
-  className="sc-dkPtRN bctRfx k-Carousel"
+  className="sc-dkPtRN dKFCpL k-Carousel"
 >
   <div
     className="k-Carousel__inner"
@@ -1637,10 +1616,7 @@ exports[`<Carousel /> with loop prop on desktop matches with snapshot 1`] = `
     onTouchStart={[Function]}
   >
     <div
-      aria-label="Page 1"
       className="k-Carousel__inner__pageContainer k-Carousel__inner__pageContainer--isActivePage k-Carousel__inner__pageContainer--hasBeenViewed"
-      onClick={[Function]}
-      role="button"
     >
       <div
         className="k-Carousel__page k-Carousel__page--isActivePage k-Carousel__page--hasBeenViewed"

--- a/assets/javascripts/kitten/components/structure/carousels/carousel/components/carousel-inner.js
+++ b/assets/javascripts/kitten/components/structure/carousels/carousel/components/carousel-inner.js
@@ -171,10 +171,7 @@ export const CarouselInner = ({
 
           return (
             <div
-              key={index}
-              role="button"
-              aria-label={pageClickText(index + 1)}
-              onClick={handlePageClick(index)}
+              key={`inner_${index}`}
               className={classNames(
                 'k-Carousel__inner__pageContainer',
                 pagesClassName,
@@ -192,6 +189,14 @@ export const CarouselInner = ({
                 numberOfItemsPerPage={numberOfItemsPerPage}
                 goToCurrentPage={() => goToPage(index)}
               />
+              {!isActivePage && (
+                <button
+                  type="button"
+                  onClick={handlePageClick(index)}
+                  className="k-u-reset-button k-Carousel__inner__button"
+                  aria-label={pageClickText(index + 1)}
+                />
+              )}
             </div>
           )
         })}

--- a/assets/javascripts/kitten/components/structure/carousels/carousel/components/carousel-page.js
+++ b/assets/javascripts/kitten/components/structure/carousels/carousel/components/carousel-page.js
@@ -37,11 +37,11 @@ export const CarouselPage = ({
         .map((el, index) => {
           // If there's not enough items in the last page of the Carousel
           if (index >= pageItems.length) {
-            return <div key={index} className="k-Carousel__page__item" />
+            return <div key={`page_${index}`} className="k-Carousel__page__item" />
           }
 
           return (
-            <div key={index} className="k-Carousel__page__item">
+            <div key={`page_${index}`} className="k-Carousel__page__item">
               {React.cloneElement(pageItems[index], itemProps)}
             </div>
           )

--- a/assets/javascripts/kitten/components/structure/carousels/carousel/styles.js
+++ b/assets/javascripts/kitten/components/structure/carousels/carousel/styles.js
@@ -347,13 +347,19 @@ export const StyledCarouselContainer = styled.div`
     .k-Carousel__inner__pageContainer {
       width: 100%;
       scroll-snap-align: start;
+      position: relative;
 
-      &:not(.k-Carousel__inner__pageContainer--isActivePage) {
+      .k-Carousel__inner__button {
         cursor: pointer;
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+      }
 
-        .k-Carousel__page__item > * {
-          pointer-events: none;
-        }
+      &:not(.k-Carousel__inner__pageContainer--isActivePage) .k-Carousel__page__item > * {
+        pointer-events: none;
       }
     }
   }


### PR DESCRIPTION
Closes #.

Vercel link:

- https://kitten-git-carousel-fix-a11y-error-kisskissbankbank.vercel.app/?path=/story/structure-carousels-carousel--engagements-carousel

Screenshot:


TODO:

- [x] Tests
- [x] Changelog
- [x] A11Y
- [ ] Stories / Docs
- [ ] New component added to `assets/javascripts/kitten/index.js`
