### PR TITLE
Add `--box-shadow` variables on some cards and menu.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Feature: `Cards` & `Menu`: Add `--box-shadow` variables on some cards and menu.
+
 ## [11.0.0] - 2022-06-13
 
 Breaking changes:

--- a/assets/javascripts/kitten/components/navigation/desk-menu/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/navigation/desk-menu/__snapshots__/test.js.snap
@@ -11,7 +11,7 @@ exports[`<DeskMenu /> with default props matches with snapshot 1`] = `
 }
 
 .c0 .k-DeskMenu {
-  border: var(--border);
+  box-shadow: var(--box-shadow-m);
   border-radius: var(--border-radius-m);
   padding: var(--deskMenu-padding);
   display: -webkit-box;
@@ -168,7 +168,7 @@ exports[`<DeskMenu /> with header matches with snapshot 1`] = `
 }
 
 .c0 .k-DeskMenu {
-  border: var(--border);
+  box-shadow: var(--box-shadow-m);
   border-radius: var(--border-radius-m);
   padding: var(--deskMenu-padding);
   display: -webkit-box;

--- a/assets/javascripts/kitten/components/navigation/desk-menu/index.js
+++ b/assets/javascripts/kitten/components/navigation/desk-menu/index.js
@@ -16,7 +16,7 @@ const StyledDeskMenu = styled.nav`
   }
 
   .k-DeskMenu {
-    border: var(--border);
+    box-shadow: var(--box-shadow-m);
     border-radius: var(--border-radius-m);
     padding: var(--deskMenu-padding);
     display: flex;

--- a/assets/javascripts/kitten/components/navigation/floating-menu/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/navigation/floating-menu/__snapshots__/test.js.snap
@@ -106,7 +106,7 @@ exports[`<FloatingMenu /> with default props matches with snapshot 1`] = `
 
 @media (min-width:1080px) {
   .c0:not(.k-FloatingMenu--horizontal) {
-    box-shadow: var(--box-shadow-s);
+    box-shadow: var(--box-shadow-m);
     border-radius: var(--border-radius-m);
     padding: 0.625rem 0;
   }

--- a/assets/javascripts/kitten/components/navigation/floating-menu/index.js
+++ b/assets/javascripts/kitten/components/navigation/floating-menu/index.js
@@ -82,7 +82,7 @@ const StyledFloatingMenu = styled.nav`
 
   &:not(.k-FloatingMenu--horizontal) {
     @media ${mq.desktop} {
-      box-shadow: var(--box-shadow-s);
+      box-shadow: var(--box-shadow-m);
       border-radius: var(--border-radius-m);
       padding: ${pxToRem(10)} 0;
 

--- a/assets/javascripts/kitten/components/structure/cards/manager-card/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/structure/cards/manager-card/__snapshots__/test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<ManagerCard /> default matches with snapshot 1`] = `
 <article
-  className="sc-bdvvtL iYxOWD k-ManagerCard k-ManagerCard--hasAction"
+  className="sc-bdvvtL dLfVst k-ManagerCard k-ManagerCard--hasAction"
 >
   <a
     aria-label="Click to show item"

--- a/assets/javascripts/kitten/components/structure/cards/manager-card/index.js
+++ b/assets/javascripts/kitten/components/structure/cards/manager-card/index.js
@@ -15,7 +15,7 @@ const StyledManagerCard = styled.article`
 
   transition: background-color var(--transition), border-color var(--transition);
 
-  border: var(--border);
+  box-shadow: var(--box-shadow-m);
   border-radius: var(--border-radius-m);
 
   display: flex;
@@ -24,7 +24,7 @@ const StyledManagerCard = styled.article`
   &.k-ManagerCard--hasAction {
     &:hover {
       background-color: var(--color-grey-100);
-      border-color: var(--color-grey-500);
+      box-shadow: var(--box-shadow-hover-m);
     }
 
     &:active {

--- a/assets/javascripts/kitten/components/structure/cards/summary-card/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/structure/cards/summary-card/__snapshots__/test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<SummaryCard /> default matches with snapshot 1`] = `
 <div
-  className="sc-bdvvtL fgEEwc k-SummaryCard k-SummaryCard-Wrapper--large k-SummaryCard--hasAction"
+  className="sc-bdvvtL egSjrO k-SummaryCard k-SummaryCard-Wrapper--large k-SummaryCard--hasAction"
 >
   <a
     aria-label="Click to show item"

--- a/assets/javascripts/kitten/components/structure/cards/summary-card/styles.js
+++ b/assets/javascripts/kitten/components/structure/cards/summary-card/styles.js
@@ -255,13 +255,13 @@ export const StyledSummaryCard = styled(({ type, ...props }) => (
 
   transition: background-color 0.2s ease, border-color 0.2s ease;
 
-  border: var(--border);
+  box-shadow: var(--box-shadow-m);
   border-radius: var(--border-radius-m);
 
   &.k-SummaryCard--hasAction {
     &:hover {
       background-color: var(--color-grey-100);
-      border-color: var(--color-grey-500);
+      box-shadow: var(--box-shadow-hover-m);
     }
     &:active {
       background-color: var(--color-grey-200);


### PR DESCRIPTION
Closes #.

Vercel link:

- https://kitten-git-…

Screenshot:


TODO:

- [ ] Tests
- [ ] Changelog
- [ ] A11Y
- [ ] Stories / Docs
- [ ] New component added to `assets/javascripts/kitten/index.js`
