### PR TITLE
[Location] Add new prop to display custom value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Feature: `Location`: Add `inputValue` prop to display custom value.
 - Fix: Helpers: Add `checkDeprecatedSizes` utility.
 - Fix: `DashboardMenu.Selector`: Fix no active item case.
 

--- a/assets/javascripts/kitten/components/form/input/location-input/index.js
+++ b/assets/javascripts/kitten/components/form/input/location-input/index.js
@@ -126,6 +126,7 @@ export const LocationInput = ({
   inputProps,
   name,
   loadingText,
+  customInputValue,
   ...others
 }) => {
   const [address, updateAddress] = useState(defaultValue)
@@ -148,7 +149,7 @@ export const LocationInput = ({
 
   return (
     <PlacesAutocomplete
-      value={inputProps?.inputValue || address}
+      value={customInputValue || address}
       onSelect={handleSelect}
       onChange={handleChange}
       {...others}
@@ -209,6 +210,7 @@ LocationInput.defaultProps = {
   inputProps: {},
   name: 'location-input',
   loadingText: 'Loading...',
+  customInputValue: '',
 }
 
 LocationInput.propTypes = {
@@ -218,4 +220,5 @@ LocationInput.propTypes = {
   inputProps: PropTypes.object,
   name: PropTypes.string,
   loadingText: PropTypes.string,
+  customInputValue: PropTypes.string,
 }

--- a/assets/javascripts/kitten/components/form/input/location-input/index.js
+++ b/assets/javascripts/kitten/components/form/input/location-input/index.js
@@ -148,7 +148,7 @@ export const LocationInput = ({
 
   return (
     <PlacesAutocomplete
-      value={address}
+      value={inputProps?.inputValue || address}
       onSelect={handleSelect}
       onChange={handleChange}
       {...others}

--- a/assets/javascripts/kitten/components/form/input/location-input/stories.js
+++ b/assets/javascripts/kitten/components/form/input/location-input/stories.js
@@ -33,6 +33,10 @@ export default {
       name: 'gPlaceApiKey (story prop)',
       control: 'text',
     },
+    customInputValue: {
+      name: 'customInputValue',
+      control: 'text',
+    },
   },
   args: {
     onChange: e => console.warn(e),
@@ -41,6 +45,7 @@ export default {
     inputProps: {},
     name: 'location-input',
     loadingText: 'Loading',
+    customInputValue: '',
     gPlaceApiKey: 'YOUR KEY',
   },
   parameters: {


### PR DESCRIPTION
Permet de gérer, côté KissKiss, ce qu'on veut afficher dans l'input une fois une adresse sélectionnée.
Par exemple, seulement numéro et libellé de voie

Vercel link:

- https://kitten-git-…

Screenshot:


TODO:

- [ ] Tests
- [ ] Changelog
- [ ] A11Y
- [ ] Stories / Docs
- [ ] New component added to `assets/javascripts/kitten/index.js`
