### PR TITLE
[V11/AvatarWithTextAndBadge] Remove `textClassName` prop.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Breaking change: `AvatarWithTextAndBadge`: Remove `textClassName` prop.
 - Fix: `Checkbox` and `RadioButton`: Improve styles.
 - Feature: `HorizontalProjectCard`: Remove last line if no info is supplied.
 

--- a/assets/javascripts/kitten/components/information/avatar-with-text-and-badge/index.js
+++ b/assets/javascripts/kitten/components/information/avatar-with-text-and-badge/index.js
@@ -2,7 +2,6 @@ import React from 'react'
 import styled from 'styled-components'
 import classNames from 'classnames'
 import PropTypes from 'prop-types'
-import deprecated from 'prop-types-extra/lib/deprecated'
 
 import { Badge as BadgeComponent } from '../../information/badge'
 import COLORS from '../../../constants/colors-config'
@@ -229,10 +228,10 @@ Badge.defaultProps = {
   a11yText: 'Notification(s)',
 }
 
-const Text = ({ textClassName, className, withEllipsisOverflow, ...props }) => {
+const Text = ({ className, withEllipsisOverflow, ...props }) => {
   return (
     <span
-      className={classNames('k-Avatar__text', textClassName, className, {
+      className={classNames('k-Avatar__text', className, {
         'k-Avatar__text--hasEllipsis': withEllipsisOverflow,
       })}
       {...props}
@@ -242,10 +241,6 @@ const Text = ({ textClassName, className, withEllipsisOverflow, ...props }) => {
 
 Text.propTypes = {
   withEllipsisOverflow: PropTypes.bool,
-  textClassName: deprecated(
-    PropTypes.string,
-    'Please use standard `className` prop.',
-  ),
 }
 
 Text.defaultProps = {


### PR DESCRIPTION
Closes #.

Vercel link:

- https://kitten-git-…

Screenshot:


TODO:

- [ ] Tests
- [ ] Changelog
- [ ] A11Y
- [ ] Stories / Docs
- [ ] New component added to `assets/javascripts/kitten/index.js`
