### PR TITLE
[DashboardLayout] Add `background` and `fullSize` props to `Toaster` subcomponent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- `DashboardLayout`: Add `background` and `fullSize` props to `Toaster` subcomponent.
+
 ## [12.8.0] - 2022-09-07 🥷
 
 Features: 

--- a/assets/javascripts/kitten/components/layout/dashboard-layout/__snapshots__/test.js.snap
+++ b/assets/javascripts/kitten/components/layout/dashboard-layout/__snapshots__/test.js.snap
@@ -849,6 +849,7 @@ button:focus .c1.k-BurgerIcon--isAnimatedOnHover .k-BurgerIcon__patty {
   opacity: 0;
   -webkit-transition: opacity 0.4s cubic-bezier(0.34,1.56,0.64,1),bottom 0.4s cubic-bezier(0.34,1.56,0.64,1),left 0.3s ease-in-out;
   transition: opacity 0.4s cubic-bezier(0.34,1.56,0.64,1),bottom 0.4s cubic-bezier(0.34,1.56,0.64,1),left 0.3s ease-in-out;
+  z-index: 2;
 }
 
 .c0 .k-DashboardLayout__toaster__wrapper + .k-DashboardLayout__toaster__spacer {
@@ -1057,8 +1058,7 @@ button:focus .c1.k-BurgerIcon--isAnimatedOnHover .k-BurgerIcon__patty {
   }
 
   .c0 .k-DashboardLayout .k-DashboardLayout__mainWrapper .k-DashboardLayout__heading {
-    padding-left: 2.5rem;
-    padding-right: 2.5rem;
+    padding-inline: 2.5rem;
     height: 4.0625rem;
     -webkit-flex: 0 0 4.0625rem;
     -ms-flex: 0 0 4.0625rem;
@@ -1123,13 +1123,11 @@ button:focus .c1.k-BurgerIcon--isAnimatedOnHover .k-BurgerIcon__patty {
   }
 
   .c0 .k-DashboardLayout .k-DashboardLayout__mainWrapper .k-DashboardLayout__main:not(.k-DashboardLayout__main--fullHeight) {
-    padding-top: 5rem;
-    padding-bottom: 5rem;
+    padding-block: 5rem;
   }
 
   .c0 .k-DashboardLayout .k-DashboardLayout__mainWrapper .k-DashboardLayout__main > *:not(.k-DashboardLayout__fullWidth) {
-    margin-left: var(--DashboardLayout-main-margin);
-    margin-right: var(--DashboardLayout-main-margin);
+    margin-inline: var(--DashboardLayout-main-margin);
   }
 
   .c0 .k-DashboardLayout .k-DashboardLayout__toaster__wrapper {
@@ -1156,22 +1154,32 @@ button:focus .c1.k-BurgerIcon--isAnimatedOnHover .k-BurgerIcon__patty {
   }
 
   .c0 .k-DashboardLayout .k-DashboardLayout__mainWrapper .k-DashboardLayout__heading {
-    padding-left: 1.25rem;
-    padding-right: 1.25rem;
+    padding-inline: 1.25rem;
   }
 
   .c0 .k-DashboardLayout .k-DashboardLayout__mainWrapper .k-DashboardLayout__main:not(.k-DashboardLayout__main--fullHeight) {
-    padding-top: 3.125rem;
-    padding-bottom: 3.125rem;
+    padding-block: 3.125rem;
   }
 }
 
 @media (min-width:640px) {
   .c0 .k-DashboardLayout__toaster {
-    background-color: var(--color-grey-900);
-    color: var(--color-grey-000);
     border-radius: var(--border-radius-s);
     padding: 1.25rem;
+  }
+
+  .c0 .k-DashboardLayout__toaster:not(.k-DashboardLayout__toaster--fullSize) {
+    margin-inline: calc(var(--DashboardLayout-main-margin) - 1.25rem);
+  }
+
+  .c0 .k-DashboardLayout__toaster--dark {
+    background-color: var(--color-grey-900);
+    color: var(--color-grey-000);
+  }
+
+  .c0 .k-DashboardLayout__toaster--light {
+    background-color: var(--color-grey-200);
+    color: var(--color-grey-900);
   }
 }
 
@@ -1237,13 +1245,11 @@ button:focus .c1.k-BurgerIcon--isAnimatedOnHover .k-BurgerIcon__patty {
   }
 
   .c0 .k-DashboardLayout .k-DashboardLayout__mainWrapper .k-DashboardLayout__main:not(.k-DashboardLayout__main--fullHeight) {
-    padding-top: 5rem;
-    padding-bottom: 5rem;
+    padding-block: 5rem;
   }
 
   .c0 .k-DashboardLayout .k-DashboardLayout__mainWrapper .k-DashboardLayout__main > *:not(.k-DashboardLayout__fullWidth) {
-    margin-left: var(--DashboardLayout-main-margin);
-    margin-right: var(--DashboardLayout-main-margin);
+    margin-inline: var(--DashboardLayout-main-margin);
   }
 
   .c0 .k-DashboardLayout__toaster__wrapper {
@@ -1396,10 +1402,10 @@ button:focus .c1.k-BurgerIcon--isAnimatedOnHover .k-BurgerIcon__patty {
         </p>
         <section
           aria-live="polite"
-          className="k-DashboardLayout__toaster__wrapper k-DashboardLayout__fullWidth"
+          className="k-DashboardLayout__toaster__wrapper"
         >
           <div
-            className="k-DashboardLayout__toaster"
+            className="k-DashboardLayout__toaster k-DashboardLayout__toaster--dark k-DashboardLayout__toaster--fullSize"
           >
             Toaster
           </div>
@@ -1504,6 +1510,7 @@ button:focus .c1.k-BurgerIcon--isAnimatedOnHover .k-BurgerIcon__patty {
   opacity: 0;
   -webkit-transition: opacity 0.4s cubic-bezier(0.34,1.56,0.64,1),bottom 0.4s cubic-bezier(0.34,1.56,0.64,1),left 0.3s ease-in-out;
   transition: opacity 0.4s cubic-bezier(0.34,1.56,0.64,1),bottom 0.4s cubic-bezier(0.34,1.56,0.64,1),left 0.3s ease-in-out;
+  z-index: 2;
 }
 
 .c0 .k-DashboardLayout__toaster__wrapper + .k-DashboardLayout__toaster__spacer {
@@ -1712,8 +1719,7 @@ button:focus .c1.k-BurgerIcon--isAnimatedOnHover .k-BurgerIcon__patty {
   }
 
   .c0 .k-DashboardLayout .k-DashboardLayout__mainWrapper .k-DashboardLayout__heading {
-    padding-left: 2.5rem;
-    padding-right: 2.5rem;
+    padding-inline: 2.5rem;
     height: 4.0625rem;
     -webkit-flex: 0 0 4.0625rem;
     -ms-flex: 0 0 4.0625rem;
@@ -1778,13 +1784,11 @@ button:focus .c1.k-BurgerIcon--isAnimatedOnHover .k-BurgerIcon__patty {
   }
 
   .c0 .k-DashboardLayout .k-DashboardLayout__mainWrapper .k-DashboardLayout__main:not(.k-DashboardLayout__main--fullHeight) {
-    padding-top: 5rem;
-    padding-bottom: 5rem;
+    padding-block: 5rem;
   }
 
   .c0 .k-DashboardLayout .k-DashboardLayout__mainWrapper .k-DashboardLayout__main > *:not(.k-DashboardLayout__fullWidth) {
-    margin-left: var(--DashboardLayout-main-margin);
-    margin-right: var(--DashboardLayout-main-margin);
+    margin-inline: var(--DashboardLayout-main-margin);
   }
 
   .c0 .k-DashboardLayout .k-DashboardLayout__toaster__wrapper {
@@ -1811,22 +1815,32 @@ button:focus .c1.k-BurgerIcon--isAnimatedOnHover .k-BurgerIcon__patty {
   }
 
   .c0 .k-DashboardLayout .k-DashboardLayout__mainWrapper .k-DashboardLayout__heading {
-    padding-left: 1.25rem;
-    padding-right: 1.25rem;
+    padding-inline: 1.25rem;
   }
 
   .c0 .k-DashboardLayout .k-DashboardLayout__mainWrapper .k-DashboardLayout__main:not(.k-DashboardLayout__main--fullHeight) {
-    padding-top: 3.125rem;
-    padding-bottom: 3.125rem;
+    padding-block: 3.125rem;
   }
 }
 
 @media (min-width:640px) {
   .c0 .k-DashboardLayout__toaster {
-    background-color: var(--color-grey-900);
-    color: var(--color-grey-000);
     border-radius: var(--border-radius-s);
     padding: 1.25rem;
+  }
+
+  .c0 .k-DashboardLayout__toaster:not(.k-DashboardLayout__toaster--fullSize) {
+    margin-inline: calc(var(--DashboardLayout-main-margin) - 1.25rem);
+  }
+
+  .c0 .k-DashboardLayout__toaster--dark {
+    background-color: var(--color-grey-900);
+    color: var(--color-grey-000);
+  }
+
+  .c0 .k-DashboardLayout__toaster--light {
+    background-color: var(--color-grey-200);
+    color: var(--color-grey-900);
   }
 }
 
@@ -1892,13 +1906,11 @@ button:focus .c1.k-BurgerIcon--isAnimatedOnHover .k-BurgerIcon__patty {
   }
 
   .c0 .k-DashboardLayout .k-DashboardLayout__mainWrapper .k-DashboardLayout__main:not(.k-DashboardLayout__main--fullHeight) {
-    padding-top: 5rem;
-    padding-bottom: 5rem;
+    padding-block: 5rem;
   }
 
   .c0 .k-DashboardLayout .k-DashboardLayout__mainWrapper .k-DashboardLayout__main > *:not(.k-DashboardLayout__fullWidth) {
-    margin-left: var(--DashboardLayout-main-margin);
-    margin-right: var(--DashboardLayout-main-margin);
+    margin-inline: var(--DashboardLayout-main-margin);
   }
 
   .c0 .k-DashboardLayout__toaster__wrapper {

--- a/assets/javascripts/kitten/components/layout/dashboard-layout/index.js
+++ b/assets/javascripts/kitten/components/layout/dashboard-layout/index.js
@@ -352,13 +352,19 @@ const Alerts = ({ className, ...props }) => (
   />
 )
 
-const Toaster = ({ className, isOpen, children, ...props }) => {
+const Toaster = ({
+  className,
+  isOpen,
+  children,
+  background = 'dark',
+  fullSize = true,
+  ...props
+}) => {
   return (
     <>
       <section
         className={classNames(
           'k-DashboardLayout__toaster__wrapper',
-          'k-DashboardLayout__fullWidth',
           className,
           {
             'k-DashboardLayout__toaster--isOpen': isOpen,
@@ -367,7 +373,17 @@ const Toaster = ({ className, isOpen, children, ...props }) => {
         aria-live="polite"
         {...props}
       >
-        <div className="k-DashboardLayout__toaster">{children}</div>
+        <div
+          className={classNames(
+            'k-DashboardLayout__toaster',
+            `k-DashboardLayout__toaster--${background}`,
+            {
+              'k-DashboardLayout__toaster--fullSize': fullSize,
+            },
+          )}
+        >
+          {children}
+        </div>
       </section>
       <div className="k-DashboardLayout__toaster__spacer" />
     </>
@@ -395,6 +411,12 @@ Header.propTypes = {
   }),
   hasButton: PropTypes.bool,
   isOpen: PropTypes.bool,
+}
+
+Toaster.propTypes = {
+  isOpen: PropTypes.bool,
+  fullSize: PropTypes.bool,
+  background: PropTypes.oneOf(['dark', 'light']),
 }
 
 DashboardLayout.SiteHeader = SiteHeader

--- a/assets/javascripts/kitten/components/layout/dashboard-layout/stories.js
+++ b/assets/javascripts/kitten/components/layout/dashboard-layout/stories.js
@@ -50,9 +50,9 @@ export default {
       flowShowTwoButtons: false,
       flowShowUnsavedText: false,
     },
-    toasterIsOpen: false,
     multiMenu: false,
     hasDarkBg: false,
+    toasterIsOpen: false,
   },
   argTypes: {
     quickAccessLinkText: { control: 'text' },
@@ -70,7 +70,6 @@ export default {
     },
     displayHeader: { name: 'displayHeader (story prop)', control: 'boolean' },
     displayAlerts: { name: 'displayAlerts (story prop)', control: 'boolean' },
-    toasterIsOpen: { name: 'toasterIsOpen (story prop)', control: 'boolean' },
     status: {
       name: 'Project status (story prop)',
       control: 'radio',
@@ -79,6 +78,7 @@ export default {
     flowProps: { name: 'Flow Props (story prop)', control: 'object' },
     multiMenu: { name: 'MultiMenu (story prop)', control: 'boolean' },
     hasDarkBg: 'boolean',
+    toasterIsOpen: { name: 'toasterIsOpen (story prop)', control: 'boolean' },
   },
 }
 
@@ -109,7 +109,7 @@ export const WithDashboardContent = args => {
 export const WithRewardContent = args => {
   return (
     <StoryLayout {...args}>
-      <StoryWithReward />
+      <StoryWithReward toasterIsOpen={args.toasterIsOpen} />
     </StoryLayout>
   )
 }
@@ -117,7 +117,7 @@ export const WithRewardContent = args => {
 export const WithFlowContent = ({ flowProps, ...args }) => {
   return (
     <StoryLayout {...args} fullHeightContent hasDarkBg>
-      <StoryWithFlow {...flowProps} />
+      <StoryWithFlow {...flowProps} toasterIsOpen={args.toasterIsOpen} />
     </StoryLayout>
   )
 }

--- a/assets/javascripts/kitten/components/layout/dashboard-layout/stories/with-flow.js
+++ b/assets/javascripts/kitten/components/layout/dashboard-layout/stories/with-flow.js
@@ -12,6 +12,7 @@ import {
   InstagramIcon,
   YoutubeIcon,
   GlobeIcon,
+  FlexWrapper,
 } from 'kitten'
 
 const options = [
@@ -51,6 +52,7 @@ export const StoryWithFlow = ({
   flowLoading,
   flowShowTwoButtons,
   flowShowUnsavedText,
+  toasterIsOpen,
 }) => (
   <DashboardLayout.Flow loading={flowLoading}>
     <DashboardLayout.Flow.Title modifier="quinary">
@@ -194,5 +196,25 @@ export const StoryWithFlow = ({
         Save
       </Button>
     </DashboardLayout.Flow.Nav>
+
+    <DashboardLayout.Toaster isOpen={toasterIsOpen}>
+      <FlexWrapper
+        gap={10}
+        direction="row"
+        className="k-u-flex-alignItems-center"
+      >
+        <div style={{ flex: '1 0 auto' }} className="k-u-hidden@xs-down">
+          <Text color="background1" size="small" weight="500">
+            Text
+          </Text>
+        </div>
+        <Button modifier="boron" size="small" className="k-u-hidden@m-down">
+          Hello
+        </Button>
+        <Button modifier="helium" size="small">
+          Hello
+        </Button>
+      </FlexWrapper>
+    </DashboardLayout.Toaster>
   </DashboardLayout.Flow>
 )

--- a/assets/javascripts/kitten/components/layout/dashboard-layout/stories/with-reward.js
+++ b/assets/javascripts/kitten/components/layout/dashboard-layout/stories/with-reward.js
@@ -14,11 +14,14 @@ import {
   useWindowWidth,
   ScreenConfig,
   Text,
+  DashboardLayout,
+  FlexWrapper,
+  Button,
 } from 'kitten'
 
 const StyledDragAndDropList = styled(DragAndDropList)`
   @media ${mq.tabletAndDesktop} {
-    margin-left: -${DRAG_AND_DROP_LIST_BUTTON_SHIFT};
+    margin-left: -${DRAG_AND_DROP_LIST_BUTTON_SHIFT} !important;
   }
 
   @media ${mq.mobile} {
@@ -85,7 +88,7 @@ const RewardCardComponent = ({
   </SummaryCard>
 )
 
-export const StoryWithReward = () => {
+export const StoryWithReward = ({ toasterIsOpen }) => {
   const { ref, size } = useSummaryCardResizeObserver()
 
   // on KissKiss, use `viewportIsSOrLess` from `useMediaQuery()`
@@ -179,6 +182,27 @@ export const StoryWithReward = () => {
           simpleName="Anim enim deserunt ut mollit"
         />
       </StyledDragAndDropList>
+
+      <DashboardLayout.Toaster
+        background="light"
+        isOpen={toasterIsOpen}
+        fullSize={false}
+      >
+        <FlexWrapper
+          gap={10}
+          direction="row"
+          className="k-u-flex-alignItems-center"
+        >
+          <div className="k-u-flex-grow-single k-u-hidden@xs-down">
+            <Text size="small" weight="500">
+              Text
+            </Text>
+          </div>
+          <Button modifier="beryllium" size="small">
+            Hello
+          </Button>
+        </FlexWrapper>
+      </DashboardLayout.Toaster>
     </div>
   )
 }

--- a/assets/javascripts/kitten/components/layout/dashboard-layout/styles.js
+++ b/assets/javascripts/kitten/components/layout/dashboard-layout/styles.js
@@ -83,6 +83,7 @@ export const StyledDashboard = styled.div`
     opacity: 0;
     transition: opacity 0.4s cubic-bezier(0.34, 1.56, 0.64, 1),
       bottom 0.4s cubic-bezier(0.34, 1.56, 0.64, 1), left 0.3s ease-in-out;
+    z-index: 2;
 
     & + .k-DashboardLayout__toaster__spacer {
       max-height: 0;
@@ -303,10 +304,21 @@ export const StyledDashboard = styled.div`
 
   @media ${mq.tabletAndDesktop} {
     .k-DashboardLayout__toaster {
-      background-color: var(--color-grey-900);
-      color: var(--color-grey-000);
       border-radius: var(--border-radius-s);
       padding: ${pxToRem(20)};
+    }
+
+    .k-DashboardLayout__toaster:not(.k-DashboardLayout__toaster--fullSize) {
+      margin-inline: calc(var(--DashboardLayout-main-margin) - ${pxToRem(20)});
+    }
+
+    .k-DashboardLayout__toaster--dark {
+      background-color: var(--color-grey-900);
+      color: var(--color-grey-000);
+    }
+    .k-DashboardLayout__toaster--light {
+      background-color: var(--color-grey-200);
+      color: var(--color-grey-900);
     }
   }
 

--- a/assets/javascripts/kitten/components/layout/dashboard-layout/styles.js
+++ b/assets/javascripts/kitten/components/layout/dashboard-layout/styles.js
@@ -194,8 +194,7 @@ export const StyledDashboard = styled.div`
         position: relative;
 
         .k-DashboardLayout__heading {
-          padding-left: ${pxToRem(CONTAINER_PADDING)};
-          padding-right: ${pxToRem(CONTAINER_PADDING)};
+          padding-inline: ${pxToRem(CONTAINER_PADDING)};
           height: ${pxToRem(65)};
           flex: 0 0 ${pxToRem(65)};
           display: flex;
@@ -245,13 +244,11 @@ export const StyledDashboard = styled.div`
           flex: 1 0 auto;
 
           &:not(.k-DashboardLayout__main--fullHeight) {
-            padding-top: ${pxToRem(80)};
-            padding-bottom: ${pxToRem(80)};
+            padding-block: ${pxToRem(80)};
           }
 
           > *:not(.k-DashboardLayout__fullWidth) {
-            margin-left: var(--DashboardLayout-main-margin);
-            margin-right: var(--DashboardLayout-main-margin);
+            margin-inline: var(--DashboardLayout-main-margin);
           }
         }
       }
@@ -287,13 +284,11 @@ export const StyledDashboard = styled.div`
       }
       .k-DashboardLayout__mainWrapper {
         .k-DashboardLayout__heading {
-          padding-left: ${pxToRem(CONTAINER_PADDING_THIN)};
-          padding-right: ${pxToRem(CONTAINER_PADDING_THIN)};
+          padding-inline: ${pxToRem(CONTAINER_PADDING_THIN)};
         }
         .k-DashboardLayout__main {
           &:not(.k-DashboardLayout__main--fullHeight) {
-            padding-top: ${pxToRem(50)};
-            padding-bottom: ${pxToRem(50)};
+            padding-block: ${pxToRem(50)};
           }
         }
       }
@@ -378,13 +373,11 @@ export const StyledDashboard = styled.div`
 
         .k-DashboardLayout__main {
           &:not(.k-DashboardLayout__main--fullHeight) {
-            padding-top: ${pxToRem(80)};
-            padding-bottom: ${pxToRem(80)};
+            padding-block: ${pxToRem(80)};
           }
 
           > *:not(.k-DashboardLayout__fullWidth) {
-            margin-left: var(--DashboardLayout-main-margin);
-            margin-right: var(--DashboardLayout-main-margin);
+            margin-inline: var(--DashboardLayout-main-margin);
           }
         }
       }


### PR DESCRIPTION
Closes #.

Vercel link:

- https://kitten-git-dashboard-layout-add-backgro-479e2d-kisskissbankbank.vercel.app/?path=/story/layout-dashboardlayout--with-reward-content&args=toasterIsOpen:true

Screenshot:


TODO:

- [ ] Tests
- [ ] Changelog
- [ ] A11Y
- [ ] Stories / Docs
- [ ] New component added to `assets/javascripts/kitten/index.js`
