### PR TITLE
[MessagesMenu] Add close button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Feature: `MessagesMenu`: Add `closeButtonProps` prop.
+
 ## [11.1.0] - 2022-06-14
 
 Feature:

--- a/assets/javascripts/kitten/components/interaction/discussion/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/interaction/discussion/__snapshots__/test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<Discussion /> compare with snapshot matches with snapshot 1`] = `
 <div
-  className="sc-hKwDye fPcPOF k-Discussion"
+  className="sc-hKwDye iDaFjl k-Discussion"
 >
   <p
     className="k-u-a11y-visuallyHidden"

--- a/assets/javascripts/kitten/components/interaction/discussion/index.js
+++ b/assets/javascripts/kitten/components/interaction/discussion/index.js
@@ -16,8 +16,8 @@ const DiscussionWrapper = styled.div`
   justify-content: space-between;
 
   .k-Discussion__list {
-    flex-grow: 0;
-    flex-shrink: 1;
+    flex-grow: 1;
+    flex-shrink: 0;
     display: flex;
     flex-direction: column;
     gap: ${pxToRem(20)};

--- a/assets/javascripts/kitten/components/navigation/messages-menu/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/navigation/messages-menu/__snapshots__/test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<MessagesMenu /> compare with snapshot matches with snapshot 1`] = `
 <ul
-  className="sc-bdvvtL NKIbJ k-MessagesMenu"
+  className="sc-gsDKAQ oAlYL k-MessagesMenu"
 >
   <li
     className="k-MessagesMenu__message k-MessagesMenu__message--unread k-MessagesMenu__message--active"
@@ -17,7 +17,9 @@ exports[`<MessagesMenu /> compare with snapshot matches with snapshot 1`] = `
         className="k-MessagesMenu__message__avatar"
         src="/kitten-0.jpg"
       />
-      <div>
+      <div
+        className="k-MessagesMenu__message__content"
+      >
         <div>
           <span>
             Claude L.
@@ -38,6 +40,31 @@ exports[`<MessagesMenu /> compare with snapshot matches with snapshot 1`] = `
         </span>
       </div>
     </button>
+    <button
+      aria-label="Hello world"
+      className="sc-bdvvtL dsilnN k-Button k-MessagesMenu__message__closeButton k-Button--micro k-Button--hydrogen k-Button--fit-icon k-Button--rounded"
+      onClick={[Function]}
+      style={
+        Object {
+          "--Button-border-radius": null,
+          "--Button-bullet-color": null,
+        }
+      }
+      type="button"
+    >
+      <svg
+        fill="none"
+        height="18"
+        viewBox="0 0 17 18"
+        width="17"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M12.693 4.707a1 1 0 0 0-1.415 0L8.485 7.5 5.692 4.707a1 1 0 1 0-1.414 1.414l2.793 2.793-2.864 2.864a1 1 0 1 0 1.414 1.414l2.864-2.864 2.864 2.864a1 1 0 0 0 1.415-1.414L9.9 8.914l2.793-2.793a1 1 0 0 0 0-1.414Z"
+          fill="var(--color-grey-900, #222)"
+        />
+      </svg>
+    </button>
   </li>
   <li
     className="k-MessagesMenu__message k-MessagesMenu__message--read"
@@ -52,7 +79,9 @@ exports[`<MessagesMenu /> compare with snapshot matches with snapshot 1`] = `
         className="k-MessagesMenu__message__avatar"
         src="/kitten-0.jpg"
       />
-      <div>
+      <div
+        className="k-MessagesMenu__message__content"
+      >
         <div>
           <span>
             Claude L.
@@ -72,6 +101,31 @@ exports[`<MessagesMenu /> compare with snapshot matches with snapshot 1`] = `
           Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.
         </span>
       </div>
+    </button>
+    <button
+      aria-label="Hello world"
+      className="sc-bdvvtL dsilnN k-Button k-MessagesMenu__message__closeButton k-Button--micro k-Button--hydrogen k-Button--fit-icon k-Button--rounded"
+      onClick={[Function]}
+      style={
+        Object {
+          "--Button-border-radius": null,
+          "--Button-bullet-color": null,
+        }
+      }
+      type="button"
+    >
+      <svg
+        fill="none"
+        height="18"
+        viewBox="0 0 17 18"
+        width="17"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M12.693 4.707a1 1 0 0 0-1.415 0L8.485 7.5 5.692 4.707a1 1 0 1 0-1.414 1.414l2.793 2.793-2.864 2.864a1 1 0 1 0 1.414 1.414l2.864-2.864 2.864 2.864a1 1 0 0 0 1.415-1.414L9.9 8.914l2.793-2.793a1 1 0 0 0 0-1.414Z"
+          fill="var(--color-grey-900, #222)"
+        />
+      </svg>
     </button>
   </li>
 </ul>

--- a/assets/javascripts/kitten/components/navigation/messages-menu/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/navigation/messages-menu/__snapshots__/test.js.snap
@@ -40,6 +40,87 @@ exports[`<MessagesMenu /> compare with snapshot matches with snapshot 1`] = `
         </span>
       </div>
     </button>
+  </li>
+  <li
+    className="k-MessagesMenu__message k-MessagesMenu__message--read"
+  >
+    <button
+      className="k-u-reset-button k-MessagesMenu__message__button"
+      onClick={[Function]}
+      type="button"
+    >
+      <img
+        alt=""
+        className="k-MessagesMenu__message__avatar"
+        src="/kitten-0.jpg"
+      />
+      <div
+        className="k-MessagesMenu__message__content"
+      >
+        <div>
+          <span>
+            Claude L.
+          </span>
+          <span>
+             • Hier
+             
+            <span
+              className="k-u-a11y-visuallyHidden"
+            >
+              à 
+            </span>
+            19:30
+          </span>
+        </div>
+        <span>
+          Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.
+        </span>
+      </div>
+    </button>
+  </li>
+</ul>
+`;
+
+exports[`<MessagesMenu /> compare with snapshot with close button matches with snapshot 1`] = `
+<ul
+  className="sc-gsDKAQ oAlYL k-MessagesMenu"
+>
+  <li
+    className="k-MessagesMenu__message k-MessagesMenu__message--unread k-MessagesMenu__message--active"
+  >
+    <button
+      className="k-u-reset-button k-MessagesMenu__message__button"
+      onClick={[Function]}
+      type="button"
+    >
+      <img
+        alt=""
+        className="k-MessagesMenu__message__avatar"
+        src="/kitten-0.jpg"
+      />
+      <div
+        className="k-MessagesMenu__message__content"
+      >
+        <div>
+          <span>
+            Claude L.
+          </span>
+          <span>
+             • Hier
+             
+            <span
+              className="k-u-a11y-visuallyHidden"
+            >
+              à 
+            </span>
+            19:30
+          </span>
+        </div>
+        <span>
+          Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Donec ullamcorper nulla non metus auctor fringilla. Nulla vitae elit libero, a pharetra augue. Nullam quis risus eget urna mollis ornare vel eu leo. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+        </span>
+      </div>
+    </button>
     <button
       aria-label="Hello world"
       className="sc-bdvvtL dsilnN k-Button k-MessagesMenu__message__closeButton k-Button--micro k-Button--hydrogen k-Button--fit-icon k-Button--rounded"

--- a/assets/javascripts/kitten/components/navigation/messages-menu/index.js
+++ b/assets/javascripts/kitten/components/navigation/messages-menu/index.js
@@ -151,20 +151,23 @@ MessagesMenu.Message = ({
         />
         <div className="k-MessagesMenu__message__content">{children}</div>
       </button>
-      <Button
-        rounded
-        fit="icon"
-        size="micro"
-        className={classNames(
-          'k-MessagesMenu__message__closeButton',
-          avatarProps.className,
-        )}
-        {...closeButtonProps}
-      >
-        {closeButtonProps.children || (
-          <CrossIconNext />
-        )}
-      </Button>
+
+      {Object.keys(closeButtonProps).length > 0 && (
+        <Button
+          rounded
+          fit="icon"
+          size="micro"
+          className={classNames(
+            'k-MessagesMenu__message__closeButton',
+            avatarProps.className,
+          )}
+          {...closeButtonProps}
+        >
+          {closeButtonProps.children || (
+            <CrossIconNext />
+          )}
+        </Button>
+      )}
     </li>
   )
 }

--- a/assets/javascripts/kitten/components/navigation/messages-menu/index.js
+++ b/assets/javascripts/kitten/components/navigation/messages-menu/index.js
@@ -3,6 +3,9 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import styled from 'styled-components'
 import { pxToRem } from '../../../helpers/utils/typography'
+import { Button } from '../../../components/action/button'
+import { CrossIconNext } from '../../../components/graphics/icons-next/cross-icon-next'
+import { mq } from '../../../constants/screen-config'
 
 const StyledMessagesMenu = styled.ul`
   display: flex;
@@ -17,9 +20,16 @@ const StyledMessagesMenu = styled.ul`
   padding-left: ${pxToRem(3)};
 
   .k-MessagesMenu__message {
+    overflow: hidden;
     position: relative;
     margin: 0;
     padding: 0;
+    display: flex;
+    gap: ${pxToRem(10)};
+    align-items: center;
+    margin-left: ${pxToRem(-3)};
+    padding-left: ${pxToRem(3)};
+    transition: width var(--transition);
   }
 
   .k-MessagesMenu__message--unread .k-MessagesMenu__message__button {
@@ -37,7 +47,7 @@ const StyledMessagesMenu = styled.ul`
 
   .k-MessagesMenu__message__button {
     display: flex;
-    width: 100%;
+    flex: 1 0 calc(100% - ${pxToRem(15 + 10 + 30 + 10)});
     gap: ${pxToRem(10)};
     align-items: center;
     height: ${pxToRem(55)};
@@ -45,7 +55,6 @@ const StyledMessagesMenu = styled.ul`
     padding-inline: ${pxToRem(15)} ${pxToRem(10)};
     transition: background-color var(--transition);
     border-radius: var(--border-radius-m);
-
     outline-offset: ${pxToRem(-2)};
   }
 
@@ -59,6 +68,10 @@ const StyledMessagesMenu = styled.ul`
     border: var(--border-width) solid var(--color-grey-300);
   }
 
+  .k-MessagesMenu__message__content {
+    flex: 1 0 calc(100% - pxToRem(15 + 30 + 2 + 10));
+  }
+
   .k-MessagesMenu__message--unread {
     &::before {
       content: '';
@@ -68,7 +81,24 @@ const StyledMessagesMenu = styled.ul`
       border-radius: var(--border-radius-rounded);
       background-color: var(--color-primary-500);
       top: calc(50% - ${pxToRem(3)});
-      left: ${pxToRem(-3)};
+      left: 0;
+    }
+  }
+
+  .k-MessagesMenu__message__closeButton {
+    flex: 0 0  ${pxToRem(30)};
+    transition: opacity var(--transition), margin-right var(--transition);
+    margin-right: ${pxToRem(-30 - 10)};
+    opacity: 0;
+  }
+
+  @media (hover: hover) {
+    .k-MessagesMenu__message:hover,
+    .k-MessagesMenu__message:focus-within {
+      .k-MessagesMenu__message__closeButton {
+        margin-right: ${pxToRem(10)};
+        opacity: 1;
+      }
     }
   }
 `
@@ -90,7 +120,8 @@ MessagesMenu.Message = ({
   status = 'read',
   active,
   onClick,
-  avatarProps,
+  avatarProps = {},
+  closeButtonProps = {},
   ...props
 }) => {
   return (
@@ -118,12 +149,28 @@ MessagesMenu.Message = ({
             avatarProps.className,
           )}
         />
-        <div>{children}</div>
+        <div className="k-MessagesMenu__message__content">{children}</div>
       </button>
+      <Button
+        rounded
+        fit="icon"
+        size="micro"
+        className={classNames(
+          'k-MessagesMenu__message__closeButton',
+          avatarProps.className,
+        )}
+        {...closeButtonProps}
+      >
+        {closeButtonProps.children || (
+          <CrossIconNext />
+        )}
+      </Button>
     </li>
   )
 }
 
 MessagesMenu.Message.propTypes = {
   status: PropTypes.oneOf(['active', 'read', 'unread']),
+  avatarProps: PropTypes.object,
+  closeButtonProps: PropTypes.object,
 }

--- a/assets/javascripts/kitten/components/navigation/messages-menu/stories.js
+++ b/assets/javascripts/kitten/components/navigation/messages-menu/stories.js
@@ -121,7 +121,7 @@ const discussions = [
     name: 'Marshall',
     email: 'marshall@kisskissbankbank.com',
     longName: 'Marshall Kudley',
-    avatar: '/kitten-15.jpg',
+    avatar: '/kitten-0.jpg',
     status: 'read',
   },
 ]
@@ -140,6 +140,12 @@ export const Default = () => {
             action('Clicked')({ ...item, ...event })
             setActiveDiscussion(item)
           }}
+          closeButtonProps={{
+            onClick: (event) => {
+              action('Close clicked')({ ...item, ...event })
+              setActiveDiscussion(item)
+            }
+          }}
           avatarProps={{
             src: item.avatar,
           }}
@@ -156,8 +162,8 @@ export const Default = () => {
               color="grey-700"
               transform="uppercase"
             >
-              &nbsp;•&nbsp;Hier{' '}
-              <span className="k-u-a11y-visuallyHidden">à </span>19:30
+              &nbsp;<span aria-hidden>•</span>{' '}Hier&nbsp;
+              <span className="k-u-a11y-visuallyHidden">à&nbsp;</span>19:30
             </Text>
           </div>
           <Text

--- a/assets/javascripts/kitten/components/navigation/messages-menu/test.js
+++ b/assets/javascripts/kitten/components/navigation/messages-menu/test.js
@@ -17,6 +17,66 @@ describe('<MessagesMenu />', () => {
               avatarProps={{
                 src: '/kitten-0.jpg',
               }}
+            >
+              <div>
+                <span>Claude L.</span>
+                <span>
+                  &nbsp;•&nbsp;Hier{' '}
+                  <span className="k-u-a11y-visuallyHidden">à </span>19:30
+                </span>
+              </div>
+              <span>
+                Fusce dapibus, tellus ac cursus commodo, tortor mauris
+                condimentum nibh, ut fermentum massa justo sit amet risus. Cras
+                justo odio, dapibus ac facilisis in, egestas eget quam. Donec
+                ullamcorper nulla non metus auctor fringilla. Nulla vitae elit
+                libero, a pharetra augue. Nullam quis risus eget urna mollis
+                ornare vel eu leo. Cum sociis natoque penatibus et magnis dis
+                parturient montes, nascetur ridiculus mus.
+              </span>
+            </MessagesMenu.Message>
+            <MessagesMenu.Message
+              status="read"
+              onClick={() => {}}
+              avatarProps={{
+                src: '/kitten-0.jpg',
+              }}
+            >
+              <div>
+                <span>Claude L.</span>
+                <span>
+                  &nbsp;•&nbsp;Hier{' '}
+                  <span className="k-u-a11y-visuallyHidden">à </span>19:30
+                </span>
+              </div>
+              <span>
+                Integer posuere erat a ante venenatis dapibus posuere velit
+                aliquet. Aenean eu leo quam. Pellentesque ornare sem lacinia
+                quam venenatis vestibulum.
+              </span>
+            </MessagesMenu.Message>
+          </MessagesMenu>,
+        )
+        .toJSON()
+    })
+
+    it('matches with snapshot', () => {
+      expect(component).toMatchSnapshot()
+    })
+  })
+
+  describe('compare with snapshot with close button', () => {
+    beforeEach(() => {
+      component = renderer
+        .create(
+          <MessagesMenu>
+            <MessagesMenu.Message
+              status="unread"
+              active
+              onClick={() => {}}
+              avatarProps={{
+                src: '/kitten-0.jpg',
+              }}
               closeButtonProps={{
                 onClick: () => {},
                 'aria-label': "Hello world",

--- a/assets/javascripts/kitten/components/navigation/messages-menu/test.js
+++ b/assets/javascripts/kitten/components/navigation/messages-menu/test.js
@@ -17,6 +17,10 @@ describe('<MessagesMenu />', () => {
               avatarProps={{
                 src: '/kitten-0.jpg',
               }}
+              closeButtonProps={{
+                onClick: () => {},
+                'aria-label': "Hello world",
+              }}
             >
               <div>
                 <span>Claude L.</span>
@@ -40,6 +44,10 @@ describe('<MessagesMenu />', () => {
               onClick={() => {}}
               avatarProps={{
                 src: '/kitten-0.jpg',
+              }}
+              closeButtonProps={{
+                onClick: () => {},
+                'aria-label': "Hello world",
               }}
             >
               <div>


### PR DESCRIPTION
Closes #.

Vercel link:

- https://kitten-git-messages-menu-add-close-button-kisskissbankbank.vercel.app/?path=/story/navigation-messagesmenu--default

Screenshot:


TODO:

- [ ] Tests
- [ ] Changelog
- [ ] A11Y
- [ ] Stories / Docs
- [ ] New component added to `assets/javascripts/kitten/index.js`
