### PR TITLE
[HeroLayout] Fix automated assignment of hasTopMenu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix: `HeroLayout`: Fix automated assignment of hasTopMenu.
+
 ## [10.9.0] - 2022-05-17
 
 Features:

--- a/assets/javascripts/kitten/components/layout/hero-layout/index.js
+++ b/assets/javascripts/kitten/components/layout/hero-layout/index.js
@@ -59,11 +59,16 @@ HeroLayout.Promo = ({ className, ...props }) => (
   <div className={classNames('k-HeroLayout__promo', className)} {...props} />
 )
 
-HeroLayout.Main = ({ className, hasTopMenu, children, ...props }) => {
+HeroLayout.Main = ({ className, hasTopMenu = false, children, ...props }) => {
+  const TopMenuElement = getReactElementsByType({
+    children: children,
+    type: MainTopMenu,
+  })[0]
+
   return (
     <div
       className={classNames('k-HeroLayout__page', className, {
-        'k-HeroLayout__page--hasTopMenu': hasTopMenu,
+        'k-HeroLayout__page--hasTopMenu': hasTopMenu || !!TopMenuElement,
       })}
       {...props}
     >


### PR DESCRIPTION
Closes #.

Vercel link:

- https://kitten-git-…

Screenshot:


TODO:

- [ ] Tests
- [ ] Changelog
- [ ] A11Y
- [ ] Stories / Docs
- [ ] New component added to `assets/javascripts/kitten/index.js`
