### PR TITLE
[Modal] Add `as` prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Feature: `Modal`: Add `as` prop, defaults to `div`.
+
 ## [10.5.0] - 2022-05-02
 
 Features:

--- a/assets/javascripts/kitten/components/layer/modal/index.js
+++ b/assets/javascripts/kitten/components/layer/modal/index.js
@@ -118,6 +118,7 @@ const InnerModal = ({
   size,
   isOpen,
   zIndex,
+  as: ModalElement,
   ...others
 }) => {
   const [{ show }, dispatch] = useContext(ModalContext)
@@ -201,7 +202,7 @@ const InnerModal = ({
   )
 
   return (
-    <div className={classNames('k-Modal', className)} {...others}>
+    <ModalElement className={classNames('k-Modal', className)} {...others}>
       {trigger &&
         React.cloneElement(trigger, {
           onClick: clickEvent => {
@@ -215,7 +216,7 @@ const InnerModal = ({
           },
         })}
       {ModalPortal}
-    </div>
+    </ModalElement>
   )
 }
 
@@ -238,6 +239,7 @@ Modal.propTypes = {
   zIndex: PropTypes.number,
   hasCloseButton: PropTypes.bool,
   onClose: PropTypes.func,
+  as: PropTypes.string,
 }
 
 Modal.defaultProps = {
@@ -250,6 +252,7 @@ Modal.defaultProps = {
   zIndex: 110,
   hasCloseButton: true,
   onClose: () => {},
+  as: 'div'
 }
 
 Modal.Title = ModalTitle

--- a/assets/javascripts/kitten/components/layer/modal/stories.js
+++ b/assets/javascripts/kitten/components/layer/modal/stories.js
@@ -115,6 +115,10 @@ const argTypes = {
     name: 'zIndex',
     control: 'number',
   },
+  as: {
+    name: 'as',
+    control: 'text',
+  },
 }
 
 export const Default = ({ contentText, buttonSelection, ...args }) => (

--- a/assets/javascripts/kitten/components/layer/modal/test.js
+++ b/assets/javascripts/kitten/components/layer/modal/test.js
@@ -15,11 +15,12 @@ describe('<Modal />', () => {
   })
 
   describe('with content prop', () => {
-    const component = mount(<Modal className="content-example" />)
+    const component = mount(<Modal className="content-example" as="strong" />)
 
     it('contains the content', () => {
       expect(component.render().hasClass('content-example')).toBe(true)
       expect(component.render().hasClass('k-Modal')).toBe(true)
+      expect(component.render().is('strong')).toBe(true)
     })
   })
 


### PR DESCRIPTION
Closes #.

Vercel link:

- https://kitten-git-…

Screenshot:


TODO:

- [ ] Tests
- [ ] Changelog
- [ ] A11Y
- [ ] Stories / Docs
- [ ] New component added to `assets/javascripts/kitten/index.js`
