### PR TITLE
[TextInput] Fix length limit init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [unreleased]
 
 - Feature: `TitleWithStroke`: Add `noMargin` prop.
+- Fix: `TextInput`: Fix `limit` initialization.
 
 ## [12.2.0] - 2022-07-28 🔮
 

--- a/assets/javascripts/kitten/components/form/input/text-input/index.js
+++ b/assets/javascripts/kitten/components/form/input/text-input/index.js
@@ -39,7 +39,7 @@ export const TextInput = React.forwardRef(
     },
     ref,
   ) => {
-    const [length, setLength] = useState(value || defaultValue || ''.length)
+    const [length, setLength] = useState((value || defaultValue || '').length)
 
     const digitsClass = !!digits
       ? `k-TextInput-hasDigits k-TextInput-hasDigits_${digits}`


### PR DESCRIPTION
Sans les parenthèses le `.length` n'est forcément pris en compte que par le `''`……… 