### PR TITLE
[SummaryCard] Replace `xlarge` by `huge` prop size value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Changes : `SummaryCard`: Replace `xlarge` by `huge` prop size value.
+
 ## [10.1.0] - 2022-04-08
 
 Deprecations/Changes:

--- a/assets/javascripts/kitten/components/structure/cards/summary-card/components/title-bar.js
+++ b/assets/javascripts/kitten/components/structure/cards/summary-card/components/title-bar.js
@@ -64,7 +64,7 @@ TitleBar.propTypes = {
     availability: PropTypes.string,
   }),
   size: PropTypes.oneOf([
-    'xlarge',
+    'huge',
     'large',
     'medium',
     'tablet',

--- a/assets/javascripts/kitten/components/structure/cards/summary-card/hooks/use-resize-observer.js
+++ b/assets/javascripts/kitten/components/structure/cards/summary-card/hooks/use-resize-observer.js
@@ -14,7 +14,7 @@ export const useResizeObserver = () => {
     const { width } = entries[0].contentRect
 
     if (width >= 1000) {
-      setSize('xlarge')
+      setSize('huge')
     } else if (width < 1000 && width >= 870) {
       setSize('large')
     } else if (width < 870 && width >= 760) {

--- a/assets/javascripts/kitten/components/structure/cards/summary-card/index.js
+++ b/assets/javascripts/kitten/components/structure/cards/summary-card/index.js
@@ -97,7 +97,7 @@ SummaryCard.propTypes = {
   show: PropTypes.bool,
   actionProps: PropTypes.object,
   size: PropTypes.oneOf([
-    'xlarge',
+    'huge',
     'large',
     'medium',
     'tablet',


### PR DESCRIPTION
Closes #.

Vercel link:

- https://kitten-git-…

Screenshot:


TODO:

- [ ] Tests
- [ ] Changelog
- [ ] A11Y
- [ ] Stories / Docs
- [ ] New component added to `assets/javascripts/kitten/index.js`
