### PR TITLE
[Modal] Better typing of `as` prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [unreleased]
 
 - Feature: `TagButton`: Add `rounded` prop, defaults to false.
+- Fix: `Modal`: Better typing of `as` prop, for use with `React.Fragment`.
 
 ## [12.6.0] - 2022-08-30 🏮
 

--- a/assets/javascripts/kitten/components/layer/modal/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/layer/modal/__snapshots__/test.js.snap
@@ -125,3 +125,23 @@ exports[`<Modal /> snapshot tests is open matches with snapshot 1`] = `
   </div>
 </div>
 `;
+
+exports[`<Modal /> snapshot tests is wrapped in a React.Fragment matches with snapshot 1`] = `
+<button
+  onClick={[Function]}
+>
+  Open
+</button>
+`;
+
+exports[`<Modal /> snapshot tests is wrapped in a custom element matches with snapshot 1`] = `
+<section
+  className="k-Modal"
+>
+  <button
+    onClick={[Function]}
+  >
+    Open
+  </button>
+</section>
+`;

--- a/assets/javascripts/kitten/components/layer/modal/index.js
+++ b/assets/javascripts/kitten/components/layer/modal/index.js
@@ -1,4 +1,10 @@
-import React, { useEffect, createContext, useReducer, useContext } from 'react'
+import React, {
+  useEffect,
+  createContext,
+  useReducer,
+  useContext,
+  Fragment,
+} from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import ReactDOM from 'react-dom'
@@ -217,8 +223,17 @@ const InnerModal = ({
     document.body,
   )
 
+  const modalElementProps =
+    ModalElement === Fragment
+      ? { children, key: others.key }
+      : {
+          children,
+          ...others,
+          className: classNames('k-Modal', className),
+        }
+
   return (
-    <ModalElement className={classNames('k-Modal', className)} {...others}>
+    <ModalElement {...modalElementProps}>
       {trigger &&
         React.cloneElement(trigger, {
           onClick: clickEvent => {
@@ -255,7 +270,7 @@ Modal.propTypes = {
   zIndex: PropTypes.number,
   hasCloseButton: PropTypes.bool,
   onClose: PropTypes.func,
-  as: PropTypes.string,
+  as: PropTypes.oneOfType([PropTypes.node, PropTypes.oneOf([Fragment])]),
 }
 
 Modal.defaultProps = {

--- a/assets/javascripts/kitten/components/layer/modal/index.js
+++ b/assets/javascripts/kitten/components/layer/modal/index.js
@@ -225,9 +225,8 @@ const InnerModal = ({
 
   const modalElementProps =
     ModalElement === Fragment
-      ? { children, key: others.key }
+      ? { key: others.key }
       : {
-          children,
           ...others,
           className: classNames('k-Modal', className),
         }

--- a/assets/javascripts/kitten/components/layer/modal/stories.js
+++ b/assets/javascripts/kitten/components/layer/modal/stories.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { Fragment } from 'react'
 import { DocsPage } from 'storybook/docs-page'
 import { action } from '@storybook/addon-actions'
 import styled from 'styled-components'
@@ -163,6 +163,31 @@ Default.argTypes = {
     control: { type: 'range', min: 0, max: 2 },
   },
 }
+
+export const AsFragment = ({ contentText, ...args }) => (
+  <Modal {...args}>
+    {() => (
+      <>
+        <Modal.Title align="center">
+          Lorem ipsum dolor sit consectetuer
+        </Modal.Title>
+        <Modal.Content align="center">
+          <Paragraph modifier="tertiary" noMargin className="k-u-align-center">
+            {contentText}
+          </Paragraph>
+        </Modal.Content>
+        <Modal.Actions>
+          <Button modifier="helium">Modal.Button</Button>
+        </Modal.Actions>
+      </>
+    )}
+  </Modal>
+)
+AsFragment.args = {
+  ...args,
+  as: Fragment,
+}
+AsFragment.argTypes = argTypes
 
 export const withForm = () => (
   <Modal {...Default.args}>

--- a/assets/javascripts/kitten/components/layer/modal/test.js
+++ b/assets/javascripts/kitten/components/layer/modal/test.js
@@ -100,5 +100,77 @@ describe('<Modal />', () => {
         expect(component).toMatchSnapshot()
       })
     })
+
+    describe('is wrapped in a React.Fragment', () => {
+      beforeEach(() => {
+        ReactDOM.createPortal = jest.fn(element => {
+          return element
+        })
+
+        component = renderer
+          .create(
+            <Modal
+              size="medium"
+              as={React.Fragment}
+              trigger={<button>Open</button>}
+            >
+              <Modal.Title>Oops… Quelque chose s’est mal passé.</Modal.Title>
+              <Modal.Content>
+                <p>
+                  Notre équipe a été automatiquement notifiée et fait en sorte
+                  de résoudre ce problème au plus vite.
+                </p>
+                <Modal.Actions>
+                  <button>Retour à la page d’accueil</button>
+                  <button>Recharger la page</button>
+                </Modal.Actions>
+              </Modal.Content>
+            </Modal>,
+          )
+          .toJSON()
+      })
+
+      afterEach(() => {
+        ReactDOM.createPortal.mockClear()
+      })
+
+      it('matches with snapshot', () => {
+        expect(component).toMatchSnapshot()
+      })
+    })
+
+    describe('is wrapped in a custom element', () => {
+      beforeEach(() => {
+        ReactDOM.createPortal = jest.fn(element => {
+          return element
+        })
+
+        component = renderer
+          .create(
+            <Modal size="medium" as="section" trigger={<button>Open</button>}>
+              <Modal.Title>Oops… Quelque chose s’est mal passé.</Modal.Title>
+              <Modal.Content>
+                <p>
+                  Notre équipe a été automatiquement notifiée et fait en sorte
+                  de résoudre ce problème au plus vite.
+                </p>
+                <Modal.Actions>
+                  <button>Retour à la page d’accueil</button>
+                  <button>Recharger la page</button>
+                </Modal.Actions>
+              </Modal.Content>
+            </Modal>,
+          )
+          .toJSON()
+      })
+
+      afterEach(() => {
+        ReactDOM.createPortal.mockClear()
+      })
+
+      it('matches with snapshot', () => {
+        expect(component).toMatchSnapshot()
+      })
+    })
   })
 })


### PR DESCRIPTION
Closes #.

Vercel link:

- https://kitten-git-…

Screenshot:


TODO:

- [x] Tests
- [x] Changelog
- [ ] A11Y
- [x] Stories / Docs
- [ ] New component added to `assets/javascripts/kitten/index.js`
