### PR TITLE
[DashboardMenu] Fix Expandable open state by removing useless code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Feature: `IconBadge`: Add `micro` to the size prop.
 - Fix: `AlertBox`: Improved styles.
+- Fix: `DashboardMenu`: Fix `DashboardMenu.Expandable` open state by removing useless code.
 
 ## [8.5.0] - 2022-02-15
 

--- a/assets/javascripts/kitten/components/navigation/dashboard-menu/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/navigation/dashboard-menu/__snapshots__/test.js.snap
@@ -185,7 +185,6 @@ exports[`<DashboardMenu /> with default props matches with snapshot 1`] = `
 }
 
 .c0 .k-DashboardMenu__expandable[open] .k-DashboardMenu__expandable__title,
-.c0 .k-DashboardMenu__expandable--hasActiveInside .k-DashboardMenu__expandable__title,
 .c0 .k-DashboardMenu__list > li > .k-DashboardMenu__item[aria-current='page'] {
   color: var(--color-grey-000,#fff);
   background-color: var(--color-grey-800,#2d2d2d);
@@ -443,7 +442,6 @@ exports[`<DashboardMenu /> with default props matches with snapshot 1`] = `
     >
       <details
         className="k-DashboardMenu__expandable k-DashboardMenu__expandable--default"
-        open={null}
       >
         <summary>
           <div

--- a/assets/javascripts/kitten/components/navigation/dashboard-menu/index.js
+++ b/assets/javascripts/kitten/components/navigation/dashboard-menu/index.js
@@ -65,17 +65,6 @@ const Expandable = ({
   size = 'default',
   ...props
 }) => {
-  const expandableList = useRef(null)
-  const [hasActiveInside, setActiveInside] = useState(false)
-
-  useEffect(() => {
-    setActiveInside(false)
-    const activeChild = expandableList?.current.querySelector(
-      '.k-DashboardMenu__item[aria-current="page"]',
-    )
-    setActiveInside(!!activeChild)
-  })
-
   return (
     <li className="k-DashboardMenu__expandableWrapper">
       <details
@@ -83,11 +72,7 @@ const Expandable = ({
           'k-DashboardMenu__expandable',
           className,
           `k-DashboardMenu__expandable--${size}`,
-          {
-            'k-DashboardMenu__expandable--hasActiveInside': hasActiveInside,
-          },
         )}
-        open={hasActiveInside ? hasActiveInside : null}
         {...props}
       >
         <summary>
@@ -105,7 +90,7 @@ const Expandable = ({
             </span>
           </div>
         </summary>
-        <ul ref={expandableList} className="k-DashboardMenu__expandable__list">
+        <ul className="k-DashboardMenu__expandable__list">
           {children}
         </ul>
       </details>

--- a/assets/javascripts/kitten/components/navigation/dashboard-menu/styles.js
+++ b/assets/javascripts/kitten/components/navigation/dashboard-menu/styles.js
@@ -183,8 +183,6 @@ export const StyledDashboardMenu = styled.nav`
     cursor: pointer;
   }
   .k-DashboardMenu__expandable[open] .k-DashboardMenu__expandable__title,
-  .k-DashboardMenu__expandable--hasActiveInside
-    .k-DashboardMenu__expandable__title,
   .k-DashboardMenu__list > li > .k-DashboardMenu__item[aria-current='page'] {
     color: ${COLORS.background1};
     background-color: ${COLORS.line3};


### PR DESCRIPTION
Closes #.

Vercel link:

- https://kitten-git-…

Screenshot:


TODO:

- [x] Tests
- [x] Changelog
- [ ] A11Y
- [ ] Stories / Docs
- [ ] New component added to `assets/javascripts/kitten/index.js`
